### PR TITLE
chore: bump bulletin-deploy 0.6.9 -> 0.6.16

### DIFF
--- a/.changeset/bump-bulletin-deploy-0-6-16.md
+++ b/.changeset/bump-bulletin-deploy-0-6-16.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": patch
+---
+
+Bump `bulletin-deploy` pin from 0.6.9 → 0.6.16.
+
+Picks up a fix for `merkleizeJS` (CIDs now preserve their codec so DAG-PB blocks are correctly indexed in the CAR body — the upstream bug our `jsMerkle` workaround was avoiding), on-chain verification after every DotNS `setContenthash`, clearer preflight messages on sanitized-to-Reserved labels, chain-time commit-age waits, and an idempotent pool `topUpBy`. No API changes required on our side.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@polkadot-apps/terminal": "latest",
         "@polkadot-apps/tx": "latest",
         "@polkadot-apps/utils": "latest",
-        "bulletin-deploy": "0.6.9",
+        "bulletin-deploy": "0.6.16",
         "commander": "^12.0.0",
         "ink": "^5.2.1",
         "polkadot-api": "^1.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: latest
         version: 0.4.0
       bulletin-deploy:
-        specifier: 0.6.9
-        version: 0.6.9(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
+        specifier: 0.6.16
+        version: 0.6.16(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       commander:
         specifier: ^12.0.0
         version: 12.1.0
@@ -1602,8 +1602,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  bulletin-deploy@0.6.9:
-    resolution: {integrity: sha512-LspXpFy4q7wnKr8X7+wO6nRzMK0lyVz/8rjZ6QcTAbf8xyJa8qW6bpdXw4g70IXJGUV0HBnDHpTmpQvnUOQVuw==}
+  bulletin-deploy@0.6.16:
+    resolution: {integrity: sha512-Kc576rv1uAG7V+/7d/3ZMz/V9cZwd0lS28FbC0oU/ecV4rlhMe8D/MPTLKBBhmPqiw4SgtA9OmKpGH5goMrybQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4538,7 +4538,7 @@ snapshots:
 
   '@polkadot-labs/hdkd@0.0.26':
     dependencies:
-      '@polkadot-labs/hdkd-helpers': 0.0.27
+      '@polkadot-labs/hdkd-helpers': 0.0.28
 
   '@polkadot/keyring@13.5.9(@polkadot/util-crypto@13.5.9(@polkadot/util@13.5.9))(@polkadot/util@13.5.9)':
     dependencies:
@@ -5013,7 +5013,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bulletin-deploy@0.6.9(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3):
+  bulletin-deploy@0.6.16(@polkadot-api/ink-contracts@0.6.1)(@polkadot/util@13.5.9)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3):
     dependencies:
       '@dotdm/cdm': 0.5.4(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       '@ipld/car': 5.4.3
@@ -5025,7 +5025,6 @@ snapshots:
       '@polkadot/keyring': 13.5.9(@polkadot/util-crypto@13.5.9(@polkadot/util@13.5.9))(@polkadot/util@13.5.9)
       '@polkadot/util-crypto': 13.5.9(@polkadot/util@13.5.9)
       '@sentry/node': 9.47.1
-      blockstore-core: 6.1.3
       ipfs-unixfs: 11.2.5
       ipfs-unixfs-importer: 16.1.5
       multiformats: 13.4.2


### PR DESCRIPTION
## Summary

Bump the `bulletin-deploy` pin from `0.6.9` → `0.6.16`. Every API we consume (`deploy`, `DeployContent`, `DeployOptions`, `DeployResult`, `DotNS`) still exports with compatible shapes — no source changes required.

Notable upstream changes picked up:

- **PR #126 (0.6.13) — `merkleizeJS` now produces complete DAG-PB CARs.** Replaces the `MemoryBlockstore` with a `CidPreservingBlockstore` so the CAR body indexes DAG-PB structural blocks under their real codec (not rebuilt as raw). This is the upstream fix the `jsMerkle: true` workaround in `CLAUDE.md` was waiting on. **Not flipped on in this PR** — that's a separate decision with its own testing.
- **PR #130 (0.6.14):** DotNS verifies on-chain after every `setContenthash` write.
- **PR #128 (0.6.14):** actionable preflight messages when a label sanitizes into Reserved.
- **PR #98 (0.6.11):** commit-reveal waits on chain time, not wall-clock — fewer spurious failures on flaky Paseo blocks.
- **PR #96 (0.6.11):** idempotent pool `topUpBy` + DotNS commit-reveal verification.
- **PR #144 (0.6.16):** bulletin-deploy drops the legacy `--playground` publish path. We never used it — `registry.publish()` stays on our side so `env::caller()` is the user, per `CLAUDE.md`.

New opt-in `DeployOptions` fields (`derivationPath`, `tag`, `ghPagesMirror`) are not consumed by us.

## Test plan

- [x] `pnpm install` succeeds; lockfile regenerated cleanly.
- [x] `pnpm test` → 21 files / 189 tests pass.
- [ ] Smoke-test a real `dot deploy` against Paseo in a follow-up before release cut.