### PR TITLE
chore: 0.3.0 changeset (account setup + dot update)

### DIFF
--- a/.changeset/account-setup-and-update.md
+++ b/.changeset/account-setup-and-update.md
@@ -1,0 +1,10 @@
+---
+"playground-cli": minor
+---
+
+- `dot init` now runs account setup after QR login + toolchain install: funds the account from Alice (testnet), signs `Revive.map_account` via the mobile wallet, and grants bulletin allowance.
+- New `dot update` command — self-updates from GitHub releases with atomic write-then-rename, safe to run over the live binary.
+- Session signer now routes transactions through `signPayload` to avoid the mobile's `<Bytes>` wrap that produced `BadProof` on-chain.
+- Connection singleton with a 30 s timeout and preserved `Error.cause` for debugging.
+- `install.sh` propagates the exit code of the auto-run `dot init`.
+- Introduced a vitest suite (73 tests across 9 files).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ These are things that aren't self-evident from reading the code and have bitten 
 
 ## Repo conventions
 
+- **Every user-facing PR must include a changeset.** Releases are automated via `.github/workflows/release.yml`, but the workflow is a no-op unless a `.changeset/*.md` file exists on merge. Create one with `pnpm changeset` (or write `.changeset/<slug>.md` by hand — frontmatter: `"playground-cli": patch|minor|major`, body: user-visible summary). Pure refactors / test-only changes can skip it.
 - Tests are `*.test.ts` next to the source. `vitest.config.ts` only picks up `.test.ts`; if you add `.tsx` tests update the config too.
 - Pure logic that lives inside a `.tsx` component should be lifted into a sibling `.ts` file (see `completion.ts` next to `InitScreen.tsx`, or the `formatPas`/`formatMb` exports in `AccountSetup.tsx`). Tests can then import it without dragging React + Ink into the vitest runner.
 - Do NOT add Claude attribution (`Co-Authored-By: Claude`, emoji signatures, etc.) to commits, PRs, or generated files.


### PR DESCRIPTION
## Summary

- Adds a `minor` changeset for the work that landed in #13 so `release.yml` can cut `v0.3.0` with binaries when this merges.
- Documents the invariant in `CLAUDE.md` — future PRs with user-visible changes must include a changeset, otherwise `release.yml` runs on merge but exits without doing anything (which is what happened with #13).

## Test plan

- [x] `pnpm format:check` clean
- [x] Reviewer: verify that on merge, `release.yml` bumps `playground-cli` to `0.3.0`, creates the `v0.3.0` tag with `dot-{linux,darwin}-{x64,arm64}` binaries attached, and commits `chore: version packages` back to `main`.