### PR TITLE
added scaffolding for key commands

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -52,5 +52,5 @@ jobs:
                       Dev build from `${{ github.head_ref }}`.
 
                       ```
-                      VERSION=${{ github.head_ref }} curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | bash
+                      curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=${{ github.head_ref }} bash
                       ```

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -32,14 +32,14 @@ jobs:
                   bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dot-darwin-arm64
 
             - name: Delete previous dev release
-              run: gh release delete "${{ github.head_ref }}" --cleanup-tag -y 2>/dev/null || true
+              run: gh release delete "dev/${{ github.head_ref }}" --cleanup-tag -y 2>/dev/null || true
               env:
                   GH_TOKEN: ${{ github.token }}
 
             - name: Create dev release
               uses: softprops/action-gh-release@v2
               with:
-                  tag_name: ${{ github.head_ref }}
+                  tag_name: dev/${{ github.head_ref }}
                   name: "Dev: ${{ github.head_ref }}"
                   prerelease: true
                   make_latest: false
@@ -52,5 +52,5 @@ jobs:
                       Dev build from `${{ github.head_ref }}`.
 
                       ```
-                      curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=${{ github.head_ref }} bash
+                      curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=dev/${{ github.head_ref }} bash
                       ```

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
     contents: write
+    pull-requests: write
 
 jobs:
     release:
@@ -54,3 +55,24 @@ jobs:
                       ```
                       curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=dev/${{ github.head_ref }} bash
                       ```
+
+            - name: Comment install command on PR
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR: ${{ github.event.pull_request.number }}
+                  BRANCH: ${{ github.head_ref }}
+              run: |
+                  MARKER="<!-- dev-release -->"
+                  BODY="${MARKER}
+                  **Dev build ready** — try this branch:
+                  \`\`\`
+                  curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=dev/${BRANCH} bash
+                  \`\`\`"
+
+                  # Find existing comment by marker, update or create
+                  COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${PR}/comments --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+                  if [ -n "$COMMENT_ID" ]; then
+                    gh api repos/${{ github.repository }}/issues/comments/${COMMENT_ID} -X PATCH -f body="$BODY"
+                  else
+                    gh pr comment "$PR" --body "$BODY"
+                  fi

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm cli:install
 Every PR automatically publishes a dev release tagged with the branch name. Others can try it with:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=my-branch bash
+curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=dev/my-branch bash
 ```
 
 ### Releasing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/inst
 To install a specific version:
 
 ```bash
-VERSION=v0.2.0 curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=v0.2.0 bash
 ```
 
 ## Contributing
@@ -36,7 +36,7 @@ pnpm cli:install
 Every PR automatically publishes a dev release tagged with the branch name. Others can try it with:
 
 ```bash
-VERSION=my-branch curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=my-branch bash
 ```
 
 ### Releasing

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+
+export const buildCommand = new Command("build")
+    .description("Detect and build all contracts and frontend")
+    .action(async () => {
+        console.log("TODO: build");
+    });

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+
+export const deployCommand = new Command("deploy")
+    .description("Build and deploy contracts and frontend")
+    .option("--suri <suri>", "Signer secret URI (e.g. //Alice for dev)")
+    .option("--contracts", "Include contract build & deploy")
+    .option("--skip-frontend", "Skip frontend build & deploy")
+    .option("--domain <name>", "App domain (overrides package.json)")
+    .action(async (opts) => {
+        console.log("TODO: deploy", opts);
+    });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+
+export const initCommand = new Command("init")
+    .description("Install prerequisites and login via mobile QR")
+    .action(async () => {
+        console.log("TODO: init");
+    });

--- a/src/commands/mod.ts
+++ b/src/commands/mod.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+
+export const modCommand = new Command("mod")
+    .description("Clone a playground app template")
+    .argument("[domain]", "App domain to clone (interactive picker if omitted)")
+    .action(async (domain, opts) => {
+        console.log("TODO: mod", { domain, ...opts });
+    });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,19 @@
 
 import { Command } from "commander";
 import pkg from "../package.json" with { type: "json" };
+import { initCommand } from "./commands/init.js";
+import { modCommand } from "./commands/mod.js";
+import { buildCommand } from "./commands/build.js";
+import { deployCommand } from "./commands/deploy.js";
 
 const program = new Command()
     .name("dot")
     .description("CLI for Polkadot Playground")
     .version(pkg.version);
+
+program.addCommand(initCommand);
+program.addCommand(modCommand);
+program.addCommand(buildCommand);
+program.addCommand(deployCommand);
 
 program.parse();


### PR DESCRIPTION
adds blank `init`, `deploy` and `mod` commands.

Also using this first PR to test & validate the dev release.
- Added a step in dev release to comment the install command on PR
- changed tag to add `dev/` in front of branch name to avoid collisions with commit history