### PR TITLE
fix(deploy): correct re-deploy preflight ownership reference in dev mode

### DIFF
--- a/.changeset/fix-redeploy-owner-mismatch.md
+++ b/.changeset/fix-redeploy-owner-mismatch.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": patch
+---
+
+Fix `dot deploy` reporting "already registered" on re-deploys made in dev mode when a phone session was also present.
+
+The domain-availability preflight was passing the logged-in user's SS58 address as the reference owner for the on-chain ownership check regardless of signer mode. In dev mode bulletin-deploy signs DotNS with its built-in `DEFAULT_MNEMONIC`, so the domain is owned by the dev account — not the user — and the preflight incorrectly reported the re-deploy as taken by a different account. We now only pass the user's address when `--signer phone` (where bulletin-deploy actually uses the user's signer). In dev mode we skip the ownership check and let bulletin-deploy's own preflight classify the re-deploy with the right signer.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -203,7 +203,12 @@ export function DeployScreen({
             {stage.kind === "validate-domain" && (
                 <ValidateDomainStage
                     domain={stage.domain}
-                    ownerSs58Address={userSigner?.address}
+                    // Only gate on the user's address in phone mode — see
+                    // `ownerSs58Address` docs in availability.ts. In dev mode
+                    // bulletin-deploy signs DotNS with its own DEFAULT_MNEMONIC,
+                    // so the user's H160 does not match the registrar's H160
+                    // and the preflight would mis-report re-deploys as "taken".
+                    ownerSs58Address={mode === "phone" ? userSigner?.address : undefined}
                     onAvailable={(result) => {
                         setDomain(result.fullDomain);
                         setPlan(result.plan);

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -227,10 +227,19 @@ async function runHeadless(ctx: {
 
     // Check availability BEFORE we build + upload, so CI fails fast on a
     // Reserved / already-taken name without wasting a chunk upload.
+    //
+    // `ownerSs58Address` MUST match whoever will actually sign the DotNS
+    // `register()` extrinsic — otherwise the preflight reports "taken" on a
+    // re-deploy. In phone mode bulletin-deploy uses the user's signer, so
+    // passing the user's address is correct. In dev mode bulletin-deploy
+    // falls back to its built-in DEFAULT_MNEMONIC, so the user's H160 does
+    // NOT match the on-chain owner — we omit the address and let
+    // bulletin-deploy's own preflight (run with the right signer during
+    // `deploy()`) do the comparison.
     process.stdout.write(`\nChecking availability of ${domain.replace(/\.dot$/, "") + ".dot"}…\n`);
     const availability = await checkDomainAvailability(domain, {
         env: ctx.env,
-        ownerSs58Address: ctx.userSigner?.address,
+        ownerSs58Address: mode === "phone" ? ctx.userSigner?.address : undefined,
     });
     if (availability.status !== "available") {
         throw new Error(formatAvailability(availability));

--- a/src/utils/deploy/availability.ts
+++ b/src/utils/deploy/availability.ts
@@ -90,11 +90,23 @@ export interface CheckAvailabilityOptions {
     /** Optional timeout in ms. Each RPC call has its own internal timeout. */
     timeoutMs?: number;
     /**
-     * The deploying account's SS58 address. When provided we derive its H160
-     * via `ss58ToH160` and treat "owned by you" as an update path rather than
-     * a `taken` block. Omit in dev-mode-without-signer and we skip the
-     * ownership check entirely (bulletin-deploy's own preflight is the
-     * ultimate source of truth when the real signer is used).
+     * SS58 address of the account that will SIGN the DotNS `register()` /
+     * `setContenthash` extrinsics — NOT necessarily the currently logged-in
+     * user. When provided we derive its H160 via `ss58ToH160` and treat
+     * "owned by you" as an update path rather than a `taken` block.
+     *
+     * Must match whoever bulletin-deploy will use as its DotNS signer:
+     *   - Phone mode → user's signer address.
+     *   - Dev mode   → omit entirely (bulletin-deploy falls back to its
+     *     built-in `DEFAULT_MNEMONIC`, and we have no easy way to derive
+     *     that H160 without replicating bulletin-deploy internals). When
+     *     omitted we skip the preflight ownership check; bulletin-deploy's
+     *     own preflight during `deploy()` is run with the right signer and
+     *     classifies the re-deploy correctly.
+     *
+     * Passing the wrong address (e.g. the phone session's H160 in dev mode)
+     * mis-reports re-deploys as `taken` because the on-chain owner is the
+     * dev account, not the user.
      */
     ownerSs58Address?: string;
 }


### PR DESCRIPTION
## Summary

- In dev mode bulletin-deploy signs the DotNS `register()` extrinsic with its built-in `DEFAULT_MNEMONIC`, so previously-deployed domains are owned by the dev account's H160 (`0x35Cdb…`) — not the user.
- The availability preflight was passing `userSigner?.address` as the ownership reference regardless of signer mode. When a user had both a `dot init` phone session AND was deploying via `--signer dev`, their phone H160 ≠ dev H160, so the preflight reported the re-deploy as `taken by <dev H160>` and blocked the deploy.
- Fix: only pass `ownerSs58Address` when `mode === "phone"`. In dev mode we skip the preflight ownership check; bulletin-deploy's own preflight (run with the right signer during `deploy()`) handles the re-deploy/update path correctly.

Note: the casing mismatch visible in the error line was unrelated — bulletin-deploy already does `owner.toLowerCase() === checkAddress.toLowerCase()` in `checkOwnership`. The `H160 Address:` line logged at the top of the screenshot is from bulletin-deploy's own `dotns.connect()` falling back to `DEFAULT_MNEMONIC` (since the preflight doesn't pass a signer), which is why it matches the "registered by" address.

## Test plan

- [x] `pnpm vitest run src/utils/deploy/availability.test.ts` — existing 13 tests pass (the "skips the ownership check when no SS58 address is provided" case is the contract we now rely on in dev mode).
- [x] `pnpm tsc --noEmit` clean.
- [x] Manual: with a `dot init` phone session active, run `dot deploy` twice against the same name using `--signer dev` — second run should proceed rather than report "already registered".
- [x] Manual: with a phone session, `dot deploy --signer phone` twice — second run still shows "Already owned by you — will update the existing deployment." (unchanged behaviour).