### PR TITLE
Add account setup, dot update, and vitest suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,21 @@
 # CLAUDE.md
 
-Refer to the **Contributing** section of [README.md](./README.md) for development workflows, release process, and repo conventions.
+Refer to the **Contributing** and **Architecture Highlights** sections of [README.md](./README.md) for development workflows, release process, and repo conventions.
+
+## Non-obvious invariants
+
+These are things that aren't self-evident from reading the code and have bitten us before:
+
+- **Do not upgrade `polkadot-api` or `@polkadot-api/sdk-ink`** past the current pins without also bumping `@polkadot-apps/chain-client`. Newer versions break the internal `PolkadotClient` shape that `chain-client` still relies on.
+- **The mobile app wraps `signRaw` data with `<Bytes>…</Bytes>`**, which breaks transaction signing. Our `src/utils/signer.ts` exists specifically to route transactions through `signPayload` instead. Delete this file once `@polkadot-apps/terminal` ships a fix — nothing else.
+- **`getSessionSigner()` returns an adapter that keeps the Node event loop alive**. Every caller must invoke the returned `destroy()` when done. If you add a new top-level command that signs on behalf of the user, wire up the cleanup or the process will hang after the work is done.
+- **`dot init` auto-runs at the end of `install.sh`**. If the init fails, the exit code is surfaced so CI runs don't silently pass.
+
+## Repo conventions
+
+- Tests are `*.test.ts` next to the source. `vitest.config.ts` only picks up `.test.ts`; if you add `.tsx` tests update the config too.
+- Pure logic that lives inside a `.tsx` component should be lifted into a sibling `.ts` file (see `completion.ts` next to `InitScreen.tsx`, or the `formatPas`/`formatMb` exports in `AccountSetup.tsx`). Tests can then import it without dragging React + Ink into the vitest runner.
+- Do NOT add Claude attribution (`Co-Authored-By: Claude`, emoji signatures, etc.) to commits, PRs, or generated files.
+- Do NOT commit design docs, brainstorming notes, or context dumps (e.g. `context.md`) to the repo. They belong in tickets or scratch files outside the tree.
+- Don't mock primitives from `polkadot-api` (`Enum`, encoders) in tests — doing so turns intended coverage into tautology.
+- Long-lived resources (`TerminalAdapter`, `PaseoClient`) have explicit `destroy()` / `destroyConnection()` — always release them, especially from React `useEffect` cleanups. The WebSocket keeps the event loop alive; forgetting a destroy manifests as `dot <cmd>` hanging after its work is visibly finished.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,44 @@ To install a specific version:
 curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | VERSION=v0.2.0 bash
 ```
 
+The installer drops the binary into `~/.polkadot/bin/`, symlinks it at `~/.local/bin/dot`, appends the path to your shell rc, and then runs `dot init` so you can finish setup without a second command.
+
+## Commands
+
+### `dot init`
+
+End-to-end first-run setup. Login and toolchain install run **concurrently**; account setup runs **once both have completed successfully**.
+
+1. **Login via the Polkadot mobile app** — a QR code is printed to the terminal. Scan it with the app. If you already have a session persisted in `~/.polkadot-apps/`, this step is skipped.
+2. **Toolchain install** — `rustup`, nightly, `rust-src`, `cdm`, IPFS, and `gh`. Existing installs are detected and skipped.
+3. **Account setup** (only if a session is available) — in order:
+    - **Fund** — if your balance on Paseo Asset Hub is below 1 PAS, Alice sends 10 PAS (testnet).
+    - **Map** — `Revive.map_account` is signed by you on the mobile app so an H160 is associated with your SS58 address.
+    - **Allow** — Alice grants you 1000 transactions / 100 MB of Bulletin storage.
+
+Flags:
+
+- `-y, --yes` — skip the QR login entirely. Dependencies still install, account setup is skipped (no session).
+
+### `dot update`
+
+Self-update from the latest GitHub release. Detects your OS/arch, downloads the corresponding `dot-<os>-<arch>` asset, verifies HOME is set, and atomically replaces the running binary (write-to-staging-then-rename so the running process is never served a half-written file).
+
+### `dot deploy` (stub)
+
+Will build and publish an app + its contracts. Currently accepts and prints its flags:
+
+- `--contracts` — include contract build & deploy
+- `--skip-frontend` — skip frontend build & deploy
+- `--domain <name>` — DNS name override (else read from `package.json`)
+- `--playground` — publish to the playground registry
+- `--env <env>` — `testnet` (default) or `mainnet`
+- `-y, --yes` — skip interactive prompts
+
+### `dot mod` / `dot build` (stubs)
+
+Planned. No behaviour yet.
+
 ## Contributing
 
 ### Setup
@@ -30,6 +68,16 @@ Compile and install the `dot` binary to `~/.polkadot/bin/`:
 ```bash
 pnpm cli:install
 ```
+
+### Tests
+
+```bash
+pnpm test            # one-shot
+pnpm test:watch      # rerun on change
+npx tsc --noEmit     # type check
+```
+
+Tests live alongside the code as `*.test.ts`. They avoid mocking so deeply that they just re-implement the code under test — real `polkadot-api` primitives (`Enum`) stay real so a variant name change is caught.
 
 ### Testing a Branch Build
 
@@ -55,3 +103,14 @@ Uses [Biome](https://biomejs.dev/). Checked in CI on every PR.
 pnpm format        # fix
 pnpm format:check  # check only
 ```
+
+## Dependency Notes
+
+- `@polkadot-apps/*` are pinned to `latest` intentionally — they are our own packages and we want the lockfile to track head.
+- `@polkadot-api/sdk-ink` is pinned to `^0.6.2` and `polkadot-api` to `^1.23.3` because `chain-client` currently embeds an internal `PolkadotClient` shape that breaks with newer versions. Bump together with `chain-client` only.
+
+## Architecture Highlights
+
+- **Signer shim** (`src/utils/signer.ts`) — the default session signer from `@polkadot-apps/terminal` uses `signRaw`, which the Polkadot mobile app wraps with `<Bytes>…</Bytes>` (producing a `BadProof` on-chain). We delegate to `getPolkadotSignerFromPjs` from `polkadot-api/pjs-signer`, which formats the payload as polkadot.js `SignerPayloadJSON` — exactly what the mobile's `SignPayloadJsonInteractor` consumes. This file can be removed once `@polkadot-apps/terminal` defaults to `signPayload`.
+- **Connection singleton** (`src/utils/connection.ts`) — stores the promise (not the resolved client) so concurrent callers share a single WebSocket. Has a 30s timeout and preserves the underlying error via `Error.cause` for debugging.
+- **Session lifecycle** (`src/utils/auth.ts`) — `getSessionSigner()` returns an explicit `destroy()` handle. Callers MUST call it (typically from a `useEffect` cleanup) — the host-papp adapter keeps the Node event loop alive.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "files": {
-        "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
+        "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json", "vitest.config.ts"],
         "ignore": ["**/node_modules/**", "**/dist/**"]
     },
     "formatter": {

--- a/install.sh
+++ b/install.sh
@@ -65,4 +65,8 @@ export PATH="$INSTALL_DIR/bin:$HOME/.local/bin:$PATH"
 echo ""
 echo -e "dot is ready! Running: \033[1mdot init\033[0m"
 echo ""
-"$INSTALL_DIR/bin/$BIN" init
+if ! "$INSTALL_DIR/bin/$BIN" init; then
+  INIT_EXIT=$?
+  echo -e "\n\033[33mInit did not complete. Run \033[1mdot init\033[0;33m when ready.\033[0m" >&2
+  exit "$INIT_EXIT"
+fi

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
         "format": "biome format --write .",
         "format:check": "biome format .",
         "build": "bun build --compile src/index.ts --outfile ./dist/dot",
-        "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot"
+        "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@polkadot-apps/address": "latest",
@@ -24,7 +26,10 @@
         "@polkadot-apps/terminal": "latest",
         "@polkadot-apps/tx": "latest",
         "@polkadot-apps/utils": "latest",
+        "@polkadot-api/sdk-ink": "^0.6.2",
+        "bulletin-deploy": "latest",
         "commander": "^12.0.0",
+        "polkadot-api": "^1.23.3",
         "ink": "^5.2.1",
         "react": "^18.3.1",
         "react-devtools-core": "file:stubs/react-devtools-core"
@@ -34,7 +39,8 @@
         "@changesets/cli": "^2.29.8",
         "@types/node": "^22.15.3",
         "@types/react": "^18.3.18",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.1"
     },
     "pnpm": {
         "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,36 +8,45 @@ importers:
 
   .:
     dependencies:
+      '@polkadot-api/sdk-ink':
+        specifier: ^0.6.2
+        version: 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
       '@polkadot-apps/address':
         specifier: latest
-        version: 0.4.0(rxjs@7.8.2)
+        version: 0.4.0(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/bulletin':
         specifier: latest
-        version: 0.6.9(rxjs@7.8.2)
+        version: 0.6.9(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/chain-client':
         specifier: latest
-        version: 2.0.4(rxjs@7.8.2)
+        version: 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/contracts':
         specifier: latest
-        version: 0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(rxjs@7.8.2)(typescript@5.9.3)
+        version: 0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       '@polkadot-apps/keys':
         specifier: latest
-        version: 0.4.4(rxjs@7.8.2)
+        version: 0.4.4(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/terminal':
         specifier: latest
-        version: 0.2.2(esbuild@0.25.12)(rxjs@7.8.2)
+        version: 0.2.2(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/tx':
         specifier: latest
-        version: 0.3.5(rxjs@7.8.2)
+        version: 0.3.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/utils':
         specifier: latest
         version: 0.4.0
+      bulletin-deploy:
+        specifier: latest
+        version: 0.6.7(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       commander:
         specifier: ^12.0.0
         version: 12.1.0
       ink:
         specifier: ^5.2.1
         version: 5.2.1(@types/react@18.3.28)(react-devtools-core@file:stubs/react-devtools-core)(react@18.3.1)
+      polkadot-api:
+        specifier: ^1.23.3
+        version: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -60,6 +69,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.1
+        version: 3.2.4(@types/node@22.19.17)
 
 packages:
 
@@ -69,6 +81,9 @@ packages:
   '@alcalzone/ansi-tokenize@0.1.3':
     resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
     engines: {node: '>=14.13.1'}
+
+  '@assemblyscript/loader@0.9.4':
+    resolution: {integrity: sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -139,6 +154,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@chainsafe/is-ip@2.1.0':
+    resolution: {integrity: sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==}
+
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
 
@@ -199,8 +217,35 @@ packages:
     peerDependencies:
       commander: ~14.0.0
 
+  '@dnsquery/dns-packet@6.1.1':
+    resolution: {integrity: sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==}
+    engines: {node: '>=6'}
+
+  '@dotdm/cdm@0.5.4':
+    resolution: {integrity: sha512-89tu3LgQrgnZkhFPr+aYNVEp6rNTOtuE1FwAlrt/Ji/tbNFzTPJ58yfA87V8TOXGEv1Yh5kPHNHeFuH8RiEbEA==}
+
+  '@dotdm/contracts@0.4.0':
+    resolution: {integrity: sha512-1TfEmMQm5nmjMXBKSFqUKDnhaAC54D2xkvXk2lvv+r+Z7novFJSCylH7FxmiGJw7MI3V4MYl3TJB/Ka37oYgRg==}
+
+  '@dotdm/descriptors@0.1.9':
+    resolution: {integrity: sha512-1bx4GD98+ASu64WhT0RHLjf9/Kihp0+YH12IOixi0ngF6G3bK2fXciZPrhklaw0oGeB2XOjH/N8sZ2oBA6lSCQ==}
+    peerDependencies:
+      polkadot-api: '>=1.21.0'
+
+  '@dotdm/env@0.3.2':
+    resolution: {integrity: sha512-wdxuc+CiwiM3kH0WzwuNLCXLxCeKedYa5SnXhRH0J0kjWyw2BQwD05kQkbIkbPRnBAQ+h45uyzxmldR1Cebe8w==}
+
+  '@dotdm/utils@0.3.1':
+    resolution: {integrity: sha512-pT7E+6opUlulMNJ2ZxdXg7EOB+DtIWgQc7BQ6wYrUUbKKsa1Oy1lrrdrHPmTethuJM2y96BJArmdW1Ma2nPy/Q==}
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -211,8 +256,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -223,8 +280,20 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -235,8 +304,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -247,8 +328,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -259,8 +352,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -271,8 +376,20 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -283,8 +400,20 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -295,8 +424,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -307,8 +448,20 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -319,8 +472,20 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -331,8 +496,20 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -343,14 +520,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -369,6 +564,18 @@ packages:
       '@types/node':
         optional: true
 
+  '@ipld/car@5.4.3':
+    resolution: {integrity: sha512-+6QHy+9sLov1K28PmazHyqEmD5oDeMWa3mwxst8rt5OsP7CmEexwYDOflGSjPDOUWgHQ4WabQnBSZfXKvZ0DUw==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  '@ipld/dag-cbor@9.2.6':
+    resolution: {integrity: sha512-vZGJ84Em2jCVAS7td5gc08YTVN8/s4bTQxg4pU77PAXDAR/yLYOthOvkCu01fdl1lrZwz47RdUterxdkrs3p5A==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  '@ipld/dag-pb@4.1.5':
+    resolution: {integrity: sha512-w4PZ2yPqvNmlAir7/2hsCRMqny1EY5jj26iZcSgxREJexmbAc2FI21jp26MqiNdfgAxvkCnf2N/TJI18GaDNwA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -382,11 +589,30 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@leichtgewicht/ip-codec@2.0.5':
+    resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+
+  '@libp2p/interface@3.2.0':
+    resolution: {integrity: sha512-gaG4MeZ294A5VrgEaaBAW/bWse76ZCwmFQ5v8urVNQOgunF3M28zXi41MVFhYMOXlBWsOUY2OUYY1Nw3wkq44w==}
+
+  '@libp2p/logger@6.2.4':
+    resolution: {integrity: sha512-XQayi07DTLfZSrSFrxBkY4vUaHVnVoQDuVCaE3tKigpXZm5OFVMLJW9WDdEGtiJJE8sCaFvXTyg/PmOQSNxh4w==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@multiformats/dns@1.0.13':
+    resolution: {integrity: sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==}
+
+  '@multiformats/multiaddr@13.0.1':
+    resolution: {integrity: sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==}
+
+  '@multiformats/murmur3@2.2.2':
+    resolution: {integrity: sha512-B37HsL4uqZpKzOPRNmpr9hR1lbywZfJR053sYgkQGnnbfNzM1Nw4SlL9I8hMAZRk1TOqr8q+PeaFeuNmKgi2YA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -454,12 +680,200 @@ packages:
   '@novasamatech/storage-adapter@0.6.17':
     resolution: {integrity: sha512-J8xKl0dshS/r8zcrpdjQcqB74d7Y1nISVPTBPS5/Ael4zv/TOi2MKM7SE/wwRkJ6qJsvWJMNHodrm75f8YWHlQ==}
 
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1':
+    resolution: {integrity: sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.43.1':
+    resolution: {integrity: sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1':
+    resolution: {integrity: sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.47.1':
+    resolution: {integrity: sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.19.1':
+    resolution: {integrity: sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1':
+    resolution: {integrity: sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.47.1':
+    resolution: {integrity: sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.45.2':
+    resolution: {integrity: sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.57.2':
+    resolution: {integrity: sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1':
+    resolution: {integrity: sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1':
+    resolution: {integrity: sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.44.1':
+    resolution: {integrity: sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.47.1':
+    resolution: {integrity: sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1':
+    resolution: {integrity: sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0':
+    resolution: {integrity: sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1':
+    resolution: {integrity: sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2':
+    resolution: {integrity: sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.45.1':
+    resolution: {integrity: sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.51.1':
+    resolution: {integrity: sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1':
+    resolution: {integrity: sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.18.1':
+    resolution: {integrity: sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.10.1':
+    resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.36.2':
+    resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.40.1':
+    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+
   '@polkadot-api/cli@0.18.1':
     resolution: {integrity: sha512-jPa8WSNPZWdy372sBAUnm0nU1XX5mLbmgkOOU39+zpYPSE12mYXyM3r7JuT5IHdAccEJr6qK2DplPFTeNSyq9A==}
     hasBin: true
 
-  '@polkadot-api/cli@0.20.2':
-    resolution: {integrity: sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==}
+  '@polkadot-api/cli@0.20.3':
+    resolution: {integrity: sha512-aEvUuw9Fd+syt430hJjO8q04QNWmuqlOMbD9WZwLdeMAiGR0+F5h/CUF4tSybiNcbL5jDWLTzrraL5qdSfjm3w==}
     hasBin: true
 
   '@polkadot-api/codegen@0.21.2':
@@ -492,8 +906,8 @@ packages:
   '@polkadot-api/json-rpc-provider@0.2.0':
     resolution: {integrity: sha512-lhkuBS/x06i3djQIN7p8jVkMnYuGsUAEMS6RhdWeEpz7X/8/APER4Wdih7MEBovCuwVSCTjOxl8f+alH7AZHZg==}
 
-  '@polkadot-api/known-chains@0.11.1':
-    resolution: {integrity: sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==}
+  '@polkadot-api/known-chains@0.11.2':
+    resolution: {integrity: sha512-AlOpIbKLcilTf87/unNuZaNQG6IFr9QrP3i7p9SCU1LO8DqVkkWGlQ5CWqnxci1NAXLeRKlSO9M2E/UZVTxdBg==}
 
   '@polkadot-api/known-chains@0.9.18':
     resolution: {integrity: sha512-zdU4FA01lXcpNXUiFgSmFKIwDKbTw15KT4U6Zlqo6FPUMZgncVEbbS4dSgVrf+TGw9SDOUjGlEdyTHAiOAG5Tw==}
@@ -623,8 +1037,8 @@ packages:
   '@polkadot-api/wasm-executor@0.2.3':
     resolution: {integrity: sha512-B2h1o+Qlo9idpASaHvMSoViB2I5ko5OAfwfhYF8LQDkTADK0B+SeStzNj1Qn+FG34wqTuv7HzBCdjaUgzYINJQ==}
 
-  '@polkadot-api/ws-middleware@0.3.1':
-    resolution: {integrity: sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==}
+  '@polkadot-api/ws-middleware@0.3.2':
+    resolution: {integrity: sha512-x3WuA59NrcIbhfFw+LRnlDNRdMRdg9Wz8OCK6HUjjwFfL/O+yNtf/pTGuINuOigZzmBj7hHixPaVw9VJogCN6Q==}
     peerDependencies:
       rxjs: '>=7.8.0'
 
@@ -698,14 +1112,108 @@ packages:
   '@polkadot-apps/utils@0.4.0':
     resolution: {integrity: sha512-3rTR9yQ3IVINkUKUQwRDbgbkZrcCaIcxniHxyayrD/inuSKO02/lfDre5N0s4EjZZn9Gd/ILAfJnR5Oy4NtOJA==}
 
+  '@polkadot-labs/hdkd-helpers@0.0.26':
+    resolution: {integrity: sha512-mp3GCSiOQeh4aPt+DYBQq6UnX/tKgYUH5F75knjW3ATSA90ifEEWWjRan0Bddt4QKYKamaDGadK9GbVREgzQFw==}
+
   '@polkadot-labs/hdkd-helpers@0.0.27':
     resolution: {integrity: sha512-GTSj/Mw5kwtZbefvq2BhvBnHvs7AY4OnJgppO0kE2S/AuDbD6288C9rmO6qwMNmiNVX8OrYMWaJcs46Mt1UbBw==}
 
   '@polkadot-labs/hdkd-helpers@0.0.28':
     resolution: {integrity: sha512-kENij83Dr76RrcfsJmzcqNhThjWTPtzregb/i6o50kH5n1wkaE58/8PFahMnGVc9Trzk7jxfGSNQphQNwq2emg==}
 
+  '@polkadot-labs/hdkd@0.0.25':
+    resolution: {integrity: sha512-+yZJC1TE4ZKdfoILw8nGxu3H/klrYXm9GdVB0kcyQDecq320ThUmM1M4l8d1F/3QD0Nez9NwHi9t5B++OgJU5A==}
+
   '@polkadot-labs/hdkd@0.0.26':
     resolution: {integrity: sha512-9B+egs7pIwmaxi3X7XBbruxS40aVbcdI1iIqSxfSOf4+RS52E+sgd3MW/LECWrHSof2h4ngcdsXRrOl95FVV8g==}
+
+  '@polkadot/keyring@13.5.9':
+    resolution: {integrity: sha512-bMCpHDN7U8ytxawjBZ89/he5s3AmEZuOdkM/ABcorh/flXNPfyghjFK27Gy4OKoFxX52yJ2sTHR4NxM87GuFXQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/util-crypto': 13.5.9
+
+  '@polkadot/networks@13.5.9':
+    resolution: {integrity: sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/util-crypto@13.5.9':
+    resolution: {integrity: sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 13.5.9
+
+  '@polkadot/util@13.5.9':
+    resolution: {integrity: sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/wasm-bridge@7.5.4':
+    resolution: {integrity: sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-crypto-asmjs@7.5.4':
+    resolution: {integrity: sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/wasm-crypto-init@7.5.4':
+    resolution: {integrity: sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-crypto-wasm@7.5.4':
+    resolution: {integrity: sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/wasm-crypto@7.5.4':
+    resolution: {integrity: sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+      '@polkadot/x-randomvalues': '*'
+
+  '@polkadot/wasm-util@7.5.4':
+    resolution: {integrity: sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': '*'
+
+  '@polkadot/x-bigint@13.5.9':
+    resolution: {integrity: sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-global@13.5.9':
+    resolution: {integrity: sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-randomvalues@13.5.9':
+    resolution: {integrity: sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-util': '*'
+
+  '@polkadot/x-textdecoder@13.5.9':
+    resolution: {integrity: sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==}
+    engines: {node: '>=18'}
+
+  '@polkadot/x-textencoder@13.5.9':
+    resolution: {integrity: sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==}
+    engines: {node: '>=18'}
+
+  '@prisma/instrumentation@6.11.1':
+    resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -862,6 +1370,10 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@scure/sr25519@0.3.0':
+    resolution: {integrity: sha512-SKsinX2sImunfcsH3seGrwH/OayBwwaJqVN8J1cJBNRCfbBq5q0jyTKGa9PcW1HWv9vXT6Yuq41JsxFLvF59ew==}
+    engines: {node: '>= 20.19.0'}
+
   '@scure/sr25519@1.0.0':
     resolution: {integrity: sha512-b+uhK5akMINXZP95F3gJGcb5CMKYxf+q55fwMl0GoBwZDbWolmGNi1FrBSwuaZX5AhqS2byHiAueZgtDNpot2A==}
     engines: {node: '>= 20.19.0'}
@@ -869,12 +1381,60 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry/core@9.47.1':
+    resolution: {integrity: sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@9.47.1':
+    resolution: {integrity: sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.0.0
+      '@opentelemetry/core': ^1.30.1 || ^2.0.0
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.0.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
+      '@opentelemetry/semantic-conventions': ^1.34.0
+
+  '@sentry/node@9.47.1':
+    resolution: {integrity: sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@9.47.1':
+    resolution: {integrity: sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.0.0
+      '@opentelemetry/core': ^1.30.1 || ^2.0.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
+      '@opentelemetry/semantic-conventions': ^1.34.0
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@substrate/ss58-registry@1.51.0':
+    resolution: {integrity: sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==}
+
+  '@types/bn.js@5.2.0':
+    resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/mysql@2.15.26':
+    resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -891,14 +1451,55 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pg-pool@2.0.6':
+    resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.6.1':
+    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
@@ -910,6 +1511,14 @@ packages:
         optional: true
       zod:
         optional: true
+
+  abort-error@1.0.2:
+    resolution: {integrity: sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -953,17 +1562,47 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bl@5.1.0:
+    resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
+
+  blockstore-core@6.1.3:
+    resolution: {integrity: sha512-GLb6XpvbWOlrz1Liz8lTH8iZoXfJ7otY02i26Ok1q6lDkr9uN3jcZq8GzhNq76jJ7CkFG/EGP8J75F3MFo7v6A==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bulletin-deploy@0.6.7:
+    resolution: {integrity: sha512-RyXF5EpdzcuZIWpTMzqcNgmfOvIT4xd1kJiDAYnbpbpIvNrQumGWTKh/3aactUm7DCd4tTC5YscAW2Ej5x0qRQ==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -979,6 +1618,14 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
+  cborg@5.1.0:
+    resolution: {integrity: sha512-OwailRORD5pIyxaLKKVdGHQ2OXWmYW7YsjDXnl64cIwWdQiyXRffVFsL34JR5c+BEeeSOHADM3cy/QNERH1SUw==}
+    hasBin: true
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -986,9 +1633,16 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -1067,6 +1721,10 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge-ts@7.1.5:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
@@ -1103,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -1111,6 +1773,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1123,12 +1790,19 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1164,6 +1838,9 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1179,6 +1856,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1206,6 +1886,16 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hamt-sharding@3.0.6:
+    resolution: {integrity: sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==}
+
+  hashlru@2.3.0:
+    resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -1226,9 +1916,15 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1241,6 +1937,9 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ink@5.2.1:
     resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
@@ -1255,6 +1954,28 @@ packages:
         optional: true
       react-devtools-core:
         optional: true
+
+  interface-blockstore@6.0.2:
+    resolution: {integrity: sha512-Z8LscLfuNWYatKVgaEXK8su+wY6iEEcCXYQiwXf20XVuMvR/zyFa6A0s36epfw8CvUrIv+bXT+FZ2hMEfUCmJw==}
+
+  interface-datastore@9.0.3:
+    resolution: {integrity: sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==}
+
+  interface-store@7.0.2:
+    resolution: {integrity: sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==}
+
+  ipfs-unixfs-importer@16.1.5:
+    resolution: {integrity: sha512-w/voTDW5gt5RlZlJ/EljU4q4s+4any2LZ+10UJR7i24+xWWv1+ReyaC9dz46U6HB5YqztAKCzBB123OOsDsNFg==}
+
+  ipfs-unixfs@11.2.5:
+    resolution: {integrity: sha512-uasYJ0GLPbViaTFsOLnL9YPjX5VmhnqtWRriogAHOe4ApmIi9VAOFBzgDHsUW2ub4pEa/EysbtWk126g2vkU/g==}
+
+  ipfs-unixfs@12.0.2:
+    resolution: {integrity: sha512-uZ3rutVVZZ+tw52P+sgDSgOSK6ztExJVlfCjKvSD+NIEVlWQPDeKgdSFm+Kxchmgp7t6g1h+dzir+NgY+VsQXg==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1317,12 +2038,39 @@ packages:
     peerDependencies:
       ws: '*'
 
+  it-all@3.0.11:
+    resolution: {integrity: sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ==}
+
+  it-batch@3.0.11:
+    resolution: {integrity: sha512-2bvKErkXhtwKYDLKAGdEgveOs8wB0i3RItbaroP/6cC/QlrM7j+HAq/yJq6ci4J7KnzdRi76GyipKlafdOTBgw==}
+
+  it-filter@3.1.6:
+    resolution: {integrity: sha512-yXiGPAvJn/exXjVFSCMQc3+J/7RLpOMwKoY2DH1yMhF4lYkdRoAdOwU0vnDACAlRAexf7AZvESZIc9mzhEoi/A==}
+
+  it-first@3.0.11:
+    resolution: {integrity: sha512-0ig8DKpg09V1o7JBagm3oPx3VY7WYfU5w3lpbLbqzijnfMPSvMGoMZuLm17h/RgOJXKP+9mt7vsCNiU2TW8TkQ==}
+
+  it-merge@3.0.14:
+    resolution: {integrity: sha512-D3t1Go2G2SQMkTujaA6EVojJPJKA9pFksxlSPDRBfrHKhWl6O40vEP7Itr5eCAjyCQH5p9+BFFVIy9bhLM4ZuQ==}
+
+  it-parallel-batch@3.0.11:
+    resolution: {integrity: sha512-n2gvHRVx14COn25jkio+fOHuKWaA5EVf9f0GbdWgVe8gXRIMYCai+CbmQACIv7o2Jn3ZAUOXD9Ob1Ftod0qtJQ==}
+
+  it-peekable@3.0.10:
+    resolution: {integrity: sha512-2E6+p1pelZOhzp69aaiiBuEybWzAl10uYbIdCR3Pxy8bFNnS/kgpbLtGbNbIZ6RVdU7yHHkmATYwjy52GfFEKA==}
+
+  it-queueless-pushable@2.0.5:
+    resolution: {integrity: sha512-BaKqGLL1AQMR1AEaxiM09vzJQVXHHhfhh9UV0qPqORw/8Rm8igDQqT1qHregfHIb1NIW9jxQ/aXBibHJyuivuQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1364,6 +2112,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1373,6 +2124,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  main-event@1.0.4:
+    resolution: {integrity: sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1390,8 +2144,18 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1399,6 +2163,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  ms@3.0.0-canary.202508261828:
+    resolution: {integrity: sha512-NotsCoUCIUkojWCzQff4ttdCfIPoA1UGZsyQbi7KmqkNRfKCrvga8JJi2PknHymHOuor0cJSn/ylj52Cbt2IrQ==}
+    engines: {node: '>=18'}
 
   multiformats@13.4.2:
     resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
@@ -1410,6 +2178,11 @@ packages:
     resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.7:
     resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
@@ -1418,6 +2191,15 @@ packages:
   neverthrow@8.2.0:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -1458,6 +2240,10 @@ packages:
       typescript:
         optional: true
 
+  p-defer@4.0.1:
+    resolution: {integrity: sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==}
+    engines: {node: '>=12'}
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -1473,6 +2259,14 @@ packages:
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
+
+  p-queue@9.1.2:
+    resolution: {integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==}
+    engines: {node: '>=20'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -1505,12 +2299,30 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1544,8 +2356,8 @@ packages:
     peerDependencies:
       rxjs: '>=7.8.0'
 
-  polkadot-api@2.0.1:
-    resolution: {integrity: sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==}
+  polkadot-api@2.0.2:
+    resolution: {integrity: sha512-eYj7VUVuZu4CibGnhJGfixqiGc5IIiJX87fNpW+UVvqht3DxVBWpPpUCDwP6AH4lKY97zgNfp4o18HMgp9aV2Q==}
     hasBin: true
     peerDependencies:
       rxjs: '>=7.8.0'
@@ -1568,6 +2380,26 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -1576,6 +2408,15 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  progress-events@1.1.0:
+    resolution: {integrity: sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==}
+
+  protons-runtime@5.6.0:
+    resolution: {integrity: sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==}
+
+  protons-runtime@6.0.1:
+    resolution: {integrity: sha512-ONL+jDj143WA1m+WKLuuqBIaDKxm32dx6HfJdyujrRcni/6KkhXzVnyg22nH/Wwqmbwnd1BKUVkD1hMEWZFeww==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1591,6 +2432,13 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rabin-wasm@0.1.5:
+    resolution: {integrity: sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==}
+    hasBin: true
+
+  race-signal@2.0.0:
+    resolution: {integrity: sha512-P31bLhE4ByBX/70QDXMutxnqgwrF1WUXea1O8DXuviAgkdbQ1iQMQotNgzJIBC9yUSn08u/acZrMUhgw7w6GpA==}
 
   react-devtools-core@file:stubs/react-devtools-core:
     resolution: {directory: stubs/react-devtools-core, type: directory}
@@ -1617,6 +2465,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1624,6 +2476,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -1634,6 +2490,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
@@ -1665,6 +2526,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1689,6 +2553,12 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1716,10 +2586,17 @@ packages:
     resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
     engines: {node: '>=12'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  sparse-array@1.3.2:
+    resolution: {integrity: sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -1743,6 +2620,12 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
@@ -1758,6 +2641,9 @@ packages:
   string-width@8.2.0:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1775,10 +2661,21 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -1795,6 +2692,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -1802,9 +2702,24 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -1868,6 +2783,15 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  uint8-varint@2.0.4:
+    resolution: {integrity: sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==}
+
+  uint8arraylist@2.4.9:
+    resolution: {integrity: sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==}
+
+  uint8arrays@5.1.1:
+    resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -1897,8 +2821,17 @@ packages:
     resolution: {integrity: sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==}
     engines: {node: '>=18.12.0'}
 
+  utf8-codec@1.0.0:
+    resolution: {integrity: sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
   verifiablejs@1.2.0:
     resolution: {integrity: sha512-+VVQo9yZko+w3THKaYvLbjXdfaiw1WJnX12wJEU5jHsHrMkjDrAMWoKYcBvtlHXufJirr8FlT6v2i/0yA3/ivQ==}
@@ -1911,8 +2844,90 @@ packages:
       typescript:
         optional: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  weald@1.1.1:
+    resolution: {integrity: sha512-PaEQShzMCz8J/AD2N3dJMc1hTZWkJeLKS2NMeiVkV5KDHwgZe7qXLEzyodsT/SODxWDdXJJqocuwf3kHzcXhSQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -1923,6 +2938,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -1973,6 +2993,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -1999,6 +3023,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
+
+  '@assemblyscript/loader@0.9.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2044,6 +3070,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@chainsafe/is-ip@2.1.0': {}
 
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
@@ -2192,82 +3220,240 @@ snapshots:
     dependencies:
       commander: 14.0.3
 
+  '@dnsquery/dns-packet@6.1.1':
+    dependencies:
+      '@leichtgewicht/ip-codec': 2.0.5
+      utf8-codec: 1.0.0
+
+  '@dotdm/cdm@0.5.4(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)':
+    dependencies:
+      '@dotdm/contracts': 0.4.0(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
+      '@dotdm/env': 0.3.2(postcss@8.5.10)(rxjs@7.8.2)
+      '@dotdm/utils': 0.3.1
+      '@polkadot-api/sdk-ink': 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@polkadot-api/ink-contracts'
+      - '@swc/core'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+      - zod
+
+  '@dotdm/contracts@0.4.0(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)':
+    dependencies:
+      '@dotdm/descriptors': 0.1.9(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
+      '@dotdm/env': 0.3.2(postcss@8.5.10)(rxjs@7.8.2)
+      '@dotdm/utils': 0.3.1
+      '@noble/hashes': 2.2.0
+      '@polkadot-api/sdk-ink': 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
+      multiformats: 13.4.2
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@polkadot-api/ink-contracts'
+      - '@swc/core'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+      - zod
+
+  '@dotdm/descriptors@0.1.9(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))':
+    dependencies:
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+
+  '@dotdm/env@0.3.2(postcss@8.5.10)(rxjs@7.8.2)':
+    dependencies:
+      '@dotdm/descriptors': 0.1.9(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
+      '@dotdm/utils': 0.3.1
+      '@polkadot-labs/hdkd': 0.0.26
+      '@polkadot-labs/hdkd-helpers': 0.0.27
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+      smoldot: 2.0.40
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - utf-8-validate
+      - yaml
+
+  '@dotdm/utils@0.3.1':
+    dependencies:
+      '@polkadot-labs/hdkd': 0.0.26
+      '@polkadot-labs/hdkd-helpers': 0.0.27
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@ethereumjs/rlp@10.1.1': {}
@@ -2278,6 +3464,22 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.19.17
+
+  '@ipld/car@5.4.3':
+    dependencies:
+      '@ipld/dag-cbor': 9.2.6
+      cborg: 5.1.0
+      multiformats: 13.4.2
+      varint: 6.0.0
+
+  '@ipld/dag-cbor@9.2.6':
+    dependencies:
+      cborg: 5.1.0
+      multiformats: 13.4.2
+
+  '@ipld/dag-pb@4.1.5':
+    dependencies:
+      multiformats: 13.4.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2292,6 +3494,25 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@leichtgewicht/ip-codec@2.0.5': {}
+
+  '@libp2p/interface@3.2.0':
+    dependencies:
+      '@multiformats/dns': 1.0.13
+      '@multiformats/multiaddr': 13.0.1
+      main-event: 1.0.4
+      multiformats: 13.4.2
+      progress-events: 1.1.0
+      uint8arraylist: 2.4.9
+
+  '@libp2p/logger@6.2.4':
+    dependencies:
+      '@libp2p/interface': 3.2.0
+      '@multiformats/multiaddr': 13.0.1
+      interface-datastore: 9.0.3
+      multiformats: 13.4.2
+      weald: 1.1.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -2308,6 +3529,26 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@multiformats/dns@1.0.13':
+    dependencies:
+      '@dnsquery/dns-packet': 6.1.1
+      '@libp2p/interface': 3.2.0
+      hashlru: 2.3.0
+      p-queue: 9.1.2
+      progress-events: 1.1.0
+      uint8arrays: 5.1.1
+
+  '@multiformats/multiaddr@13.0.1':
+    dependencies:
+      '@chainsafe/is-ip': 2.1.0
+      multiformats: 13.4.2
+      uint8-varint: 2.0.4
+      uint8arrays: 5.1.1
+
+  '@multiformats/murmur3@2.2.2':
+    dependencies:
+      multiformats: 13.4.2
 
   '@noble/ciphers@1.3.0': {}
 
@@ -2354,14 +3595,14 @@ snapshots:
       neverthrow: 8.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/host-papp@0.6.17(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/host-papp@0.6.17(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1
       '@novasamatech/host-api': 0.6.17
       '@novasamatech/scale': 0.6.17
-      '@novasamatech/statement-store': 0.6.17(esbuild@0.25.12)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.6.17(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.6.17
       '@polkadot-api/substrate-bindings': 0.17.0
       '@polkadot-api/utils': 0.2.0
@@ -2370,7 +3611,7 @@ snapshots:
       nanoevents: 9.1.0
       nanoid: 5.1.7
       neverthrow: 8.2.0
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       scale-ts: 1.6.1
       verifiablejs: 1.2.0
     transitivePeerDependencies:
@@ -2391,11 +3632,11 @@ snapshots:
       '@polkadot-api/utils': 0.2.0
       scale-ts: 1.6.1
 
-  '@novasamatech/sdk-statement@0.5.0(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/sdk-statement@0.5.0(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.19.0
       '@polkadot-api/utils': 0.3.0
-      polkadot-api: 2.0.1(esbuild@0.25.12)(rxjs@7.8.2)
+      polkadot-api: 2.0.2(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -2403,18 +3644,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.6.17(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.6.17(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      '@novasamatech/sdk-statement': 0.5.0(esbuild@0.25.12)(rxjs@7.8.2)
+      '@novasamatech/sdk-statement': 0.5.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@polkadot-api/substrate-bindings': 0.17.0
       '@polkadot-api/substrate-client': 0.5.0
       '@polkadot-api/utils': 0.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.28
       '@scure/sr25519': 1.0.0
       neverthrow: 8.2.0
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
@@ -2434,7 +3675,249 @@ snapshots:
       nanoevents: 9.1.0
       neverthrow: 8.2.0
 
-  '@polkadot-api/cli@0.18.1':
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+      forwarded-parse: 2.1.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.26
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.6.1
+      '@types/pg-pool': 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.7.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.36.2': {}
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@polkadot-api/cli@0.18.1(postcss@8.5.10)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
       '@polkadot-api/codegen': 0.21.2
@@ -2460,7 +3943,7 @@ snapshots:
       read-pkg: 10.1.0
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@5.9.3)
-      tsup: 8.5.0(typescript@5.9.3)
+      tsup: 8.5.0(postcss@8.5.10)(typescript@5.9.3)
       typescript: 5.9.3
       write-package: 7.2.0
     transitivePeerDependencies:
@@ -2474,13 +3957,13 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-api/cli@0.20.2(esbuild@0.25.12)':
+  '@polkadot-api/cli@0.20.3(esbuild@0.27.7)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
       '@polkadot-api/codegen': 0.22.3
       '@polkadot-api/ink-contracts': 0.6.1
       '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.1
+      '@polkadot-api/known-chains': 0.11.2
       '@polkadot-api/metadata-compatibility': 0.6.1
       '@polkadot-api/observable-client': 0.18.4(rxjs@7.8.2)
       '@polkadot-api/sm-provider': 0.3.0(@polkadot-api/smoldot@0.4.0)
@@ -2489,7 +3972,7 @@ snapshots:
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-api/utils': 0.4.0
       '@polkadot-api/wasm-executor': 0.2.3
-      '@polkadot-api/ws-middleware': 0.3.1(rxjs@7.8.2)
+      '@polkadot-api/ws-middleware': 0.3.2(rxjs@7.8.2)
       '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
       '@types/node': 25.6.0
       commander: 14.0.3
@@ -2498,7 +3981,7 @@ snapshots:
       ora: 9.3.0
       read-pkg: 10.1.0
       rollup: 4.60.1
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.60.1)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.60.1)
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -2525,9 +4008,9 @@ snapshots:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
 
-  '@polkadot-api/common-sdk-utils@0.2.0(polkadot-api@1.23.3(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@polkadot-api/common-sdk-utils@0.2.0(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       rxjs: 7.8.2
 
   '@polkadot-api/ink-contracts@0.4.6':
@@ -2550,7 +4033,7 @@ snapshots:
 
   '@polkadot-api/json-rpc-provider@0.2.0': {}
 
-  '@polkadot-api/known-chains@0.11.1': {}
+  '@polkadot-api/known-chains@0.11.2': {}
 
   '@polkadot-api/known-chains@0.9.18': {}
 
@@ -2648,14 +4131,14 @@ snapshots:
     dependencies:
       '@polkadot-api/json-rpc-provider': 0.2.0
 
-  '@polkadot-api/sdk-ink@0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)':
+  '@polkadot-api/sdk-ink@0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:
       '@ethereumjs/rlp': 10.1.1
-      '@polkadot-api/common-sdk-utils': 0.2.0(polkadot-api@1.23.3(rxjs@7.8.2))(rxjs@7.8.2)
+      '@polkadot-api/common-sdk-utils': 0.2.0(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)
       '@polkadot-api/ink-contracts': 0.6.1
       '@polkadot-api/substrate-bindings': 0.16.6
       abitype: 1.2.3(typescript@5.9.3)
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       rxjs: 7.8.2
       viem: 2.48.0(typescript@5.9.3)
     transitivePeerDependencies:
@@ -2780,7 +4263,7 @@ snapshots:
 
   '@polkadot-api/wasm-executor@0.2.3': {}
 
-  '@polkadot-api/ws-middleware@0.3.1(rxjs@7.8.2)':
+  '@polkadot-api/ws-middleware@0.3.2(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/json-rpc-provider': 0.2.0
       '@polkadot-api/json-rpc-provider-proxy': 0.4.0
@@ -2806,10 +4289,10 @@ snapshots:
       '@polkadot-api/utils': 0.4.0
       rxjs: 7.8.2
 
-  '@polkadot-apps/address@0.4.0(rxjs@7.8.2)':
+  '@polkadot-apps/address@0.4.0(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-api/substrate-bindings': 0.17.0
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@swc/core'
@@ -2822,16 +4305,16 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/bulletin@0.6.9(rxjs@7.8.2)':
+  '@polkadot-apps/bulletin@0.6.9(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/chain-client': 2.0.4(rxjs@7.8.2)
-      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(rxjs@7.8.2))
-      '@polkadot-apps/host': 0.5.1(rxjs@7.8.2)
+      '@polkadot-apps/chain-client': 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
+      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
-      '@polkadot-apps/tx': 0.3.5(rxjs@7.8.2)
+      '@polkadot-apps/tx': 0.3.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/utils': 0.4.0
       multiformats: 13.4.2
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@swc/core'
@@ -2844,11 +4327,11 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/chain-client@2.0.4(rxjs@7.8.2)':
+  '@polkadot-apps/chain-client@2.0.4(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(rxjs@7.8.2))
-      '@polkadot-apps/host': 0.5.1(rxjs@7.8.2)
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
+      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@novasamatech/product-sdk'
@@ -2862,15 +4345,15 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/contracts@0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(rxjs@7.8.2)(typescript@5.9.3)':
+  '@polkadot-apps/contracts@0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:
-      '@polkadot-api/sdk-ink': 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
-      '@polkadot-apps/keys': 0.4.4(rxjs@7.8.2)
+      '@polkadot-api/sdk-ink': 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
+      '@polkadot-apps/keys': 0.4.4(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
-      '@polkadot-apps/signer': 1.1.0(@novasamatech/host-api@0.6.17)(rxjs@7.8.2)
-      '@polkadot-apps/tx': 0.3.5(rxjs@7.8.2)
+      '@polkadot-apps/signer': 1.1.0(@novasamatech/host-api@0.6.17)(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/tx': 0.3.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@novasamatech/host-api'
@@ -2894,13 +4377,13 @@ snapshots:
       '@noble/hashes': 2.2.0
       tweetnacl: 1.0.3
 
-  '@polkadot-apps/descriptors@1.0.1(polkadot-api@1.23.3(rxjs@7.8.2))':
+  '@polkadot-apps/descriptors@1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))':
     dependencies:
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
 
-  '@polkadot-apps/host@0.5.1(rxjs@7.8.2)':
+  '@polkadot-apps/host@0.5.1(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@swc/core'
@@ -2913,15 +4396,15 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/keys@0.4.4(rxjs@7.8.2)':
+  '@polkadot-apps/keys@0.4.4(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/address': 0.4.0(rxjs@7.8.2)
+      '@polkadot-apps/address': 0.4.0(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/crypto': 1.0.0
-      '@polkadot-apps/storage': 0.2.8(rxjs@7.8.2)
+      '@polkadot-apps/storage': 0.2.8(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/utils': 0.4.0
       '@polkadot-labs/hdkd': 0.0.26
       '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@novasamatech/product-sdk'
@@ -2937,13 +4420,13 @@ snapshots:
 
   '@polkadot-apps/logger@0.1.5': {}
 
-  '@polkadot-apps/signer@1.1.0(@novasamatech/host-api@0.6.17)(rxjs@7.8.2)':
+  '@polkadot-apps/signer@1.1.0(@novasamatech/host-api@0.6.17)(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/address': 0.4.0(rxjs@7.8.2)
-      '@polkadot-apps/host': 0.5.1(rxjs@7.8.2)
-      '@polkadot-apps/keys': 0.4.4(rxjs@7.8.2)
+      '@polkadot-apps/address': 0.4.0(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/keys': 0.4.4(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     optionalDependencies:
       '@novasamatech/host-api': 0.6.17
     transitivePeerDependencies:
@@ -2958,9 +4441,9 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/storage@0.2.8(rxjs@7.8.2)':
+  '@polkadot-apps/storage@0.2.8(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/host': 0.5.1(rxjs@7.8.2)
+      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
       dexie: 4.4.2
     transitivePeerDependencies:
@@ -2976,14 +4459,14 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/terminal@0.2.2(esbuild@0.25.12)(rxjs@7.8.2)':
+  '@polkadot-apps/terminal@0.2.2(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@novasamatech/host-papp': 0.6.17(esbuild@0.25.12)(rxjs@7.8.2)
-      '@novasamatech/statement-store': 0.6.17(esbuild@0.25.12)(rxjs@7.8.2)
+      '@novasamatech/host-papp': 0.6.17(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.6.17(esbuild@0.27.7)(postcss@8.5.10)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.6.17
       '@polkadot-api/ws-provider': 0.7.5
       neverthrow: 8.2.0
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
       qrcode: 1.5.4
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
@@ -2998,12 +4481,12 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/tx@0.3.5(rxjs@7.8.2)':
+  '@polkadot-apps/tx@0.3.5(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/keys': 0.4.4(rxjs@7.8.2)
+      '@polkadot-apps/keys': 0.4.4(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
       '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 1.23.3(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@novasamatech/product-sdk'
@@ -3022,6 +4505,14 @@ snapshots:
       '@noble/hashes': 2.2.0
       '@polkadot-apps/logger': 0.1.5
 
+  '@polkadot-labs/hdkd-helpers@0.0.26':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.0.0
+      '@scure/sr25519': 0.3.0
+      scale-ts: 1.6.1
+
   '@polkadot-labs/hdkd-helpers@0.0.27':
     dependencies:
       '@noble/curves': 2.2.0
@@ -3038,9 +4529,125 @@ snapshots:
       '@scure/sr25519': 1.0.0
       scale-ts: 1.6.1
 
+  '@polkadot-labs/hdkd@0.0.25':
+    dependencies:
+      '@polkadot-labs/hdkd-helpers': 0.0.28
+
   '@polkadot-labs/hdkd@0.0.26':
     dependencies:
       '@polkadot-labs/hdkd-helpers': 0.0.27
+
+  '@polkadot/keyring@13.5.9(@polkadot/util-crypto@13.5.9(@polkadot/util@13.5.9))(@polkadot/util@13.5.9)':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/util-crypto': 13.5.9(@polkadot/util@13.5.9)
+      tslib: 2.8.1
+
+  '@polkadot/networks@13.5.9':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@substrate/ss58-registry': 1.51.0
+      tslib: 2.8.1
+
+  '@polkadot/util-crypto@13.5.9(@polkadot/util@13.5.9)':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@polkadot/networks': 13.5.9
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-crypto': 7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/x-bigint': 13.5.9
+      '@polkadot/x-randomvalues': 13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9))
+      '@scure/base': 1.2.6
+      tslib: 2.8.1
+
+  '@polkadot/util@13.5.9':
+    dependencies:
+      '@polkadot/x-bigint': 13.5.9
+      '@polkadot/x-global': 13.5.9
+      '@polkadot/x-textdecoder': 13.5.9
+      '@polkadot/x-textencoder': 13.5.9
+      '@types/bn.js': 5.2.0
+      bn.js: 5.2.3
+      tslib: 2.8.1
+
+  '@polkadot/wasm-bridge@7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/x-randomvalues': 13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-asmjs@7.5.4(@polkadot/util@13.5.9)':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-init@7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-bridge': 7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))
+      '@polkadot/wasm-crypto-asmjs': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/wasm-crypto-wasm': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/x-randomvalues': 13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto-wasm@7.5.4(@polkadot/util@13.5.9)':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      tslib: 2.8.1
+
+  '@polkadot/wasm-crypto@7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-bridge': 7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))
+      '@polkadot/wasm-crypto-asmjs': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/wasm-crypto-init': 7.5.4(@polkadot/util@13.5.9)(@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)))
+      '@polkadot/wasm-crypto-wasm': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/x-randomvalues': 13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9))
+      tslib: 2.8.1
+
+  '@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9)':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      tslib: 2.8.1
+
+  '@polkadot/x-bigint@13.5.9':
+    dependencies:
+      '@polkadot/x-global': 13.5.9
+      tslib: 2.8.1
+
+  '@polkadot/x-global@13.5.9':
+    dependencies:
+      tslib: 2.8.1
+
+  '@polkadot/x-randomvalues@13.5.9(@polkadot/util@13.5.9)(@polkadot/wasm-util@7.5.4(@polkadot/util@13.5.9))':
+    dependencies:
+      '@polkadot/util': 13.5.9
+      '@polkadot/wasm-util': 7.5.4(@polkadot/util@13.5.9)
+      '@polkadot/x-global': 13.5.9
+      tslib: 2.8.1
+
+  '@polkadot/x-textdecoder@13.5.9':
+    dependencies:
+      '@polkadot/x-global': 13.5.9
+      tslib: 2.8.1
+
+  '@polkadot/x-textencoder@13.5.9':
+    dependencies:
+      '@polkadot/x-global': 13.5.9
+      tslib: 2.8.1
+
+  '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -3136,6 +4743,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/sr25519@0.3.0':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+
   '@scure/sr25519@1.0.0':
     dependencies:
       '@noble/curves': 2.0.1
@@ -3143,9 +4755,94 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/core@9.47.1': {}
+
+  '@sentry/node-core@9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 9.47.1
+      '@sentry/opentelemetry': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 1.15.0
+
+  '@sentry/node@9.47.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 6.11.1(@opentelemetry/api@1.9.1)
+      '@sentry/core': 9.47.1
+      '@sentry/node-core': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 1.15.0
+      minimatch: 9.0.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/opentelemetry@9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 9.47.1
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@substrate/ss58-registry@1.51.0': {}
+
+  '@types/bn.js@5.2.0':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/mysql@2.15.26':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@types/node@12.20.55': {}
 
@@ -3163,6 +4860,16 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pg-pool@2.0.6':
+    dependencies:
+      '@types/pg': 8.6.1
+
+  '@types/pg@8.6.1':
+    dependencies:
+      '@types/node': 22.19.17
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react@18.3.28':
@@ -3170,13 +4877,67 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/shimmer@1.2.0': {}
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   abitype@1.2.3(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  abort-error@1.0.2: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn@8.16.0: {}
 
@@ -3206,15 +4967,83 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   auto-bind@5.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  bl@5.1.0:
+    dependencies:
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  blockstore-core@6.1.3:
+    dependencies:
+      '@libp2p/logger': 6.2.4
+      interface-blockstore: 6.0.2
+      interface-store: 7.0.2
+      it-all: 3.0.11
+      it-filter: 3.1.6
+      it-merge: 3.0.14
+      multiformats: 13.4.2
+
+  bn.js@5.2.3: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bulletin-deploy@0.6.7(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3):
+    dependencies:
+      '@dotdm/cdm': 0.5.4(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
+      '@ipld/car': 5.4.3
+      '@ipld/dag-pb': 4.1.5
+      '@noble/hashes': 1.8.0
+      '@polkadot-api/substrate-bindings': 0.16.6
+      '@polkadot-labs/hdkd': 0.0.25
+      '@polkadot-labs/hdkd-helpers': 0.0.26
+      '@polkadot/keyring': 13.5.9(@polkadot/util-crypto@13.5.9(@polkadot/util@13.5.9))(@polkadot/util@13.5.9)
+      '@polkadot/util-crypto': 13.5.9(@polkadot/util@13.5.9)
+      '@sentry/node': 9.47.1
+      blockstore-core: 6.1.3
+      ipfs-unixfs: 11.2.5
+      ipfs-unixfs-importer: 16.1.5
+      multiformats: 13.4.2
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+      viem: 2.48.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@polkadot-api/ink-contracts'
+      - '@polkadot/util'
+      - '@swc/core'
+      - bufferutil
+      - encoding
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+      - zod
 
   bundle-require@5.1.0(esbuild@0.25.12):
     dependencies:
@@ -3225,13 +5054,27 @@ snapshots:
 
   camelcase@5.3.1: {}
 
+  cborg@5.1.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@5.6.2: {}
 
   chardet@2.1.1: {}
 
+  check-error@2.1.3: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  cjs-module-lexer@1.4.3: {}
 
   cli-boxes@3.0.0: {}
 
@@ -3292,6 +5135,8 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  deep-eql@5.0.2: {}
+
   deepmerge-ts@7.1.5: {}
 
   detect-indent@6.1.0: {}
@@ -3316,6 +5161,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   environment@1.1.0: {}
+
+  es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -3350,9 +5197,42 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escape-string-regexp@2.0.0: {}
 
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   eventemitter3@5.0.1: {}
 
@@ -3370,6 +5250,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
 
@@ -3408,6 +5290,8 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.1
 
+  forwarded-parse@2.1.2: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3424,6 +5308,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -3453,6 +5339,17 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hamt-sharding@3.0.6:
+    dependencies:
+      sparse-array: 1.3.2
+      uint8arrays: 5.1.1
+
+  hashlru@2.3.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -3469,13 +5366,24 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
+
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
   indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
+
+  inherits@2.0.4: {}
 
   ink@5.2.1(@types/react@18.3.28)(react-devtools-core@file:stubs/react-devtools-core)(react@18.3.1):
     dependencies:
@@ -3510,6 +5418,54 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  interface-blockstore@6.0.2:
+    dependencies:
+      interface-store: 7.0.2
+      multiformats: 13.4.2
+
+  interface-datastore@9.0.3:
+    dependencies:
+      interface-store: 7.0.2
+      uint8arrays: 5.1.1
+
+  interface-store@7.0.2: {}
+
+  ipfs-unixfs-importer@16.1.5:
+    dependencies:
+      '@ipld/dag-pb': 4.1.5
+      '@multiformats/murmur3': 2.2.2
+      blockstore-core: 6.1.3
+      hamt-sharding: 3.0.6
+      interface-blockstore: 6.0.2
+      interface-store: 7.0.2
+      ipfs-unixfs: 12.0.2
+      it-all: 3.0.11
+      it-batch: 3.0.11
+      it-first: 3.0.11
+      it-parallel-batch: 3.0.11
+      multiformats: 13.4.2
+      progress-events: 1.1.0
+      rabin-wasm: 0.1.5
+      uint8arraylist: 2.4.9
+      uint8arrays: 5.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  ipfs-unixfs@11.2.5:
+    dependencies:
+      protons-runtime: 5.6.0
+      uint8arraylist: 2.4.9
+
+  ipfs-unixfs@12.0.2:
+    dependencies:
+      protons-runtime: 6.0.1
+      uint8arraylist: 2.4.9
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -3549,9 +5505,37 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
+  it-all@3.0.11: {}
+
+  it-batch@3.0.11: {}
+
+  it-filter@3.1.6:
+    dependencies:
+      it-peekable: 3.0.10
+
+  it-first@3.0.11: {}
+
+  it-merge@3.0.14:
+    dependencies:
+      it-queueless-pushable: 2.0.5
+
+  it-parallel-batch@3.0.11:
+    dependencies:
+      it-batch: 3.0.11
+
+  it-peekable@3.0.10: {}
+
+  it-queueless-pushable@2.0.5:
+    dependencies:
+      abort-error: 1.0.2
+      p-defer: 4.0.1
+      race-signal: 2.0.0
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -3589,6 +5573,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.5: {}
@@ -3596,6 +5582,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  main-event@1.0.4: {}
 
   merge2@1.4.1: {}
 
@@ -3608,6 +5596,12 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -3615,9 +5609,13 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  module-details-from-path@1.0.4: {}
+
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  ms@3.0.0-canary.202508261828: {}
 
   multiformats@13.4.2: {}
 
@@ -3629,11 +5627,17 @@ snapshots:
 
   nanoevents@9.1.0: {}
 
+  nanoid@3.3.11: {}
+
   nanoid@5.1.7: {}
 
   neverthrow@8.2.0:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.60.1
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -3690,6 +5694,8 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  p-defer@4.0.1: {}
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -3703,6 +5709,13 @@ snapshots:
       p-limit: 2.3.0
 
   p-map@2.1.0: {}
+
+  p-queue@9.1.2:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 7.0.1
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 
@@ -3726,9 +5739,25 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-parse@1.0.7: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
 
   picocolors@1.1.1: {}
 
@@ -3748,9 +5777,9 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  polkadot-api@1.23.3(rxjs@7.8.2):
+  polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2):
     dependencies:
-      '@polkadot-api/cli': 0.18.1
+      '@polkadot-api/cli': 0.18.1(postcss@8.5.10)
       '@polkadot-api/ink-contracts': 0.4.6
       '@polkadot-api/json-rpc-provider': 0.0.4
       '@polkadot-api/known-chains': 0.9.18
@@ -3781,12 +5810,12 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  polkadot-api@2.0.1(esbuild@0.25.12)(rxjs@7.8.2):
+  polkadot-api@2.0.2(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:
-      '@polkadot-api/cli': 0.20.2(esbuild@0.25.12)
+      '@polkadot-api/cli': 0.20.3(esbuild@0.27.7)
       '@polkadot-api/ink-contracts': 0.6.1
       '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.1
+      '@polkadot-api/known-chains': 0.11.2
       '@polkadot-api/logs-provider': 0.2.0
       '@polkadot-api/metadata-builders': 0.14.1
       '@polkadot-api/metadata-compatibility': 0.6.1
@@ -3799,7 +5828,7 @@ snapshots:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/substrate-client': 0.7.0
       '@polkadot-api/utils': 0.4.0
-      '@polkadot-api/ws-middleware': 0.3.1(rxjs@7.8.2)
+      '@polkadot-api/ws-middleware': 0.3.2(rxjs@7.8.2)
       '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
       '@rx-state/core': 0.1.4(rxjs@7.8.2)
       rxjs: 7.8.2
@@ -3809,15 +5838,47 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.10
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prettier@2.8.8: {}
 
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  progress-events@1.1.0: {}
+
+  protons-runtime@5.6.0:
+    dependencies:
+      uint8-varint: 2.0.4
+      uint8arraylist: 2.4.9
+      uint8arrays: 5.1.1
+
+  protons-runtime@6.0.1:
+    dependencies:
+      uint8-varint: 2.0.4
+      uint8arraylist: 2.4.9
+      uint8arrays: 5.1.1
 
   punycode@2.3.1: {}
 
@@ -3830,6 +5891,20 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rabin-wasm@0.1.5:
+    dependencies:
+      '@assemblyscript/loader': 0.9.4
+      bl: 5.1.0
+      debug: 4.4.3
+      minimist: 1.2.8
+      node-fetch: 2.7.0
+      readable-stream: 3.6.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  race-signal@2.0.0: {}
 
   react-devtools-core@file:stubs/react-devtools-core: {}
 
@@ -3866,15 +5941,36 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
 
   require-directory@2.1.1: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
 
   require-main-filename@2.0.0: {}
 
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@4.0.0:
     dependencies:
@@ -3888,11 +5984,11 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.25.12)(rollup@4.60.1):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.1):
     dependencies:
       debug: 4.4.3
       es-module-lexer: 1.7.0
-      esbuild: 0.25.12
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.60.1
       unplugin-utils: 0.2.5
@@ -3938,6 +6034,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   scale-ts@1.6.1: {}
@@ -3955,6 +6053,10 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shimmer@1.2.1: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -3983,9 +6085,13 @@ snapshots:
     dependencies:
       is-plain-obj: 4.1.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  sparse-array@1.3.2: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -4012,6 +6118,10 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   stdin-discarder@0.3.2: {}
 
   string-width@4.2.3:
@@ -4031,6 +6141,10 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4043,6 +6157,10 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -4052,6 +6170,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
+
+  supports-color@10.2.2: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tagged-tag@1.0.0: {}
 
@@ -4065,6 +6187,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.16:
@@ -4072,9 +6196,17 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tr46@0.0.3: {}
 
   tr46@1.0.1:
     dependencies:
@@ -4094,7 +6226,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(typescript@5.9.3):
+  tsup@8.5.0(postcss@8.5.10)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -4105,7 +6237,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.10)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.8.0-beta.0
@@ -4114,6 +6246,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -4135,6 +6268,19 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  uint8-varint@2.0.4:
+    dependencies:
+      uint8arraylist: 2.4.9
+      uint8arrays: 5.1.1
+
+  uint8arraylist@2.4.9:
+    dependencies:
+      uint8arrays: 5.1.1
+
+  uint8arrays@5.1.1:
+    dependencies:
+      multiformats: 13.4.2
+
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
@@ -4154,10 +6300,16 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
+  utf8-codec@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  varint@6.0.0: {}
 
   verifiablejs@1.2.0: {}
 
@@ -4178,7 +6330,93 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite-node@3.2.4(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.17):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@22.19.17)
+      vite-node: 3.2.4(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  weald@1.1.1:
+    dependencies:
+      ms: 3.0.0-canary.202508261828
+      supports-color: 10.2.2
+
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@4.0.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:
@@ -4191,6 +6429,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:
@@ -4231,6 +6474,8 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.20.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -6,6 +6,9 @@ export const deployCommand = new Command("deploy")
     .option("--contracts", "Include contract build & deploy")
     .option("--skip-frontend", "Skip frontend build & deploy")
     .option("--domain <name>", "App domain (overrides package.json)")
+    .option("--playground", "Publish to the playground registry")
+    .option("--env <env>", "Target environment: testnet or mainnet", "testnet")
+    .option("-y, --yes", "Skip interactive prompts")
     .action(async (opts) => {
         console.log("TODO: deploy", opts);
     });

--- a/src/commands/init/AccountSetup.format.test.ts
+++ b/src/commands/init/AccountSetup.format.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Covers the bigint-safe display formatters used by AccountSetup.
+ *
+ * The component itself is tested via manual QA + the render smoke path;
+ * these helpers are pure, so we test them in isolation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatPas, formatMb } from "./AccountSetup.js";
+
+describe("formatPas", () => {
+    it("formats zero as '0.00 PAS'", () => {
+        expect(formatPas(0n)).toBe("0.00 PAS");
+    });
+
+    it("formats whole PAS amounts with two decimals", () => {
+        expect(formatPas(10_000_000_000n)).toBe("1.00 PAS");
+        expect(formatPas(100_000_000_000n)).toBe("10.00 PAS");
+    });
+
+    it("formats fractional PAS amounts correctly", () => {
+        // 1.5 PAS = 15_000_000_000 planck
+        expect(formatPas(15_000_000_000n)).toBe("1.50 PAS");
+        // 0.01 PAS = 100_000_000 planck
+        expect(formatPas(100_000_000n)).toBe("0.01 PAS");
+    });
+
+    it("stays exact above 2^53 planck (no lossy Number(bigint))", () => {
+        // 9_007_199_254_740_993n is 2^53 + 1 — Number(that) loses precision.
+        // Divided by 10^10 planck/PAS → whole = 900_719n, remainder = 9_254_740_993.
+        // Two-decimal fraction = 9_254_740_993 / 10^8 = 92.
+        const huge = 9_007_199_254_740_993n;
+        expect(formatPas(huge)).toBe("900719.92 PAS");
+    });
+});
+
+describe("formatMb", () => {
+    it("renders integer MB", () => {
+        expect(formatMb(100_000_000n)).toBe("100 MB");
+        expect(formatMb(0n)).toBe("0 MB");
+    });
+
+    it("truncates toward zero for sub-MB values", () => {
+        expect(formatMb(999_999n)).toBe("0 MB");
+    });
+
+    it("handles values well above 2^53", () => {
+        const tenTb = 10_000_000_000_000n; // 10 TB in bytes
+        expect(formatMb(tenTb)).toBe("10000000 MB");
+    });
+});

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -1,0 +1,231 @@
+import { useState, useEffect } from "react";
+import { Box, Text } from "ink";
+import { Spinner, Done, Failed } from "../../utils/ui/index.js";
+import { getConnection } from "../../utils/connection.js";
+import { getSessionSigner, type SessionHandle } from "../../utils/auth.js";
+import { checkBalance, ensureFunded, FUND_AMOUNT } from "../../utils/account/funding.js";
+import { checkMapping, ensureMapped } from "../../utils/account/mapping.js";
+import {
+    checkAllowance,
+    ensureAllowance,
+    LOW_TX_THRESHOLD,
+} from "../../utils/account/allowance.js";
+
+type Status = "pending" | "active" | "ok" | "failed" | "skipped";
+
+const STEP_COUNT = 3;
+
+/** Planck per PAS (10 decimals). */
+const PLANCK_PER_PAS = 10_000_000_000n;
+
+interface StepState {
+    label: string;
+    status: Status;
+    detail?: string;
+    error?: string;
+}
+
+function StatusIcon({ status }: { status: Status }) {
+    switch (status) {
+        case "active":
+            return <Spinner />;
+        case "ok":
+            return <Done />;
+        case "failed":
+            return <Failed />;
+        case "skipped":
+            return <Text dimColor>-</Text>;
+        default:
+            return <Text dimColor>·</Text>;
+    }
+}
+
+/** Format planck as "X.YZ PAS" without going through lossy `Number(bigint)`. */
+export function formatPas(planck: bigint): string {
+    const whole = planck / PLANCK_PER_PAS;
+    // Two decimal places: compute planck fraction of PAS in hundredths.
+    const hundredths = (planck % PLANCK_PER_PAS) / (PLANCK_PER_PAS / 100n);
+    const frac = hundredths.toString().padStart(2, "0");
+    return `${whole.toString()}.${frac} PAS`;
+}
+
+/** Format a raw byte count as "N MB" using integer math (no precision loss). */
+export function formatMb(bytes: bigint): string {
+    const mb = bytes / 1_000_000n;
+    return `${mb.toString()} MB`;
+}
+
+export function AccountSetup({
+    address,
+    onDone,
+}: {
+    address: string;
+    onDone: (success: boolean) => void;
+}) {
+    const [steps, setSteps] = useState<StepState[]>([
+        { label: "Funding account", status: "pending" },
+        { label: "Mapping account (Revive)", status: "pending" },
+        { label: "Granting bulletin access", status: "pending" },
+    ]);
+
+    useEffect(() => {
+        let cancelled = false;
+        let session: SessionHandle | null = null;
+
+        const update = (idx: number, patch: Partial<StepState>) => {
+            if (cancelled) return;
+            setSteps((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+        };
+
+        const finish = (success: boolean) => {
+            if (cancelled) return;
+            onDone(success);
+        };
+
+        const describe = (err: unknown): string =>
+            err instanceof Error ? err.message : String(err);
+
+        (async () => {
+            let client: Awaited<ReturnType<typeof getConnection>>;
+            try {
+                client = await getConnection();
+            } catch (err) {
+                const msg = describe(err);
+                for (let i = 0; i < STEP_COUNT; i++) update(i, { status: "failed", error: msg });
+                finish(false);
+                return;
+            }
+            if (cancelled) return;
+
+            // Step 0: Fund from Alice
+            let funded = false;
+            update(0, { status: "active" });
+            try {
+                const before = await checkBalance(client, address);
+                if (cancelled) return;
+                if (before.sufficient) {
+                    update(0, {
+                        status: "ok",
+                        detail: `Balance: ${formatPas(before.free)}`,
+                    });
+                    funded = true;
+                } else {
+                    update(0, {
+                        status: "active",
+                        detail: `Balance: ${formatPas(before.free)} — funding...`,
+                    });
+                    await ensureFunded(client, address);
+                    if (cancelled) return;
+                    // Optimistic post-balance: avoids a second RPC call that
+                    // could read a stale best-block and display the old value.
+                    const expected = before.free + FUND_AMOUNT;
+                    update(0, {
+                        status: "ok",
+                        detail: `Balance: ${formatPas(expected)}`,
+                    });
+                    funded = true;
+                }
+            } catch (err) {
+                update(0, { status: "failed", error: describe(err) });
+            }
+
+            // Step 1: Revive mapping (requires funds, user signs via mobile wallet)
+            if (funded) {
+                update(1, { status: "active" });
+                try {
+                    const mapped = await checkMapping(client, address);
+                    if (cancelled) return;
+                    if (mapped) {
+                        update(1, { status: "ok", detail: "Already mapped" });
+                    } else {
+                        session = await getSessionSigner();
+                        if (cancelled) return;
+                        if (!session) {
+                            update(1, {
+                                status: "failed",
+                                error: "No session — run dot init to log in",
+                            });
+                        } else {
+                            update(1, {
+                                status: "active",
+                                detail: "Approve on your Polkadot mobile app...",
+                            });
+                            await ensureMapped(client, address, session.signer);
+                            if (cancelled) return;
+                            update(1, { status: "ok", detail: "Mapped" });
+                        }
+                    }
+                } catch (err) {
+                    update(1, { status: "failed", error: describe(err) });
+                }
+            } else {
+                update(1, { status: "skipped", error: "Skipped — account not funded" });
+            }
+
+            // Step 2: Bulletin allowance (Alice signs, independent of mapping)
+            update(2, { status: "active" });
+            try {
+                const before = await checkAllowance(client, address);
+                if (cancelled) return;
+                if (before.authorized && before.remainingTxs >= LOW_TX_THRESHOLD) {
+                    update(2, {
+                        status: "ok",
+                        detail: `${before.remainingTxs} txs, ${formatMb(before.remainingBytes)} remaining`,
+                    });
+                } else {
+                    update(2, {
+                        status: "active",
+                        detail: before.authorized
+                            ? `Low quota (${before.remainingTxs} txs) — authorizing...`
+                            : "Not authorized — authorizing...",
+                    });
+                    await ensureAllowance(client, address);
+                    if (cancelled) return;
+                    const after = await checkAllowance(client, address);
+                    if (cancelled) return;
+                    update(2, {
+                        status: "ok",
+                        detail: `${after.remainingTxs} txs, ${formatMb(after.remainingBytes)} remaining`,
+                    });
+                }
+            } catch (err) {
+                update(2, { status: "failed", error: describe(err) });
+            }
+
+            finish(funded);
+        })().finally(() => {
+            // Always release the session adapter once setup has finished (or bailed).
+            session?.destroy();
+        });
+
+        return () => {
+            cancelled = true;
+            // If the component unmounts mid-flight the IIFE's finally will
+            // also fire and clean up, but do it eagerly here too so we don't
+            // hang on an in-flight mobile sign request.
+            session?.destroy();
+        };
+    }, [address, onDone]);
+
+    return (
+        <Box flexDirection="column" paddingLeft={2}>
+            <Box marginBottom={1}>
+                <Text bold>Account setup</Text>
+            </Box>
+            {steps.map((step) => (
+                <Box key={step.label} flexDirection="column">
+                    <Box gap={1}>
+                        <StatusIcon status={step.status} />
+                        <Text>{step.label}</Text>
+                        {step.detail && <Text dimColor>{step.detail}</Text>}
+                    </Box>
+                    {step.error && (
+                        <Box paddingLeft={4}>
+                            <Text dimColor>{step.error}</Text>
+                        </Box>
+                    )}
+                </Box>
+            ))}
+        </Box>
+    );
+}

--- a/src/commands/init/InitScreen.tsx
+++ b/src/commands/init/InitScreen.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Box, Text } from "ink";
 import { DependencyList } from "./DependencyList.js";
 import { QrLogin } from "./QrLogin.js";
+import { AccountSetup } from "./AccountSetup.js";
+import { computeAllDone } from "./completion.js";
 import type { LoginHandle } from "../../utils/auth.js";
 
 export function InitScreen({
@@ -13,24 +15,43 @@ export function InitScreen({
     existingAddress: string | null;
     onDone: () => void;
 }) {
-    const needsAuth = login !== null;
+    const needsQr = login !== null;
+    const [loggedInAddress, setLoggedInAddress] = useState<string | null>(existingAddress);
+    const [authResolved, setAuthResolved] = useState(!needsQr);
     const [depsComplete, setDepsComplete] = useState(false);
-    const [authComplete, setAuthComplete] = useState(!needsAuth);
+    const [accountComplete, setAccountComplete] = useState(false);
+    const [accountOk, setAccountOk] = useState(true);
+
+    const allDone = computeAllDone({
+        needsQr,
+        authResolved,
+        loggedInAddress,
+        depsComplete,
+        accountComplete,
+    });
 
     const handleDepsDone = () => {
         setDepsComplete(true);
-        if (authComplete) onDone();
     };
 
-    const handleAuthDone = () => {
-        setAuthComplete(true);
-        if (depsComplete) onDone();
+    const handleAuthDone = (address: string | null) => {
+        if (address) setLoggedInAddress(address);
+        setAuthResolved(true);
     };
+
+    const handleAccountDone = (success: boolean) => {
+        setAccountOk(success);
+        setAccountComplete(true);
+    };
+
+    useEffect(() => {
+        if (allDone) onDone();
+    }, [allDone]);
 
     return (
         <Box flexDirection="column">
-            {needsAuth && <QrLogin login={login} onDone={handleAuthDone} />}
-            {existingAddress && (
+            {needsQr && <QrLogin login={login} onDone={handleAuthDone} />}
+            {!needsQr && existingAddress && (
                 <Box paddingLeft={2} gap={1} marginBottom={1}>
                     <Text color="green">✔</Text>
                     <Text bold>Logged in</Text>
@@ -38,10 +59,14 @@ export function InitScreen({
                 </Box>
             )}
             <DependencyList onDone={handleDepsDone} />
-            {depsComplete && authComplete && (
+            {loggedInAddress && depsComplete && (
+                <AccountSetup address={loggedInAddress} onDone={handleAccountDone} />
+            )}
+            {allDone && (
                 <Box paddingLeft={2} marginTop={1}>
                     <Text color="green">✔</Text>
                     <Text bold> Setup complete</Text>
+                    {!accountOk && <Text dimColor> (some account setup steps failed)</Text>}
                 </Box>
             )}
         </Box>

--- a/src/commands/init/completion.test.ts
+++ b/src/commands/init/completion.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the init-completion predicate.
+ *
+ * We import the real `computeAllDone` from `./completion.js` — exactly the
+ * function the component consumes — so any drift in the predicate is caught
+ * here instead of silently passing because the test has its own copy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeAllDone } from "./completion.js";
+
+describe("computeAllDone", () => {
+    it("does not complete while deps are still running", () => {
+        expect(
+            computeAllDone({
+                needsQr: false,
+                authResolved: true,
+                loggedInAddress: null,
+                depsComplete: false,
+                accountComplete: false,
+            }),
+        ).toBe(false);
+    });
+
+    it("completes after deps when --yes is passed (no auth)", () => {
+        expect(
+            computeAllDone({
+                needsQr: false,
+                authResolved: true,
+                loggedInAddress: null,
+                depsComplete: true,
+                accountComplete: false,
+            }),
+        ).toBe(true);
+    });
+
+    it("does NOT complete while QR login is in progress even if deps are done", () => {
+        expect(
+            computeAllDone({
+                needsQr: true,
+                authResolved: false,
+                loggedInAddress: null,
+                depsComplete: true,
+                accountComplete: false,
+            }),
+        ).toBe(false);
+    });
+
+    it("completes after QR login fails (authResolved but no address)", () => {
+        expect(
+            computeAllDone({
+                needsQr: true,
+                authResolved: true,
+                loggedInAddress: null,
+                depsComplete: true,
+                accountComplete: false,
+            }),
+        ).toBe(true);
+    });
+
+    it("does NOT complete after QR login succeeds until account setup finishes", () => {
+        expect(
+            computeAllDone({
+                needsQr: true,
+                authResolved: true,
+                loggedInAddress: "5Gxyz...",
+                depsComplete: true,
+                accountComplete: false,
+            }),
+        ).toBe(false);
+    });
+
+    it("completes after QR login + account setup both finish", () => {
+        expect(
+            computeAllDone({
+                needsQr: true,
+                authResolved: true,
+                loggedInAddress: "5Gxyz...",
+                depsComplete: true,
+                accountComplete: true,
+            }),
+        ).toBe(true);
+    });
+
+    it("completes with existing session after account setup finishes", () => {
+        expect(
+            computeAllDone({
+                needsQr: false,
+                authResolved: true,
+                loggedInAddress: "5Gxyz...",
+                depsComplete: true,
+                accountComplete: true,
+            }),
+        ).toBe(true);
+    });
+
+    it("does NOT complete with existing session until account setup finishes", () => {
+        expect(
+            computeAllDone({
+                needsQr: false,
+                authResolved: true,
+                loggedInAddress: "5Gxyz...",
+                depsComplete: true,
+                accountComplete: false,
+            }),
+        ).toBe(false);
+    });
+});

--- a/src/commands/init/completion.ts
+++ b/src/commands/init/completion.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure predicate over the three parallel init streams (deps / auth / account
+ * setup). Lives in its own file so tests can import it without dragging React
+ * + Ink into the test runner.
+ */
+export interface InitCompletionState {
+    needsQr: boolean;
+    authResolved: boolean;
+    loggedInAddress: string | null;
+    depsComplete: boolean;
+    accountComplete: boolean;
+}
+
+export function computeAllDone(state: InitCompletionState): boolean {
+    const needsAccountSetup = state.loggedInAddress !== null;
+    return (
+        state.depsComplete &&
+        state.authResolved &&
+        (needsAccountSetup ? state.accountComplete : true)
+    );
+}

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -14,13 +14,18 @@ export const initCommand = new Command("init")
         let existingAddress: string | null = null;
 
         if (!opts.yes) {
-            const result = await connect();
-            if (result.kind === "existing") {
-                existingAddress = result.address;
-            } else {
-                login = result.login;
-                console.log("  Scan with the Polkadot mobile app to log in:\n");
-                console.log(result.qrCode);
+            try {
+                const result = await connect();
+                if (result.kind === "existing") {
+                    existingAddress = result.address;
+                } else {
+                    login = result.login;
+                    console.log("  Scan with the Polkadot mobile app to log in:\n");
+                    console.log(result.qrCode);
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : "Login service unavailable";
+                console.log(`  Login skipped: ${msg}\n`);
             }
         }
 

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { atomicInstall, detectAsset, fetchLatestTag, resolveInstallDir } from "./update.js";
+
+describe("detectAsset", () => {
+    it("maps darwin+arm64 → dot-darwin-arm64", () => {
+        expect(detectAsset("darwin", "arm64")).toBe("dot-darwin-arm64");
+    });
+
+    it("maps darwin+x64 → dot-darwin-x64", () => {
+        expect(detectAsset("darwin", "x64")).toBe("dot-darwin-x64");
+    });
+
+    it("maps linux+arm64 → dot-linux-arm64", () => {
+        expect(detectAsset("linux", "arm64")).toBe("dot-linux-arm64");
+    });
+
+    it("maps linux+x64 → dot-linux-x64", () => {
+        expect(detectAsset("linux", "x64")).toBe("dot-linux-x64");
+    });
+
+    it("falls back to linux for unknown OS", () => {
+        expect(detectAsset("freebsd" as any, "x64")).toBe("dot-linux-x64");
+    });
+
+    it("falls back to x64 for unknown arch", () => {
+        expect(detectAsset("linux", "riscv64" as any)).toBe("dot-linux-x64");
+    });
+});
+
+describe("resolveInstallDir", () => {
+    it("resolves under HOME when HOME is set", () => {
+        expect(resolveInstallDir({ HOME: "/Users/alice" })).toBe("/Users/alice/.polkadot/bin");
+    });
+
+    it("throws when HOME is unset instead of silently resolving ~", () => {
+        expect(() => resolveInstallDir({})).toThrow(/HOME is not set/);
+    });
+
+    it("throws when HOME is the empty string", () => {
+        expect(() => resolveInstallDir({ HOME: "" })).toThrow(/HOME is not set/);
+    });
+});
+
+describe("fetchLatestTag", () => {
+    it("returns tag_name on a successful response", async () => {
+        const fakeFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ tag_name: "v1.2.3" }),
+        } as unknown as Response);
+
+        const tag = await fetchLatestTag(fakeFetch as unknown as typeof fetch);
+        expect(tag).toBe("v1.2.3");
+        expect(fakeFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/repos/paritytech/playground-cli/releases/latest"),
+            expect.objectContaining({
+                headers: expect.objectContaining({ Accept: expect.any(String) }),
+            }),
+        );
+    });
+
+    it("throws with the HTTP status on non-2xx responses", async () => {
+        const fakeFetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+        } as unknown as Response);
+
+        await expect(fetchLatestTag(fakeFetch as unknown as typeof fetch)).rejects.toThrow(/500/);
+    });
+
+    it("throws when the body has no tag_name", async () => {
+        const fakeFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({}),
+        } as unknown as Response);
+
+        await expect(fetchLatestTag(fakeFetch as unknown as typeof fetch)).rejects.toThrow(
+            /Could not determine latest release/,
+        );
+    });
+});
+
+describe("atomicInstall", () => {
+    const makeTmpDir = () => mkdtempSync(join(tmpdir(), "dot-update-test-"));
+
+    it("writes the file with executable permissions", () => {
+        const dir = makeTmpDir();
+        try {
+            const dest = join(dir, "dot");
+            atomicInstall(dest, Buffer.from("hello"));
+            expect(readFileSync(dest, "utf8")).toBe("hello");
+            // Mode should include owner executable (0o100 bit = executable by owner).
+            const mode = statSync(dest).mode & 0o777;
+            expect(mode & 0o111).toBeTruthy();
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("replaces an existing file atomically (no half-written state)", () => {
+        const dir = makeTmpDir();
+        try {
+            const dest = join(dir, "dot");
+            atomicInstall(dest, Buffer.from("v1"));
+            atomicInstall(dest, Buffer.from("v2"));
+            expect(readFileSync(dest, "utf8")).toBe("v2");
+            // Staging sibling must not be left behind.
+            expect(existsSync(`${dest}.new`)).toBe(false);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("cleans up the staging file on fallback", () => {
+        // We trigger the atomic path to fail by making openSync target a
+        // non-existent directory, which causes our try block to throw before
+        // writing — but the catch then writes directly (creating the parent
+        // synthetically would be tricky, so we instead verify no crash and
+        // no leftover when the parent exists).
+        const dir = makeTmpDir();
+        try {
+            const dest = join(dir, "dot");
+            // The function should succeed (normal path, atomic works).
+            atomicInstall(dest, Buffer.from("ok"));
+            expect(existsSync(`${dest}.new`)).toBe(false);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,166 @@
+import { Command } from "commander";
+import {
+    chmodSync,
+    closeSync,
+    fsyncSync,
+    openSync,
+    renameSync,
+    unlinkSync,
+    writeFileSync,
+    writeSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { arch, platform } from "node:os";
+import { resolve } from "node:path";
+import pkg from "../../package.json" with { type: "json" };
+
+const REPO = "paritytech/playground-cli";
+
+export function resolveInstallDir(env: NodeJS.ProcessEnv = process.env): string {
+    const home = env.HOME;
+    if (!home) {
+        throw new Error(
+            "HOME is not set — cannot determine install location. Run with HOME=<your home directory>.",
+        );
+    }
+    return resolve(home, ".polkadot", "bin");
+}
+
+type Os = "darwin" | "linux";
+type Cpu = "arm64" | "x64";
+
+export function detectAsset(os: Os = platform() as Os, cpu: Cpu = arch() as Cpu): string {
+    const normalisedOs: Os = os === "darwin" ? "darwin" : "linux";
+    const normalisedCpu: Cpu = cpu === "arm64" ? "arm64" : "x64";
+    return `dot-${normalisedOs}-${normalisedCpu}`;
+}
+
+export async function fetchLatestTag(fetchImpl: typeof fetch = fetch): Promise<string> {
+    const res = await fetchImpl(`https://api.github.com/repos/${REPO}/releases/latest`, {
+        headers: { Accept: "application/vnd.github.v3+json" },
+    });
+    if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+    const data = (await res.json()) as { tag_name?: string };
+    if (!data.tag_name) throw new Error("Could not determine latest release");
+    return data.tag_name;
+}
+
+async function downloadBinary(
+    tag: string,
+    asset: string,
+    fetchImpl: typeof fetch = fetch,
+): Promise<Buffer> {
+    const url = `https://github.com/${REPO}/releases/download/${tag}/${asset}`;
+    const res = await fetchImpl(url);
+    if (!res.ok) throw new Error(`Download failed: ${res.status} ${res.statusText}`);
+    return Buffer.from(await res.arrayBuffer());
+}
+
+/**
+ * Atomically install `bytes` to `dest`.
+ *
+ * Writes to a sibling `${dest}.new` file, fsyncs, then renames into place.
+ * This is safe to run even when `dest` is the currently executing binary —
+ * the running process keeps its open file descriptor on the old inode while
+ * new invocations see the new one. Falls back to direct write if the atomic
+ * path fails (e.g. different filesystems, read-only parent).
+ */
+export function atomicInstall(dest: string, bytes: Buffer, mode = 0o755): void {
+    const staging = `${dest}.new`;
+    try {
+        const fd = openSync(staging, "w", mode);
+        try {
+            writeSync(fd, bytes);
+            fsyncSync(fd);
+        } finally {
+            closeSync(fd);
+        }
+        chmodSync(staging, mode);
+        renameSync(staging, dest);
+    } catch (err) {
+        // Clean up a half-written staging file before falling through.
+        try {
+            unlinkSync(staging);
+        } catch {
+            // ignore — may not exist
+        }
+        // Fall back to direct overwrite (previous behaviour). Still better
+        // than leaving the user with no installed binary.
+        writeFileSync(dest, bytes);
+        chmodSync(dest, mode);
+        // Re-throw is not what we want here — the direct write succeeded.
+        // But propagate the original error detail in a warning.
+        console.warn(
+            `Atomic install failed, wrote directly: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+}
+
+export const updateCommand = new Command("update")
+    .description("Update dot to the latest version")
+    .action(async () => {
+        let installDir: string;
+        try {
+            installDir = resolveInstallDir();
+        } catch (err) {
+            console.error(err instanceof Error ? err.message : "Could not resolve install dir");
+            process.exit(1);
+        }
+
+        const current = `v${pkg.version}`;
+        process.stdout.write("Checking for updates... ");
+
+        let tag: string;
+        try {
+            tag = await fetchLatestTag();
+        } catch (err) {
+            console.log("failed");
+            console.error(
+                `Could not reach GitHub: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+
+        if (tag === current) {
+            console.log(`already on latest (${current})`);
+            return;
+        }
+
+        console.log(`${current} → ${tag}`);
+        process.stdout.write("Downloading... ");
+
+        const asset = detectAsset();
+        let binary: Buffer;
+        try {
+            binary = await downloadBinary(tag, asset);
+        } catch (err) {
+            console.log("failed");
+            console.error(err instanceof Error ? err.message : "Download failed");
+            process.exit(1);
+        }
+
+        const dest = resolve(installDir, "dot");
+        try {
+            atomicInstall(dest, binary);
+
+            if (platform() === "darwin") {
+                // Re-sign so Gatekeeper doesn't quarantine the fresh binary.
+                // Both calls are best-effort — an unsigned binary still runs.
+                try {
+                    execSync(`codesign --sign - --force "${dest}"`, { stdio: "ignore" });
+                } catch {}
+                try {
+                    execSync(`xattr -c "${dest}"`, { stdio: "ignore" });
+                } catch {}
+            }
+        } catch (err) {
+            console.log("failed");
+            console.error(
+                `Could not write to ${dest}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+
+        console.log("done");
+        console.log(`Updated dot to ${tag}`);
+    });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { initCommand } from "./commands/init/index.js";
 import { modCommand } from "./commands/mod.js";
 import { buildCommand } from "./commands/build.js";
 import { deployCommand } from "./commands/deploy.js";
+import { updateCommand } from "./commands/update.js";
 
 const program = new Command()
     .name("dot")
@@ -16,5 +17,6 @@ program.addCommand(initCommand);
 program.addCommand(modCommand);
 program.addCommand(buildCommand);
 program.addCommand(deployCommand);
+program.addCommand(updateCommand);
 
 program.parse();

--- a/src/utils/account/allowance.test.ts
+++ b/src/utils/account/allowance.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for bulletin allowance checks and Alice-based granting.
+ *
+ * Only `@polkadot-apps/tx` is mocked — we use the real `polkadot-api`
+ * `Enum(...)` so a mistake like `Enum("User", …)` instead of `Enum("Account", …)`
+ * fails the test rather than silently passing a placeholder through.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+const mockSubmitAndWatch = vi
+    .fn<(tx: unknown, signer: unknown) => Promise<unknown>>()
+    .mockResolvedValue({ ok: true });
+const mockCreateDevSigner = vi
+    .fn<(name: string) => unknown>()
+    .mockImplementation((name) => ({ __devSigner: name }));
+
+vi.mock("@polkadot-apps/tx", () => ({
+    submitAndWatch: (...args: unknown[]) => mockSubmitAndWatch(args[0], args[1] as unknown),
+    createDevSigner: (...args: unknown[]) => mockCreateDevSigner(args[0] as string),
+}));
+
+const { checkAllowance, ensureAllowance, BULLETIN_BYTES, BULLETIN_TRANSACTIONS, LOW_TX_THRESHOLD } =
+    await import("./allowance.js");
+
+function makeClient(authResult: unknown) {
+    const authorizeFactory = vi.fn().mockImplementation((args: unknown) => ({
+        __kind: "authorize_account",
+        args,
+    }));
+    return {
+        client: {
+            bulletin: {
+                query: {
+                    TransactionStorage: {
+                        Authorizations: {
+                            getValue: vi.fn().mockResolvedValue(authResult),
+                        },
+                    },
+                },
+                tx: {
+                    TransactionStorage: {
+                        authorize_account: authorizeFactory,
+                    },
+                },
+            },
+        } as any,
+        authorizeFactory,
+    };
+}
+
+describe("checkAllowance", () => {
+    it("returns unauthorized when no authorization exists", async () => {
+        const { client } = makeClient(undefined);
+        const result = await checkAllowance(client, "5GrwvaEF...");
+        expect(result.authorized).toBe(false);
+        expect(result.remainingTxs).toBe(0);
+        expect(result.remainingBytes).toBe(0n);
+    });
+
+    it("returns authorized with remaining quota", async () => {
+        const { client } = makeClient({
+            extent: { transactions: 500, bytes: 50_000_000n },
+            expiration: 999999,
+        });
+        const result = await checkAllowance(client, "5GrwvaEF...");
+        expect(result.authorized).toBe(true);
+        expect(result.remainingTxs).toBe(500);
+        expect(result.remainingBytes).toBe(50_000_000n);
+    });
+
+    it("returns authorized even with low remaining txs", async () => {
+        const { client } = makeClient({
+            extent: { transactions: 5, bytes: 1_000_000n },
+            expiration: 100,
+        });
+        const result = await checkAllowance(client, "5GrwvaEF...");
+        expect(result.authorized).toBe(true);
+        expect(result.remainingTxs).toBe(5);
+    });
+
+    it("wraps the address in Enum('Account', …) when querying Authorizations", async () => {
+        const { client } = makeClient(undefined);
+        await checkAllowance(client, "5GrwvaEFaddr");
+
+        const getValueFn = client.bulletin.query.TransactionStorage.Authorizations.getValue;
+        const firstArg = getValueFn.mock.calls[0][0];
+        expect(firstArg).toMatchObject({ type: "Account", value: "5GrwvaEFaddr" });
+    });
+});
+
+describe("ensureAllowance", () => {
+    it("skips granting when allowance is sufficient", async () => {
+        mockSubmitAndWatch.mockClear();
+        const { client } = makeClient({
+            extent: { transactions: 500, bytes: 50_000_000n },
+            expiration: 999999,
+        });
+        await ensureAllowance(client, "5GrwvaEF...");
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
+    it("grants allowance when not authorized", async () => {
+        mockSubmitAndWatch.mockClear();
+        mockCreateDevSigner.mockClear();
+        const { client, authorizeFactory } = makeClient(undefined);
+        await ensureAllowance(client, "5GrwvaEFaddr");
+
+        expect(mockCreateDevSigner).toHaveBeenCalledWith("Alice");
+        expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
+        expect(authorizeFactory).toHaveBeenCalledWith({
+            who: "5GrwvaEFaddr",
+            transactions: BULLETIN_TRANSACTIONS,
+            bytes: BULLETIN_BYTES,
+        });
+    });
+
+    it(`re-grants allowance when remaining txs are below LOW_TX_THRESHOLD (${LOW_TX_THRESHOLD})`, async () => {
+        mockSubmitAndWatch.mockClear();
+        const { client } = makeClient({
+            extent: { transactions: LOW_TX_THRESHOLD - 5, bytes: 1_000_000n },
+            expiration: 100,
+        });
+        await ensureAllowance(client, "5GrwvaEF...");
+        expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
+    });
+
+    it(`skips granting at exactly LOW_TX_THRESHOLD (${LOW_TX_THRESHOLD})`, async () => {
+        mockSubmitAndWatch.mockClear();
+        const { client } = makeClient({
+            extent: { transactions: LOW_TX_THRESHOLD, bytes: 10_000_000n },
+            expiration: 100,
+        });
+        await ensureAllowance(client, "5GrwvaEF...");
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/account/allowance.ts
+++ b/src/utils/account/allowance.ts
@@ -1,0 +1,62 @@
+/**
+ * Bulletin storage allowance — check and grant authorization.
+ *
+ * Testnet-only: Alice grants allowance. On mainnet this will
+ * be handled differently (e.g. user pays or is pre-authorized).
+ */
+
+import { Enum } from "polkadot-api";
+import { submitAndWatch, createDevSigner } from "@polkadot-apps/tx";
+import type { PaseoClient } from "../connection.js";
+
+const AT_BEST = { at: "best" as const };
+
+/** Number of transactions to authorize. */
+export const BULLETIN_TRANSACTIONS = 1000;
+
+/** Bytes to authorize (100 MB). */
+export const BULLETIN_BYTES = 100_000_000n;
+
+/** Re-authorize when remaining transactions drop below this. */
+export const LOW_TX_THRESHOLD = 10;
+
+export interface AllowanceStatus {
+    authorized: boolean;
+    remainingTxs: number;
+    remainingBytes: bigint;
+}
+
+export async function checkAllowance(
+    client: PaseoClient,
+    address: string,
+): Promise<AllowanceStatus> {
+    const raw = await client.bulletin.query.TransactionStorage.Authorizations.getValue(
+        Enum("Account", address),
+        AT_BEST,
+    );
+
+    if (!raw) {
+        return { authorized: false, remainingTxs: 0, remainingBytes: 0n };
+    }
+
+    return {
+        authorized: true,
+        remainingTxs: raw.extent.transactions,
+        remainingBytes: raw.extent.bytes,
+    };
+}
+
+export async function ensureAllowance(client: PaseoClient, address: string): Promise<void> {
+    const status = await checkAllowance(client, address);
+    if (status.authorized && status.remainingTxs >= LOW_TX_THRESHOLD) return;
+
+    const alice = createDevSigner("Alice");
+    await submitAndWatch(
+        client.bulletin.tx.TransactionStorage.authorize_account({
+            who: address,
+            transactions: BULLETIN_TRANSACTIONS,
+            bytes: BULLETIN_BYTES,
+        }),
+        alice,
+    );
+}

--- a/src/utils/account/funding.test.ts
+++ b/src/utils/account/funding.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for balance checks and Alice-based funding.
+ *
+ * We mock only `@polkadot-apps/tx` — the SDK boundary we don't want to
+ * exercise in unit tests. The real `polkadot-api` `Enum(...)` is used so the
+ * `transfer_keep_alive({ dest: Enum("Id", …) })` call fails loudly if anyone
+ * changes the variant name ("Id" → "Index", etc.) without updating tests.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+const mockSubmitAndWatch = vi
+    .fn<(tx: unknown, signer: unknown) => Promise<unknown>>()
+    .mockResolvedValue({ ok: true });
+const mockCreateDevSigner = vi
+    .fn<(name: string) => unknown>()
+    .mockImplementation((name) => ({ __devSigner: name }));
+
+vi.mock("@polkadot-apps/tx", () => ({
+    submitAndWatch: (...args: unknown[]) => mockSubmitAndWatch(args[0], args[1] as unknown),
+    createDevSigner: (...args: unknown[]) => mockCreateDevSigner(args[0] as string),
+}));
+
+const { checkBalance, ensureFunded, FUND_AMOUNT } = await import("./funding.js");
+
+function makeClient(free: bigint) {
+    const transferFactory = vi.fn().mockImplementation((args: unknown) => ({
+        __kind: "transfer_keep_alive",
+        args,
+    }));
+    return {
+        client: {
+            assetHub: {
+                query: {
+                    System: {
+                        Account: {
+                            getValue: vi.fn().mockResolvedValue({
+                                data: { free, reserved: 0n, frozen: 0n },
+                            }),
+                        },
+                    },
+                },
+                tx: {
+                    Balances: {
+                        transfer_keep_alive: transferFactory,
+                    },
+                },
+            },
+        } as any,
+        transferFactory,
+    };
+}
+
+describe("checkBalance", () => {
+    it("reports sufficient when balance >= 1 PAS", async () => {
+        const { client } = makeClient(10_000_000_000n);
+        const result = await checkBalance(
+            client,
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        );
+        expect(result.sufficient).toBe(true);
+        expect(result.free).toBe(10_000_000_000n);
+    });
+
+    it("reports insufficient when balance < 1 PAS", async () => {
+        const { client } = makeClient(5_000_000_000n);
+        const result = await checkBalance(
+            client,
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        );
+        expect(result.sufficient).toBe(false);
+    });
+
+    it("reports insufficient when balance is zero", async () => {
+        const { client } = makeClient(0n);
+        const result = await checkBalance(
+            client,
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        );
+        expect(result.sufficient).toBe(false);
+        expect(result.free).toBe(0n);
+    });
+});
+
+describe("ensureFunded", () => {
+    it("skips funding when balance is sufficient", async () => {
+        mockSubmitAndWatch.mockClear();
+        const { client } = makeClient(50_000_000_000n);
+        await ensureFunded(client, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
+    it("funds with FUND_AMOUNT, uses Alice, and wraps the dest in Enum('Id', …)", async () => {
+        mockSubmitAndWatch.mockClear();
+        mockCreateDevSigner.mockClear();
+        const { client, transferFactory } = makeClient(0n);
+        const address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+        await ensureFunded(client, address);
+
+        expect(mockCreateDevSigner).toHaveBeenCalledWith("Alice");
+        expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
+        expect(transferFactory).toHaveBeenCalledTimes(1);
+
+        const callArgs = transferFactory.mock.calls[0][0] as {
+            dest: { type: string; value: { type: string; value: unknown } };
+            value: bigint;
+        };
+        // We don't mock polkadot-api — Enum() actually builds the runtime
+        // tag. If the caller ever changes "Id" to "Index", this assertion
+        // breaks even though the variable name looks correct.
+        expect(callArgs.value).toBe(FUND_AMOUNT);
+        expect(callArgs.dest).toMatchObject({ type: "Id" });
+    });
+});

--- a/src/utils/account/funding.ts
+++ b/src/utils/account/funding.ts
@@ -1,0 +1,42 @@
+/**
+ * Account funding — check balance and fund from Alice on testnet.
+ *
+ * Testnet-only: will be replaced for mainnet where users fund themselves.
+ */
+
+import { Enum } from "polkadot-api";
+import { submitAndWatch, createDevSigner } from "@polkadot-apps/tx";
+import type { PaseoClient } from "../connection.js";
+
+const AT_BEST = { at: "best" as const };
+
+/** 1 PAS — below this we consider the account underfunded. */
+export const MIN_BALANCE = 10_000_000_000n;
+
+/** 10 PAS — amount Alice sends when funding. */
+export const FUND_AMOUNT = 100_000_000_000n;
+
+export interface BalanceStatus {
+    free: bigint;
+    sufficient: boolean;
+}
+
+export async function checkBalance(client: PaseoClient, address: string): Promise<BalanceStatus> {
+    const account = await client.assetHub.query.System.Account.getValue(address, AT_BEST);
+    const free = account.data.free;
+    return { free, sufficient: free >= MIN_BALANCE };
+}
+
+export async function ensureFunded(client: PaseoClient, address: string): Promise<void> {
+    const { sufficient } = await checkBalance(client, address);
+    if (sufficient) return;
+
+    const alice = createDevSigner("Alice");
+    await submitAndWatch(
+        client.assetHub.tx.Balances.transfer_keep_alive({
+            dest: Enum("Id", address),
+            value: FUND_AMOUNT,
+        }),
+        alice,
+    );
+}

--- a/src/utils/account/index.ts
+++ b/src/utils/account/index.ts
@@ -1,0 +1,16 @@
+export {
+    checkBalance,
+    ensureFunded,
+    FUND_AMOUNT,
+    MIN_BALANCE,
+    type BalanceStatus,
+} from "./funding.js";
+export { checkMapping, ensureMapped } from "./mapping.js";
+export {
+    checkAllowance,
+    ensureAllowance,
+    BULLETIN_BYTES,
+    BULLETIN_TRANSACTIONS,
+    LOW_TX_THRESHOLD,
+    type AllowanceStatus,
+} from "./allowance.js";

--- a/src/utils/account/mapping.test.ts
+++ b/src/utils/account/mapping.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the Revive-mapping wrapper.
+ *
+ * `mapping.ts` itself is thin (delegates to `createInkSdk` + `ensureAccountMapped`
+ * from `@polkadot-apps/tx`, both already tested upstream). The thing that
+ * matters for us is the wrapper's branching and argument plumbing:
+ *
+ *   - `checkMapping` reflects `addressIsMapped`
+ *   - `ensureMapped` always calls `ensureAccountMapped` (the upstream helper
+ *     is itself documented idempotent, so we don't short-circuit here)
+ *   - errors from either path propagate unchanged so the UI can surface them
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+const mockAddressIsMapped = vi.fn<() => Promise<boolean>>();
+const mockEnsureAccountMapped =
+    vi.fn<(address: string, signer: unknown, sdk: unknown, client: unknown) => Promise<unknown>>();
+const mockCreateInkSdk = vi.fn();
+
+vi.mock("@polkadot-api/sdk-ink", () => ({
+    createInkSdk: (...args: unknown[]) => mockCreateInkSdk(...args),
+}));
+
+vi.mock("@polkadot-apps/tx", () => ({
+    ensureAccountMapped: (...args: unknown[]) =>
+        mockEnsureAccountMapped(...(args as [string, unknown, unknown, unknown])),
+}));
+
+const { checkMapping, ensureMapped } = await import("./mapping.js");
+
+function makeClient() {
+    return {
+        raw: { assetHub: { __raw: true } },
+        assetHub: { __typed: true },
+    } as any; // PaseoClient shape, but we only need .raw.assetHub + .assetHub
+}
+
+function makeSigner() {
+    return { __signer: true } as any;
+}
+
+describe("checkMapping", () => {
+    it("returns true when the address is already mapped", async () => {
+        mockCreateInkSdk.mockReturnValue({ addressIsMapped: mockAddressIsMapped });
+        mockAddressIsMapped.mockResolvedValue(true);
+
+        const client = makeClient();
+        const result = await checkMapping(client, "5GrwvaEF...");
+
+        expect(result).toBe(true);
+        expect(mockCreateInkSdk).toHaveBeenCalledWith(client.raw.assetHub, { atBest: true });
+        expect(mockAddressIsMapped).toHaveBeenCalledWith("5GrwvaEF...");
+    });
+
+    it("returns false when not mapped", async () => {
+        mockCreateInkSdk.mockReturnValue({ addressIsMapped: mockAddressIsMapped });
+        mockAddressIsMapped.mockResolvedValue(false);
+
+        const result = await checkMapping(makeClient(), "5Fxxx...");
+        expect(result).toBe(false);
+    });
+
+    it("propagates RPC errors so the UI can show them", async () => {
+        mockCreateInkSdk.mockReturnValue({ addressIsMapped: mockAddressIsMapped });
+        mockAddressIsMapped.mockRejectedValue(new Error("connection reset"));
+
+        await expect(checkMapping(makeClient(), "5F...")).rejects.toThrow("connection reset");
+    });
+});
+
+describe("ensureMapped", () => {
+    it("forwards client, signer, and sdk into ensureAccountMapped", async () => {
+        mockCreateInkSdk.mockClear();
+        mockEnsureAccountMapped.mockClear();
+
+        const fakeSdk = { addressIsMapped: vi.fn().mockResolvedValue(false) };
+        mockCreateInkSdk.mockReturnValue(fakeSdk);
+        mockEnsureAccountMapped.mockResolvedValue(undefined);
+
+        const client = makeClient();
+        const signer = makeSigner();
+        await ensureMapped(client, "5FAlice...", signer);
+
+        expect(mockEnsureAccountMapped).toHaveBeenCalledTimes(1);
+        const callArgs = mockEnsureAccountMapped.mock.calls[0];
+        expect(callArgs[0]).toBe("5FAlice...");
+        expect(callArgs[1]).toBe(signer);
+        expect(callArgs[2]).toBe(fakeSdk);
+        expect(callArgs[3]).toBe(client.assetHub);
+    });
+
+    it("bubbles up signing errors (e.g. user rejected on phone)", async () => {
+        mockCreateInkSdk.mockReturnValue({ addressIsMapped: vi.fn() });
+        mockEnsureAccountMapped.mockRejectedValue(
+            new Error("Mobile signing rejected: user rejected"),
+        );
+
+        await expect(ensureMapped(makeClient(), "5F...", makeSigner())).rejects.toThrow(
+            /Mobile signing rejected/,
+        );
+    });
+});

--- a/src/utils/account/mapping.ts
+++ b/src/utils/account/mapping.ts
@@ -1,0 +1,25 @@
+/**
+ * Revive account mapping — check and map SS58 to H160.
+ *
+ * Required for any EVM contract interaction on Asset Hub.
+ * The user's own signer must sign map_account (not Alice).
+ */
+
+import { createInkSdk } from "@polkadot-api/sdk-ink";
+import { ensureAccountMapped } from "@polkadot-apps/tx";
+import type { PolkadotSigner } from "polkadot-api";
+import type { PaseoClient } from "../connection.js";
+
+export async function checkMapping(client: PaseoClient, address: string): Promise<boolean> {
+    const inkSdk = createInkSdk(client.raw.assetHub, { atBest: true });
+    return inkSdk.addressIsMapped(address);
+}
+
+export async function ensureMapped(
+    client: PaseoClient,
+    address: string,
+    signer: PolkadotSigner,
+): Promise<void> {
+    const inkSdk = createInkSdk(client.raw.assetHub, { atBest: true });
+    await ensureAccountMapped(address, signer, inkSdk, client.assetHub);
+}

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for auth.ts edge cases — specifically the subscribe-before-assignment bug.
+ *
+ * The real subscribe/pairing flow requires a live adapter, so these tests
+ * verify the patterns used rather than the full integration.
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("subscribe-before-assignment pattern", () => {
+    /**
+     * Simulates the bug where `const unsub = obs.subscribe(cb)` fires
+     * the callback synchronously, causing `unsub` to be referenced
+     * before it's assigned.
+     *
+     * The fix uses `let unsub; unsub = obs.subscribe(cb)` with `unsub?.()`.
+     */
+    it("handles synchronous callback firing during subscribe", () => {
+        let callbackFired = false;
+        let unsubCalled = false;
+
+        // Simulate an observable that fires synchronously
+        const syncObservable = {
+            subscribe(cb: (status: { step: string; payload?: string }) => void) {
+                // Fires immediately during subscribe()
+                cb({ step: "pairing", payload: "qr-data" });
+                return () => {
+                    unsubCalled = true;
+                };
+            },
+        };
+
+        // The FIXED pattern (let + optional chaining)
+        let done = false;
+        let unsub: (() => void) | undefined;
+        unsub = syncObservable.subscribe((status) => {
+            if (status.step === "pairing" && !done) {
+                done = true;
+                unsub?.(); // safe — unsub is undefined when called sync, but done=true prevents re-entry
+                callbackFired = true;
+            }
+        });
+
+        expect(callbackFired).toBe(true);
+        expect(done).toBe(true);
+        // unsub?.() was called when unsub was still undefined (sync), so unsubCalled is false
+        // but the callback still ran correctly
+    });
+
+    it("handles asynchronous callback firing after subscribe returns", () => {
+        let callbackFired = false;
+        let unsubCalled = false;
+
+        // Simulate an observable that fires asynchronously
+        let storedCb: ((status: { step: string; payload?: string }) => void) | null = null;
+        const asyncObservable = {
+            subscribe(cb: (status: { step: string; payload?: string }) => void) {
+                storedCb = cb;
+                return () => {
+                    unsubCalled = true;
+                };
+            },
+        };
+
+        let done = false;
+        let unsub: (() => void) | undefined;
+        unsub = asyncObservable.subscribe((status) => {
+            if (status.step === "pairing" && !done) {
+                done = true;
+                unsub?.();
+                callbackFired = true;
+            }
+        });
+
+        // Fire callback after subscribe has returned — unsub is assigned
+        storedCb!({ step: "pairing", payload: "qr-data" });
+
+        expect(callbackFired).toBe(true);
+        expect(unsubCalled).toBe(true); // unsub was assigned, so it was called
+    });
+
+    it("done flag prevents double-resolution", () => {
+        let resolutionCount = 0;
+
+        const observable = {
+            subscribe(cb: (status: { step: string }) => void) {
+                // Fires twice
+                cb({ step: "pairing" });
+                cb({ step: "pairing" });
+                return () => {};
+            },
+        };
+
+        let done = false;
+        let unsub: (() => void) | undefined;
+        unsub = observable.subscribe((status) => {
+            if (status.step === "pairing" && !done) {
+                done = true;
+                unsub?.();
+                resolutionCount++;
+            }
+        });
+
+        expect(resolutionCount).toBe(1);
+    });
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,9 +2,10 @@
  * QR login flow — pure business logic, no UI.
  *
  * Flow:
- *   1. `connect()` — starts adapter + auth, returns existing session OR QR code
+ *   1. `connect()` — starts adapter + auth, returns existing address OR QR code
  *   2. Print QR code to stdout (if needed) — before Ink mounts
  *   3. `waitForLogin()` — awaits the already-running auth to complete
+ *   4. `getSessionSigner()` — gets a working signer for tx signing (separate adapter)
  */
 
 import { ss58Encode } from "@polkadot-apps/address";
@@ -16,10 +17,23 @@ import {
     type PairingStatus,
     type AttestationStatus,
 } from "@polkadot-apps/terminal";
+import { createTxSigner } from "./signer.js";
+import type { PolkadotSigner } from "polkadot-api";
 
 const DEFAULT_METADATA_URL =
     "https://gist.githubusercontent.com/ReinhardHatko/1967dd3f4afe78683cc0ba14d6ec8744/raw/c1625eb7ed7671b7e09a3fa2a25998dde33c70b8/metadata.json";
 const DEFAULT_PEOPLE_ENDPOINTS = ["wss://paseo-people-next-rpc.polkadot.io"];
+
+/** How long we wait for the statement store to publish the pairing QR. */
+const QR_TIMEOUT_MS = 60_000;
+
+function createAdapter(): TerminalAdapter {
+    return createTerminalAdapter({
+        appId: "dot-cli",
+        metadataUrl: DEFAULT_METADATA_URL,
+        endpoints: DEFAULT_PEOPLE_ENDPOINTS,
+    });
+}
 
 export type ConnectResult =
     | { kind: "existing"; address: string }
@@ -40,16 +54,12 @@ export interface LoginHandle {
 
 /**
  * Connect to the statement store and resolve the login state.
- * Returns immediately if an existing session is found.
+ * Returns immediately if an existing session is found (address only).
  * Otherwise kicks off authenticate(), waits for the QR payload,
  * and returns the QR code + a handle to await the auth result.
  */
 export async function connect(): Promise<ConnectResult> {
-    const adapter = createTerminalAdapter({
-        appId: "dot-cli",
-        metadataUrl: DEFAULT_METADATA_URL,
-        endpoints: DEFAULT_PEOPLE_ENDPOINTS,
-    });
+    const adapter = createAdapter();
 
     const sessions = await waitForSessions(adapter);
     if (sessions.length > 0) {
@@ -61,26 +71,44 @@ export async function connect(): Promise<ConnectResult> {
     const authPromise = adapter.sso.authenticate();
 
     // Wait for the QR payload (with timeout)
-    const qrCode = await Promise.race([
-        new Promise<string>((resolve) => {
-            let done = false;
-            const unsub = adapter.sso.pairingStatus.subscribe(async (status: PairingStatus) => {
-                if (status.step === "pairing" && !done) {
-                    done = true;
-                    unsub();
-                    resolve(await renderQrCode(status.payload));
-                }
-            });
-        }),
-        new Promise<never>((_, reject) =>
-            setTimeout(
-                () => reject(new Error("Timed out waiting for login service — check your network")),
-                30_000,
+    try {
+        const qrCode = await Promise.race([
+            new Promise<string>((resolve) => {
+                let done = false;
+                let unsub: (() => void) | undefined;
+                unsub = adapter.sso.pairingStatus.subscribe(async (status: PairingStatus) => {
+                    if (status.step === "pairing" && !done) {
+                        done = true;
+                        unsub?.();
+                        resolve(await renderQrCode(status.payload));
+                    }
+                });
+            }),
+            new Promise<never>((_, reject) =>
+                setTimeout(
+                    () =>
+                        reject(
+                            new Error(
+                                `Login service did not respond within ${Math.round(
+                                    QR_TIMEOUT_MS / 1000,
+                                )}s — try again`,
+                            ),
+                        ),
+                    QR_TIMEOUT_MS,
+                ),
             ),
-        ),
-    ]);
+        ]);
 
-    return { kind: "qr", qrCode, login: { adapter, authPromise } };
+        return { kind: "qr", qrCode, login: { adapter, authPromise } };
+    } catch (err) {
+        // Release the WebSocket so we don't leak on the error path.
+        try {
+            adapter.destroy();
+        } catch {
+            // best-effort cleanup; ignore
+        }
+        throw err;
+    }
 }
 
 /**
@@ -112,29 +140,80 @@ export async function waitForLogin(
         },
     );
 
-    // Await the auth that was started in connect()
-    const result = await authPromise;
-    unsubPairing();
-    unsubAttestation();
-
     let address: string | null = null;
-    result.match(
-        (session) => {
-            if (session) {
-                const pubkey = new Uint8Array(session.remoteAccount.accountId);
-                address = ss58Encode(pubkey);
-                onStatus({ step: "success", address });
-            }
-        },
-        (error) => {
-            onStatus({ step: "error", message: error.message });
-        },
-    );
+    try {
+        const result = await authPromise;
+        result.match(
+            (session) => {
+                if (session) {
+                    const pubkey = new Uint8Array(session.remoteAccount.accountId);
+                    address = ss58Encode(pubkey);
+                    onStatus({ step: "success", address });
+                }
+            },
+            (error) => {
+                onStatus({ step: "error", message: error.message });
+            },
+        );
+    } finally {
+        // Always clear subscriptions, even if authPromise rejects.
+        unsubPairing();
+        unsubAttestation();
+    }
 
     if (address) {
         await waitForSessions(adapter, 3000);
     }
 
     return address;
-    // Skip adapter.destroy() — causes async DestroyedError noise.
+}
+
+/**
+ * A session signer bundle — the signer plus an explicit `destroy()` that
+ * tears down the long-lived adapter the signer depends on. Callers MUST
+ * invoke `destroy()` once they're done (typically inside a `useEffect`
+ * cleanup or `try/finally`) — the WebSocket keeps the event loop alive.
+ */
+export interface SessionHandle {
+    address: string;
+    signer: PolkadotSigner;
+    destroy(): void;
+}
+
+/**
+ * Get a working signer from a persisted session.
+ *
+ * The returned handle owns a terminal adapter that stays alive for as long
+ * as the signer is in use (signing goes through the adapter's WebSocket).
+ * Call `destroy()` on the handle when you're done — otherwise the event
+ * loop will not exit on its own and you'll have to `process.exit()`.
+ *
+ * Returns null if no session exists (user hasn't logged in).
+ */
+export async function getSessionSigner(): Promise<SessionHandle | null> {
+    const adapter = createAdapter();
+
+    const sessions = await waitForSessions(adapter, 3000);
+    if (sessions.length === 0) {
+        adapter.destroy();
+        return null;
+    }
+
+    const session = sessions[0];
+    const pubkey = new Uint8Array(session.remoteAccount.accountId);
+    const address = ss58Encode(pubkey);
+    const signer = createTxSigner(session);
+
+    let destroyed = false;
+    const destroy = () => {
+        if (destroyed) return;
+        destroyed = true;
+        try {
+            adapter.destroy();
+        } catch {
+            // best-effort; adapter.destroy() is idempotent in practice
+        }
+    };
+
+    return { address, signer, destroy };
 }

--- a/src/utils/connection.test.ts
+++ b/src/utils/connection.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetChainAPI = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock("@polkadot-apps/chain-client", () => ({
+    getChainAPI: (...args: any[]) => mockGetChainAPI(...args),
+}));
+
+// Re-import after each test to reset the singleton
+let getConnection: typeof import("./connection.js").getConnection;
+let destroyConnection: typeof import("./connection.js").destroyConnection;
+
+beforeEach(async () => {
+    vi.resetModules();
+    mockGetChainAPI.mockReset();
+    mockDestroy.mockReset();
+    const mod = await import("./connection.js");
+    getConnection = mod.getConnection;
+    destroyConnection = mod.destroyConnection;
+});
+
+describe("getConnection", () => {
+    it("calls getChainAPI with 'paseo'", async () => {
+        mockGetChainAPI.mockResolvedValue({ destroy: mockDestroy });
+        await getConnection();
+        expect(mockGetChainAPI).toHaveBeenCalledWith("paseo");
+    });
+
+    it("returns the same client on subsequent calls (singleton)", async () => {
+        const fakeClient = { destroy: mockDestroy };
+        mockGetChainAPI.mockResolvedValue(fakeClient);
+
+        const first = await getConnection();
+        const second = await getConnection();
+
+        expect(first).toBe(second);
+        expect(mockGetChainAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not race when called concurrently", async () => {
+        const fakeClient = { destroy: mockDestroy };
+        mockGetChainAPI.mockResolvedValue(fakeClient);
+
+        const [a, b] = await Promise.all([getConnection(), getConnection()]);
+
+        expect(a).toBe(b);
+        expect(mockGetChainAPI).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws a readable error on connection failure", async () => {
+        mockGetChainAPI.mockRejectedValue(new Error("WebSocket failed"));
+
+        await expect(getConnection()).rejects.toThrow("Could not connect to Paseo network");
+    });
+
+    it("preserves the underlying error detail in the message", async () => {
+        // Regression guard — historically the outer message only said "check
+        // your internet connection", which is misleading when the cause is a
+        // descriptor mismatch or a bad endpoint URL.
+        mockGetChainAPI.mockRejectedValue(new Error("ECONNREFUSED 127.0.0.1:9944"));
+
+        await expect(getConnection()).rejects.toThrow(/ECONNREFUSED 127\.0\.0\.1:9944/);
+    });
+
+    it("preserves the underlying error as Error.cause", async () => {
+        const underlying = new Error("descriptor mismatch");
+        mockGetChainAPI.mockRejectedValue(underlying);
+
+        try {
+            await getConnection();
+            expect.fail("expected throw");
+        } catch (err) {
+            expect((err as Error).cause).toBe(underlying);
+        }
+    });
+
+    it("allows retry after connection failure", async () => {
+        mockGetChainAPI.mockRejectedValueOnce(new Error("timeout"));
+        const fakeClient = { destroy: mockDestroy };
+        mockGetChainAPI.mockResolvedValueOnce(fakeClient);
+
+        await expect(getConnection()).rejects.toThrow();
+        const client = await getConnection();
+        expect(client).toBe(fakeClient);
+        expect(mockGetChainAPI).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("destroyConnection", () => {
+    it("calls destroy on the client", async () => {
+        const fakeClient = { destroy: mockDestroy };
+        mockGetChainAPI.mockResolvedValue(fakeClient);
+
+        await getConnection();
+        destroyConnection();
+
+        expect(mockDestroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows reconnection after destroy", async () => {
+        const client1 = { destroy: vi.fn() };
+        const client2 = { destroy: vi.fn() };
+        mockGetChainAPI.mockResolvedValueOnce(client1).mockResolvedValueOnce(client2);
+
+        const first = await getConnection();
+        destroyConnection();
+        const second = await getConnection();
+
+        expect(first).toBe(client1);
+        expect(second).toBe(client2);
+        expect(mockGetChainAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it("is safe to call when not connected", () => {
+        expect(() => destroyConnection()).not.toThrow();
+    });
+});

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -1,0 +1,48 @@
+import { getChainAPI } from "@polkadot-apps/chain-client";
+
+export type PaseoClient = Awaited<ReturnType<typeof getChainAPI<"paseo">>>;
+
+/** If getChainAPI doesn't resolve in this window we treat the attempt as dead. */
+const CONNECT_TIMEOUT_MS = 30_000;
+
+let connectionPromise: Promise<PaseoClient> | null = null;
+let client: PaseoClient | null = null;
+
+function timeoutAfter(ms: number): Promise<never> {
+    return new Promise((_, reject) =>
+        setTimeout(
+            () =>
+                reject(new Error(`Timed out connecting to Paseo after ${Math.round(ms / 1000)}s`)),
+            ms,
+        ),
+    );
+}
+
+export function getConnection(): Promise<PaseoClient> {
+    if (!connectionPromise) {
+        connectionPromise = Promise.race([
+            getChainAPI("paseo").then((c) => {
+                client = c;
+                return c;
+            }),
+            timeoutAfter(CONNECT_TIMEOUT_MS),
+        ]).catch((err: unknown) => {
+            // Reset so the next call can retry instead of replaying the error.
+            connectionPromise = null;
+            const detail = err instanceof Error ? err.message : String(err);
+            throw new Error(
+                `Could not connect to Paseo network — check your internet connection (${detail})`,
+                { cause: err instanceof Error ? err : undefined },
+            );
+        });
+    }
+    return connectionPromise;
+}
+
+export function destroyConnection(): void {
+    if (client) {
+        client.destroy();
+        client = null;
+    }
+    connectionPromise = null;
+}

--- a/src/utils/signer.test.ts
+++ b/src/utils/signer.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the host-papp SDK adapters + hex helpers in `signer.ts`.
+ *
+ * We avoid going through `getPolkadotSignerFromPjs` directly — that lives in
+ * `polkadot-api` and already has its own test suite. Instead we exercise the
+ * adapters (`adaptSignPayload`, `adaptSignRaw`) that sit between the polkadot
+ * .js SignerPayloadJSON contract and our `UserSession.signPayload/signRaw`
+ * ResultAsync contracts — that's where our bugs historically lived.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { SignerPayloadJSON } from "polkadot-api/pjs-signer";
+import { adaptSignPayload, adaptSignRaw, fromHex, toHex } from "./signer.js";
+
+// Duck-typed Result builders. Our session.signPayload returns neverthrow's
+// ResultAsync, but our adapter only touches `isErr()`, `.value`, `.error`.
+// Building the full ResultAsync in a test would drag neverthrow into the
+// deps tree for no added coverage, so we shape-match and cast at the call
+// site.
+function ok<T>(value: T) {
+    return {
+        isErr: () => false as const,
+        isOk: () => true as const,
+        value,
+        error: undefined as never,
+    };
+}
+
+function err(error: Error) {
+    return {
+        isErr: () => true as const,
+        isOk: () => false as const,
+        value: undefined as never,
+        error,
+    };
+}
+
+function basePayload(): SignerPayloadJSON {
+    return {
+        address: "0x01",
+        blockHash: "0xaa",
+        blockNumber: "0x00000001",
+        era: "0x00",
+        genesisHash: "0xbb",
+        method: "0xcc",
+        nonce: "0x00000000",
+        specVersion: "0x01",
+        tip: "0x00000000000000000000000000000000",
+        transactionVersion: "0x0f",
+        signedExtensions: ["CheckGenesis"],
+        version: 4,
+    };
+}
+
+/**
+ * Build an `adaptSignPayload` over a fake session whose `signPayload`
+ * returns the given Result. Records the last request the adapter made.
+ */
+function payloadAdapter(resultFactory: () => ReturnType<typeof ok> | ReturnType<typeof err>): {
+    run: (payload: SignerPayloadJSON) => Promise<unknown>;
+    seen(): Record<string, unknown> | undefined;
+} {
+    let seen: Record<string, unknown> | undefined;
+    const fakeSession = {
+        signPayload: async (req: Record<string, unknown>) => {
+            seen = req;
+            return resultFactory();
+        },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: duck-typed fake session
+    const adapter = adaptSignPayload(fakeSession as any);
+    return { run: adapter, seen: () => seen };
+}
+
+describe("toHex / fromHex", () => {
+    it("round-trips arbitrary byte sequences", () => {
+        const bytes = new Uint8Array([0, 1, 16, 255, 128]);
+        const hex = toHex(bytes);
+        expect(hex).toBe("0x000110ff80");
+        expect(Array.from(fromHex(hex))).toEqual(Array.from(bytes));
+    });
+
+    it("handles empty input in both directions", () => {
+        expect(toHex(new Uint8Array())).toBe("0x");
+        expect(fromHex("0x")).toEqual(new Uint8Array());
+        expect(fromHex("")).toEqual(new Uint8Array());
+    });
+
+    it("fromHex accepts both prefixed and unprefixed hex", () => {
+        // pjs-signer always gives us 0x-prefixed, but defensive decoding
+        // matters — Buffer.from('0xab', 'hex') silently returns <Buffer >.
+        expect(Array.from(fromHex("0xabcd"))).toEqual([0xab, 0xcd]);
+        expect(Array.from(fromHex("abcd"))).toEqual([0xab, 0xcd]);
+    });
+
+    it("toHex produces lowercase hex", () => {
+        const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+        expect(toHex(bytes)).toBe("0xdeadbeef");
+    });
+});
+
+describe("adaptSignPayload", () => {
+    it("returns hex-encoded signature + signedTransaction on success", async () => {
+        const { run } = payloadAdapter(() =>
+            ok({
+                signature: new Uint8Array([0x11, 0x22]),
+                signedTransaction: new Uint8Array([0x33, 0x44]),
+            }),
+        );
+        const result = (await run(basePayload())) as {
+            signature: string;
+            signedTransaction: string;
+        };
+        expect(result.signature).toBe("0x1122");
+        expect(result.signedTransaction).toBe("0x3344");
+    });
+
+    it("throws a readable error when the session returns Err", async () => {
+        const { run } = payloadAdapter(() => err(new Error("user rejected")));
+        await expect(run(basePayload())).rejects.toThrow(/Mobile signing rejected: user rejected/);
+    });
+
+    it("throws an upgrade-guidance error when signedTransaction is missing", async () => {
+        const { run } = payloadAdapter(() =>
+            ok({
+                signature: new Uint8Array([0x11, 0x22]),
+                signedTransaction: undefined,
+            }),
+        );
+        await expect(run(basePayload())).rejects.toThrow(/update your Polkadot mobile app/);
+    });
+
+    it("forwards optional fields as explicit undefined (not missing keys)", async () => {
+        // Why this matters: the mobile's scale-ts Option codec trips if the
+        // key is absent — it expects `assetId: undefined`, not omitted.
+        const { run, seen } = payloadAdapter(() =>
+            ok({
+                signature: new Uint8Array(),
+                signedTransaction: new Uint8Array(),
+            }),
+        );
+        await run(basePayload());
+        const req = seen();
+        expect(req).toBeDefined();
+        if (!req) throw new Error("unreachable");
+        expect("assetId" in req).toBe(true);
+        expect("metadataHash" in req).toBe(true);
+        expect("mode" in req).toBe(true);
+        expect(req.assetId).toBeUndefined();
+        expect(req.metadataHash).toBeUndefined();
+        expect(req.mode).toBeUndefined();
+    });
+
+    it("defaults withSignedTransaction to true when caller omits it", async () => {
+        const { run, seen } = payloadAdapter(() =>
+            ok({
+                signature: new Uint8Array(),
+                signedTransaction: new Uint8Array(),
+            }),
+        );
+        await run(basePayload());
+        expect(seen()?.withSignedTransaction).toBe(true);
+    });
+
+    it("passes through CheckMetadataHash fields when enabled", async () => {
+        // Regression guard for the historical bug where metadataHash was
+        // silently dropped — when `mode: 1`, the 0x… hash must reach the phone.
+        const { run, seen } = payloadAdapter(() =>
+            ok({
+                signature: new Uint8Array(),
+                signedTransaction: new Uint8Array(),
+            }),
+        );
+        const payload = {
+            ...basePayload(),
+            mode: 1,
+            metadataHash:
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as `0x${string}`,
+        };
+        await run(payload);
+        expect(seen()?.mode).toBe(1);
+        expect(seen()?.metadataHash).toBe(payload.metadataHash);
+    });
+});
+
+describe("adaptSignRaw", () => {
+    it("hex-decodes the data payload before handing it to signRaw", async () => {
+        let seen: Uint8Array | undefined;
+        const fakeSession = {
+            signRaw: async (req: {
+                address: string;
+                data: { tag: "Bytes"; value: Uint8Array };
+            }) => {
+                seen = req.data.value;
+                return ok({
+                    signature: new Uint8Array([0x99]),
+                    signedTransaction: undefined,
+                });
+            },
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: duck-typed fake session
+        const adapter = adaptSignRaw(fakeSession as any);
+        const result = await adapter({ address: "5F...", data: "0xdeadbeef", type: "bytes" });
+        expect(Array.from(seen ?? [])).toEqual([0xde, 0xad, 0xbe, 0xef]);
+        expect(result.signature).toBe("0x99");
+        expect(result.id).toBe(0);
+    });
+
+    it("throws readable error when session returns Err", async () => {
+        const fakeSession = {
+            signRaw: async () => err(new Error("session closed")),
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: duck-typed fake session
+        const adapter = adaptSignRaw(fakeSession as any);
+        await expect(adapter({ address: "5F...", data: "0x00", type: "bytes" })).rejects.toThrow(
+            /Mobile signing rejected: session closed/,
+        );
+    });
+});

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -1,0 +1,110 @@
+/**
+ * Custom PolkadotSigner that uses signPayload for transactions.
+ *
+ * The default createSessionSigner from @polkadot-apps/terminal uses signRaw
+ * for all signing. The mobile app wraps signRaw data with <Bytes>...</Bytes>
+ * (via MessageSigningContext.generalUntrustedMessage), which produces a
+ * signature over different data than what the chain expects → BadProof.
+ *
+ * This signer delegates to `getPolkadotSignerFromPjs`, which formats each
+ * signed extension exactly like polkadot.js SignerPayloadJSON. The mobile's
+ * SignPayloadJsonInteractor consumes that same shape, so the two sides stay
+ * in lockstep — no hand-rolled per-extension encoding on our end.
+ *
+ * Once @polkadot-apps/terminal is updated to default to signPayload, this
+ * file can be removed.
+ */
+
+import { getPolkadotSignerFromPjs, type SignerPayloadJSON } from "polkadot-api/pjs-signer";
+import type { PolkadotSigner } from "polkadot-api";
+import type { UserSession } from "@polkadot-apps/terminal";
+
+/** Format bytes as `0x`-prefixed lowercase hex. */
+export function toHex(bytes: Uint8Array): `0x${string}` {
+    return `0x${Buffer.from(bytes).toString("hex")}` as `0x${string}`;
+}
+
+/** Decode hex with or without `0x` prefix. Empty input → empty Uint8Array. */
+export function fromHex(hex: string): Uint8Array {
+    const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+    return new Uint8Array(Buffer.from(stripped, "hex"));
+}
+
+/**
+ * Signature-shape payload we hand to the host-papp SDK. Mirrors polkadot.js'
+ * `SignerPayloadJSON` but narrowed so every optional field is explicitly
+ * `undefined` — the scale-ts codec on the other side needs that, missing
+ * keys would blow up inside its Option encoder.
+ */
+export function adaptSignPayload(session: Pick<UserSession, "signPayload">): (
+    payload: SignerPayloadJSON,
+) => Promise<{
+    signature: `0x${string}`;
+    signedTransaction: `0x${string}`;
+}> {
+    return async (payload: SignerPayloadJSON) => {
+        const result = await session.signPayload({
+            address: payload.address,
+            blockHash: payload.blockHash as `0x${string}`,
+            blockNumber: payload.blockNumber as `0x${string}`,
+            era: payload.era as `0x${string}`,
+            genesisHash: payload.genesisHash as `0x${string}`,
+            method: payload.method as `0x${string}`,
+            nonce: payload.nonce as `0x${string}`,
+            specVersion: payload.specVersion as `0x${string}`,
+            tip: payload.tip as `0x${string}`,
+            transactionVersion: payload.transactionVersion as `0x${string}`,
+            signedExtensions: payload.signedExtensions,
+            version: payload.version,
+            assetId: payload.assetId as `0x${string}` | undefined,
+            metadataHash: payload.metadataHash as `0x${string}` | undefined,
+            mode: payload.mode,
+            withSignedTransaction: payload.withSignedTransaction ?? true,
+        });
+
+        if (result.isErr()) {
+            throw new Error(`Mobile signing rejected: ${result.error.message}`);
+        }
+
+        if (!result.value.signedTransaction) {
+            throw new Error(
+                "Mobile did not return a signed transaction — update your Polkadot mobile app",
+            );
+        }
+
+        return {
+            signature: toHex(result.value.signature),
+            signedTransaction: toHex(result.value.signedTransaction),
+        };
+    };
+}
+
+export function adaptSignRaw(session: Pick<UserSession, "signRaw">): (payload: {
+    address: string;
+    data: string;
+    type: "bytes";
+}) => Promise<{
+    id: number;
+    signature: `0x${string}`;
+}> {
+    return async (payload: { address: string; data: string; type: "bytes" }) => {
+        const bytes = fromHex(payload.data);
+        const result = await session.signRaw({
+            address: payload.address,
+            data: { tag: "Bytes" as const, value: bytes },
+        });
+
+        if (result.isErr()) {
+            throw new Error(`Mobile signing rejected: ${result.error.message}`);
+        }
+
+        return { id: 0, signature: toHex(result.value.signature) };
+    };
+}
+
+export function createTxSigner(session: UserSession): PolkadotSigner {
+    const accountId = new Uint8Array(session.remoteAccount.accountId);
+    const address = toHex(accountId);
+
+    return getPolkadotSignerFromPjs(address, adaptSignPayload(session), adaptSignRaw(session));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        include: ["src/**/*.test.ts"],
+    },
+});


### PR DESCRIPTION
## Summary

- **`dot init` account setup** — after QR login and toolchain install (which run concurrently), gates on both and runs a three-step setup on Paseo: fund from Alice (testnet), `Revive.map_account` signed by the user on the mobile app, and Alice-granted bulletin allowance (1000 txs / 100 MB).
- **`dot update`** — self-updates from GitHub releases. Writes to `dot.new`, `fsync`s, then renames atomically so the live binary is never half-written.
- **Session signer shim** (`src/utils/signer.ts`) — routes transactions through `signPayload` rather than `signRaw`. The default `signRaw` path triggers the mobile's `<Bytes>…</Bytes>` wrap, producing `BadProof` on-chain. Delegates to `polkadot-api/pjs-signer`'s `getPolkadotSignerFromPjs` so per-extension mapping stays authoritative (fixes a `CheckMetadataHash` encoding error that failed on-device).
- **Connection singleton** (`src/utils/connection.ts`) — lazy `getChainAPI("paseo")` with a 30 s timeout; underlying errors preserved via `Error.cause`.
- **Explicit session lifecycle** — `getSessionSigner()` returns a `destroy()` handle that callers MUST invoke. The host-papp adapter keeps the Node event loop alive; forgetting to release manifests as `dot <cmd>` hanging after visible work finishes.
- **`install.sh`** preserves the exit code of the auto-run `dot init` so CI cannot silently pass on a failed setup.
- **Test suite introduced** — vitest + 73 tests across 9 files. Intentionally does not mock `polkadot-api` primitives (`Enum`, encoders) so tautological coverage can't slip in.
- **Docs** — `README.md` covers commands + architecture; `CLAUDE.md` captures the non-obvious invariants (dep pinning, signer-shim rationale, destroy contract, extract-pure-logic-from-tsx pattern).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 73 tests across 9 files pass
- [x] `pnpm cli:install` produces a working binary
- [x] On-device verification: `dot init` completes end-to-end — QR login, dependency install, fund, map (user signs on mobile), and allowance all succeed. Previous `CheckMetadataHash` encoding error is resolved.
- [x] Reviewer: verify `dot update` on a machine with a previously installed `dot` in `~/.polkadot/bin/` (happy path + force-overwrite of the live binary).
- [x] Reviewer: confirm `dot init -y` still only runs toolchain install (no QR, no account setup).