### PR TITLE
feat(init): fall back to dedicated funder when Alice is drained

### DIFF
--- a/.changeset/dedicated-funder-fallback.md
+++ b/.changeset/dedicated-funder-fallback.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`dot init` now falls back to a dedicated testnet funder account if Alice is drained on Paseo Asset Hub — so new users aren't blocked the moment someone drains Alice. If both funders are low, the UI points users at `https://faucet.polkadot.io/` prefilled with their own address so they can self-fund and move on. `dot deploy --signer dev` gets the same fallback and, on exhaustion, guides the user to switch to the mobile signer instead. Adds a scheduled GitHub Actions workflow that files an issue when the dedicated funder needs topping up.

--- a/.github/workflows/funder-balance-check.yml
+++ b/.github/workflows/funder-balance-check.yml
@@ -1,0 +1,90 @@
+name: Funder Balance Check
+
+# Scheduled probe for the dedicated PAS funder on Paseo Asset Hub. When the
+# balance falls below the threshold, the workflow opens (or comments on)
+# a GitHub issue labelled `funder-low-balance` so someone can top it up from
+# https://faucet.polkadot.io/. Idempotent — never files a second open issue.
+
+on:
+    schedule:
+        - cron: "*/30 * * * *"
+    workflow_dispatch:
+
+permissions:
+    issues: write
+    contents: read
+
+jobs:
+    check:
+        name: Check dedicated funder balance
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - run: pnpm install --frozen-lockfile
+
+            - id: check
+              name: Probe balance
+              # `continue-on-error` so the follow-up step can react to low /
+              # error exits instead of the job being marked failed and skipping.
+              continue-on-error: true
+              run: |
+                  bun run scripts/check-funder-balance.ts | tee balance.txt
+                  echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+            - name: File or update issue when low
+              if: steps.check.outputs.exitcode != '0'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  ADDRESS=$(grep '^address=' balance.txt | cut -d= -f2- || echo "unknown")
+                  BALANCE=$(grep '^balance=' balance.txt | cut -d= -f2- || echo "unknown")
+                  THRESHOLD=$(grep '^threshold=' balance.txt | cut -d= -f2- || echo "5000.00 PAS")
+                  FAUCET="https://faucet.polkadot.io/?network=pah&address=${ADDRESS}"
+                  NOW=$(date -u +%FT%TZ)
+
+                  # `.[0].number // empty` turns an empty result into no
+                  # output. Plain `.[0].number` returns the string "null",
+                  # which slips past `[ -z "$EXISTING" ]` and causes
+                  # `gh issue comment null` to error the first time the
+                  # balance goes low.
+                  EXISTING=$(gh issue list \
+                      --state open \
+                      --label funder-low-balance \
+                      --json number \
+                      --jq '.[0].number // empty' || true)
+
+                  if [ -z "$EXISTING" ]; then
+                      gh issue create \
+                          --title "[URGENT] Dedicated funder balance low — top up required" \
+                          --label funder-low-balance \
+                          --body "$(cat <<EOF
+                  The dedicated Paseo Asset Hub funder account is below the low-balance threshold. Without a top-up, \`dot init\` will start failing for new users once Alice drains.
+
+                  | Field | Value |
+                  | --- | --- |
+                  | Address | \`$ADDRESS\` |
+                  | Current balance | \`$BALANCE\` |
+                  | Threshold | \`$THRESHOLD\` |
+                  | Detected at | \`$NOW\` |
+
+                  **Top up:** [$FAUCET]($FAUCET)
+
+                  Close this issue manually after funding. This workflow will comment on the open issue (rather than opening a new one) while the balance stays low.
+                  EOF
+                  )"
+                  else
+                      gh issue comment "$EXISTING" --body "Still low at \`$NOW\` — current balance \`$BALANCE\` (threshold \`$THRESHOLD\`). Top up at [the faucet]($FAUCET)."
+                  fi

--- a/scripts/check-funder-balance.ts
+++ b/scripts/check-funder-balance.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+/**
+ * CI probe for the dedicated funder's PAS balance on Paseo Asset Hub.
+ *
+ * Exit codes:
+ *   0  balance >= threshold
+ *   1  balance < threshold (→ workflow files / comments on a GitHub issue)
+ *   2  unexpected error (RPC down, etc.) — treated like "low" by the workflow
+ *
+ * Output is key=value lines so the calling shell can grep + cut without a
+ * JSON parser.
+ */
+
+import { getConnection, destroyConnection } from "../src/utils/connection.js";
+import { DEDICATED_FUNDER_ADDRESS } from "../src/utils/account/funder.js";
+
+const PLANCK_PER_PAS = 10_000_000_000n;
+const THRESHOLD_PAS = 5000n;
+const THRESHOLD_PLANCK = THRESHOLD_PAS * PLANCK_PER_PAS;
+
+function formatPas(planck: bigint): string {
+    const whole = planck / PLANCK_PER_PAS;
+    const hundredths = (planck % PLANCK_PER_PAS) / (PLANCK_PER_PAS / 100n);
+    return `${whole}.${hundredths.toString().padStart(2, "0")} PAS`;
+}
+
+async function main(): Promise<number> {
+    const client = await getConnection();
+    try {
+        const account = await client.assetHub.query.System.Account.getValue(
+            DEDICATED_FUNDER_ADDRESS,
+            { at: "best" },
+        );
+        const free = account.data.free;
+        console.log(`address=${DEDICATED_FUNDER_ADDRESS}`);
+        console.log(`balance=${formatPas(free)}`);
+        console.log(`balance_planck=${free}`);
+        console.log(`threshold=${formatPas(THRESHOLD_PLANCK)}`);
+        if (free < THRESHOLD_PLANCK) {
+            console.log("status=low");
+            return 1;
+        }
+        console.log("status=ok");
+        return 0;
+    } finally {
+        // Releases the WebSocket so the process can exit cleanly.
+        destroyConnection();
+    }
+}
+
+main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(2);
+    });

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -3,6 +3,8 @@ import { Row, Section, type MarkKind } from "../../utils/ui/theme/index.js";
 import { getConnection } from "../../utils/connection.js";
 import { getSessionSigner, type SessionHandle } from "../../utils/auth.js";
 import { checkBalance, ensureFunded, FUND_AMOUNT } from "../../utils/account/funding.js";
+import { AllFundersExhaustedError } from "../../utils/account/errors.js";
+import { faucetUrlFor } from "../../utils/account/funder.js";
 import { checkMapping, ensureMapped } from "../../utils/account/mapping.js";
 import {
     checkAllowance,
@@ -126,7 +128,11 @@ export function AccountSetup({
                     funded = true;
                 }
             } catch (err) {
-                update(0, { status: "failed", error: describe(err), valueTone: "danger" });
+                const error =
+                    err instanceof AllFundersExhaustedError
+                        ? `Unable to auto fund your account, please use the faucet at: ${faucetUrlFor(address)}`
+                        : describe(err);
+                update(0, { status: "failed", error, valueTone: "danger" });
             }
 
             // Step 1: Revive mapping (requires funds, user signs via mobile wallet)

--- a/src/utils/account/errors.ts
+++ b/src/utils/account/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Typed errors raised by the account-setup subsystem so callers (TUI, deploy
+ * orchestrator) can render specific guidance instead of a raw message.
+ */
+
+/**
+ * Thrown when every funder in `FUNDER_CHAIN` is below the threshold needed to
+ * cover the requested transfer. Carries enough context for the caller to build
+ * a faucet URL and a meaningful error message without importing the chain.
+ */
+export class AllFundersExhaustedError extends Error {
+    constructor(
+        public readonly userAddress: string,
+        public readonly tried: readonly string[],
+    ) {
+        super(`All funders exhausted (tried: ${tried.join(", ")})`);
+        this.name = "AllFundersExhaustedError";
+    }
+}

--- a/src/utils/account/funder.ts
+++ b/src/utils/account/funder.ts
@@ -1,0 +1,62 @@
+/**
+ * Testnet funder accounts used to top up users and session keys on Paseo
+ * Asset Hub. We try Alice first (public dev account — free tokens while she
+ * lasts) and fall back to a dedicated account whose seed is embedded here
+ * (obscure, not one of the well-known dev dropdowns in polkadot.js Apps, so
+ * random drainers don't target it the way they target Alice).
+ *
+ * Goes away on mainnet: users fund themselves and this module is retired.
+ */
+
+import type { PolkadotSigner } from "polkadot-api";
+import { createDevSigner, getDevPublicKey } from "@polkadot-apps/tx";
+import { seedToAccount } from "@polkadot-apps/keys";
+import { ss58Encode } from "@polkadot-apps/address";
+
+/**
+ * Dedicated testnet funder mnemonic. Obscure-by-convention (not in any
+ * public dropdown), not a security boundary — anyone with this CLI binary
+ * can extract it. Acceptable on testnet; replace for mainnet.
+ */
+const DEDICATED_FUNDER_MNEMONIC =
+    "bargain obey warm sing goose glimpse kind repeat grape orchard reason rely";
+
+const dedicated = seedToAccount(DEDICATED_FUNDER_MNEMONIC, "//0");
+
+export interface Funder {
+    /** Log-friendly name — included in `AllFundersExhaustedError.tried`. */
+    name: string;
+    /** SS58 address used to query the funder's current balance. */
+    address: string;
+    /** Signer used when this funder is selected for a transfer. */
+    signer: PolkadotSigner;
+}
+
+/**
+ * Ordered chain of funders. Callers walk this list and pick the first funder
+ * whose free balance ≥ required amount. Public Alice comes first so the
+ * dedicated account only gets drawn down once she's drained.
+ */
+export const FUNDER_CHAIN: readonly Funder[] = [
+    {
+        name: "Alice",
+        address: ss58Encode(getDevPublicKey("Alice")),
+        signer: createDevSigner("Alice"),
+    },
+    {
+        name: "dedicated",
+        address: ss58Encode(dedicated.publicKey),
+        signer: dedicated.signer,
+    },
+];
+
+/** Convenience: public address of the dedicated funder. Used by the balance-check CI job. */
+export const DEDICATED_FUNDER_ADDRESS = FUNDER_CHAIN[1].address;
+
+/** Base Paseo Asset Hub faucet URL — shown when every funder is drained. */
+export const FAUCET_URL = "https://faucet.polkadot.io/?network=pah";
+
+/** Faucet URL pre-filled with the user's address — one click to self-fund. */
+export function faucetUrlFor(address: string): string {
+    return `${FAUCET_URL}&address=${address}`;
+}

--- a/src/utils/account/funding.test.ts
+++ b/src/utils/account/funding.test.ts
@@ -1,43 +1,70 @@
 /**
- * Tests for balance checks and Alice-based funding.
+ * Tests for balance checks and funder-chain selection.
  *
- * We mock only `@polkadot-apps/tx` — the SDK boundary we don't want to
- * exercise in unit tests. The real `polkadot-api` `Enum(...)` is used so the
- * `transfer_keep_alive({ dest: Enum("Id", …) })` call fails loudly if anyone
- * changes the variant name ("Id" → "Index", etc.) without updating tests.
+ * We mock:
+ *   - `./funder.js` to expose two named funders with predictable signer
+ *     identities (so `submitAndWatch` assertions can check which funder was
+ *     picked without dragging sr25519 derivation into the test).
+ *   - `@polkadot-apps/tx`'s `submitAndWatch` to observe what got submitted
+ *     without touching the network.
+ *
+ * The real `polkadot-api` `Enum(...)` is used so the `transfer_keep_alive({
+ * dest: Enum("Id", …) })` call fails loudly if anyone changes the variant
+ * name ("Id" → "Index", etc.) without updating tests.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockSubmitAndWatch = vi
     .fn<(tx: unknown, signer: unknown) => Promise<unknown>>()
     .mockResolvedValue({ ok: true });
-const mockCreateDevSigner = vi
-    .fn<(name: string) => unknown>()
-    .mockImplementation((name) => ({ __devSigner: name }));
 
 vi.mock("@polkadot-apps/tx", () => ({
     submitAndWatch: (...args: unknown[]) => mockSubmitAndWatch(args[0], args[1] as unknown),
-    createDevSigner: (...args: unknown[]) => mockCreateDevSigner(args[0] as string),
 }));
 
-const { checkBalance, ensureFunded, FUND_AMOUNT } = await import("./funding.js");
+const ALICE_SIGNER = { __funder: "Alice" };
+const DEDICATED_SIGNER = { __funder: "dedicated" };
+const ALICE_ADDRESS = "5Alice";
+const DEDICATED_ADDRESS = "5Dedicated";
 
-function makeClient(free: bigint) {
+vi.mock("./funder.js", () => ({
+    FUNDER_CHAIN: [
+        { name: "Alice", address: ALICE_ADDRESS, signer: ALICE_SIGNER },
+        { name: "dedicated", address: DEDICATED_ADDRESS, signer: DEDICATED_SIGNER },
+    ],
+    DEDICATED_FUNDER_ADDRESS: DEDICATED_ADDRESS,
+    FAUCET_URL: "https://faucet.polkadot.io/?network=pah",
+    faucetUrlFor: (addr: string) => `https://faucet.polkadot.io/?network=pah&address=${addr}`,
+}));
+
+const { checkBalance, ensureFunded, pickFunder, FUND_AMOUNT, FUNDER_FEE_BUFFER } = await import(
+    "./funding.js"
+);
+const { AllFundersExhaustedError } = await import("./errors.js");
+
+const USER_ADDRESS = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+/**
+ * Build a fake `PaseoClient`-ish object whose `System.Account.getValue` mock
+ * looks up the queried address in `balances` (defaulting to 0 for unknown
+ * addresses). Returns the transfer factory mock so callers can assert the
+ * arguments handed to `transfer_keep_alive`.
+ */
+function makeClient(balances: Record<string, bigint>) {
     const transferFactory = vi.fn().mockImplementation((args: unknown) => ({
         __kind: "transfer_keep_alive",
         args,
+    }));
+    const getValue = vi.fn().mockImplementation(async (address: string) => ({
+        data: { free: balances[address] ?? 0n, reserved: 0n, frozen: 0n },
     }));
     return {
         client: {
             assetHub: {
                 query: {
                     System: {
-                        Account: {
-                            getValue: vi.fn().mockResolvedValue({
-                                data: { free, reserved: 0n, frozen: 0n },
-                            }),
-                        },
+                        Account: { getValue },
                     },
                 },
                 tx: {
@@ -48,81 +75,99 @@ function makeClient(free: bigint) {
             },
         } as any,
         transferFactory,
+        getValue,
     };
 }
 
+beforeEach(() => {
+    mockSubmitAndWatch.mockClear();
+});
+
 describe("checkBalance", () => {
     it("reports sufficient when balance >= default MIN_BALANCE (1 PAS)", async () => {
-        const { client } = makeClient(10_000_000_000n);
-        const result = await checkBalance(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 10_000_000_000n });
+        const result = await checkBalance(client, USER_ADDRESS);
         expect(result.sufficient).toBe(true);
         expect(result.free).toBe(10_000_000_000n);
     });
 
     it("reports insufficient when balance < default MIN_BALANCE (1 PAS)", async () => {
-        const { client } = makeClient(5_000_000_000n);
-        const result = await checkBalance(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 5_000_000_000n });
+        const result = await checkBalance(client, USER_ADDRESS);
         expect(result.sufficient).toBe(false);
     });
 
     it("reports insufficient when balance is zero", async () => {
-        const { client } = makeClient(0n);
-        const result = await checkBalance(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 0n });
+        const result = await checkBalance(client, USER_ADDRESS);
         expect(result.sufficient).toBe(false);
         expect(result.free).toBe(0n);
     });
 
     it("respects an explicit minBalance override (below default)", async () => {
-        const { client } = makeClient(6_000_000_000n);
-        const result = await checkBalance(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            5_000_000_000n,
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 6_000_000_000n });
+        const result = await checkBalance(client, USER_ADDRESS, 5_000_000_000n);
         expect(result.sufficient).toBe(true);
     });
 
     it("respects an explicit minBalance override (above default)", async () => {
-        const { client } = makeClient(10_000_000_000n);
-        const result = await checkBalance(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            50_000_000_000n,
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 10_000_000_000n });
+        const result = await checkBalance(client, USER_ADDRESS, 50_000_000_000n);
         expect(result.sufficient).toBe(false);
+    });
+});
+
+describe("pickFunder", () => {
+    const required = FUND_AMOUNT + FUNDER_FEE_BUFFER;
+
+    it("returns Alice when she has enough (and never queries the dedicated account)", async () => {
+        const { client, getValue } = makeClient({ [ALICE_ADDRESS]: required + 1n });
+        const funder = await pickFunder(client, required);
+        expect(funder?.name).toBe("Alice");
+        // Short-circuits: only Alice's balance was queried.
+        const addresses = getValue.mock.calls.map((c) => c[0]);
+        expect(addresses).toEqual([ALICE_ADDRESS]);
+    });
+
+    it("falls through to dedicated when Alice is low", async () => {
+        const { client } = makeClient({
+            [ALICE_ADDRESS]: 0n,
+            [DEDICATED_ADDRESS]: required + 1n,
+        });
+        const funder = await pickFunder(client, required);
+        expect(funder?.name).toBe("dedicated");
+    });
+
+    it("returns null when every funder is below the threshold", async () => {
+        const { client } = makeClient({
+            [ALICE_ADDRESS]: 0n,
+            [DEDICATED_ADDRESS]: 0n,
+        });
+        expect(await pickFunder(client, required)).toBeNull();
     });
 });
 
 describe("ensureFunded", () => {
     it("skips funding when balance is sufficient", async () => {
-        mockSubmitAndWatch.mockClear();
-        const { client } = makeClient(50_000_000_000n);
-        await ensureFunded(client, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+        const { client } = makeClient({ [USER_ADDRESS]: 50_000_000_000n });
+        await ensureFunded(client, USER_ADDRESS);
         expect(mockSubmitAndWatch).not.toHaveBeenCalled();
     });
 
-    it("funds with FUND_AMOUNT, uses Alice, and wraps the dest in Enum('Id', …)", async () => {
-        mockSubmitAndWatch.mockClear();
-        mockCreateDevSigner.mockClear();
-        const { client, transferFactory } = makeClient(0n);
-        const address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-        await ensureFunded(client, address);
+    it("funds with FUND_AMOUNT via Alice when she has balance", async () => {
+        const { client, transferFactory } = makeClient({
+            [USER_ADDRESS]: 0n,
+            [ALICE_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
+        });
+        await ensureFunded(client, USER_ADDRESS);
 
-        expect(mockCreateDevSigner).toHaveBeenCalledWith("Alice");
         expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
-        expect(transferFactory).toHaveBeenCalledTimes(1);
+        const [, signer] = mockSubmitAndWatch.mock.calls[0];
+        expect(signer).toBe(ALICE_SIGNER);
 
+        expect(transferFactory).toHaveBeenCalledTimes(1);
         const callArgs = transferFactory.mock.calls[0][0] as {
-            dest: { type: string; value: { type: string; value: unknown } };
+            dest: { type: string };
             value: bigint;
         };
         // We don't mock polkadot-api — Enum() actually builds the runtime
@@ -132,28 +177,46 @@ describe("ensureFunded", () => {
         expect(callArgs.dest).toMatchObject({ type: "Id" });
     });
 
+    it("falls through to the dedicated funder when Alice is low", async () => {
+        const { client } = makeClient({
+            [USER_ADDRESS]: 0n,
+            [ALICE_ADDRESS]: 0n,
+            [DEDICATED_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
+        });
+        await ensureFunded(client, USER_ADDRESS);
+
+        expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
+        const [, signer] = mockSubmitAndWatch.mock.calls[0];
+        expect(signer).toBe(DEDICATED_SIGNER);
+    });
+
+    it("throws AllFundersExhaustedError carrying the user address + tried list when every funder is low", async () => {
+        const { client } = makeClient({
+            [USER_ADDRESS]: 0n,
+            [ALICE_ADDRESS]: 0n,
+            [DEDICATED_ADDRESS]: 0n,
+        });
+        await expect(ensureFunded(client, USER_ADDRESS)).rejects.toSatisfy((err: unknown) => {
+            if (!(err instanceof AllFundersExhaustedError)) return false;
+            return err.userAddress === USER_ADDRESS && err.tried.join(",") === "Alice,dedicated";
+        });
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
     it("uses caller-supplied minBalance + fundAmount when passed", async () => {
-        mockSubmitAndWatch.mockClear();
-        const { client, transferFactory } = makeClient(3_000_000_000n);
-        await ensureFunded(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            5_000_000_000n,
-            20_000_000_000n,
-        );
+        const { client, transferFactory } = makeClient({
+            [USER_ADDRESS]: 3_000_000_000n,
+            [ALICE_ADDRESS]: 40_000_000_000n, // covers 20 PAS + buffer
+        });
+        await ensureFunded(client, USER_ADDRESS, 5_000_000_000n, 20_000_000_000n);
         expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
         const callArgs = transferFactory.mock.calls[0][0] as { value: bigint };
         expect(callArgs.value).toBe(20_000_000_000n);
     });
 
     it("skips funding when balance is above the caller-supplied minBalance", async () => {
-        mockSubmitAndWatch.mockClear();
-        const { client } = makeClient(6_000_000_000n);
-        await ensureFunded(
-            client,
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            5_000_000_000n,
-        );
+        const { client } = makeClient({ [USER_ADDRESS]: 6_000_000_000n });
+        await ensureFunded(client, USER_ADDRESS, 5_000_000_000n);
         expect(mockSubmitAndWatch).not.toHaveBeenCalled();
     });
 });

--- a/src/utils/account/funding.ts
+++ b/src/utils/account/funding.ts
@@ -1,20 +1,35 @@
 /**
- * Account funding — check balance and fund from Alice on testnet.
+ * Account funding — check balance and fund the user from a testnet funder
+ * chain on Paseo Asset Hub.
+ *
+ * The funder chain is walked in order: Alice first (public dev account — free
+ * while she lasts), then a dedicated obscure seed. If every funder is below
+ * the required threshold, callers receive `AllFundersExhaustedError` carrying
+ * the user's address so they can render a faucet link.
  *
  * Testnet-only: will be replaced for mainnet where users fund themselves.
  */
 
 import { Enum } from "polkadot-api";
-import { submitAndWatch, createDevSigner } from "@polkadot-apps/tx";
+import { submitAndWatch } from "@polkadot-apps/tx";
 import type { PaseoClient } from "../connection.js";
+import { FUNDER_CHAIN, type Funder } from "./funder.js";
+import { AllFundersExhaustedError } from "./errors.js";
 
 const AT_BEST = { at: "best" as const };
 
 /** 1 PAS — below this we consider the account underfunded. */
 export const MIN_BALANCE = 10_000_000_000n;
 
-/** 10 PAS — amount Alice sends when funding. */
+/** 10 PAS — amount sent when funding. */
 export const FUND_AMOUNT = 100_000_000_000n;
+
+/**
+ * Headroom on top of the transfer amount a funder must carry — covers the
+ * Balances.transfer_keep_alive fee and keeps the funder above its own
+ * existential deposit. 0.1 PAS is an order of magnitude above observed fees.
+ */
+export const FUNDER_FEE_BUFFER = 1_000_000_000n;
 
 export interface BalanceStatus {
     free: bigint;
@@ -31,6 +46,24 @@ export async function checkBalance(
     return { free, sufficient: free >= minBalance };
 }
 
+/**
+ * Walk `FUNDER_CHAIN` in order and return the first funder whose free balance
+ * covers `requiredBalance`. Returns `null` when every funder is low. Once
+ * selected, callers should use the returned funder as-is; we do NOT retry
+ * across funders if its submission fails at tx-submit time (the error there
+ * is not a balance problem and deserves to surface unchanged).
+ */
+export async function pickFunder(
+    client: PaseoClient,
+    requiredBalance: bigint,
+): Promise<Funder | null> {
+    for (const funder of FUNDER_CHAIN) {
+        const { free } = await checkBalance(client, funder.address, requiredBalance);
+        if (free >= requiredBalance) return funder;
+    }
+    return null;
+}
+
 export async function ensureFunded(
     client: PaseoClient,
     address: string,
@@ -40,12 +73,19 @@ export async function ensureFunded(
     const { sufficient } = await checkBalance(client, address, minBalance);
     if (sufficient) return;
 
-    const alice = createDevSigner("Alice");
+    const funder = await pickFunder(client, fundAmount + FUNDER_FEE_BUFFER);
+    if (!funder) {
+        throw new AllFundersExhaustedError(
+            address,
+            FUNDER_CHAIN.map((f) => f.name),
+        );
+    }
+
     await submitAndWatch(
         client.assetHub.tx.Balances.transfer_keep_alive({
             dest: Enum("Id", address),
             value: fundAmount,
         }),
-        alice,
+        funder.signer,
     );
 }

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -14,8 +14,8 @@ const {
     getOrCreateSessionAccountMock,
     getConnectionMock,
     checkBalanceMock,
+    pickFunderMock,
     submitAndWatchMock,
-    createDevSignerMock,
 } = vi.hoisted(() => ({
     runStorageDeploy: vi.fn<
         (arg: any) => Promise<{
@@ -77,7 +77,12 @@ const {
     submitAndWatchMock: vi.fn<(tx: unknown, signer: unknown) => Promise<unknown>>(async () => ({
         ok: true,
     })),
-    createDevSignerMock: vi.fn((name: string) => ({ __devSigner: name })),
+    pickFunderMock: vi.fn<
+        (
+            client: unknown,
+            required: bigint,
+        ) => Promise<{ name: string; address: string; signer: unknown } | null>
+    >(async () => ({ name: "Alice", address: "5Alice", signer: { __funder: "Alice" } })),
 }));
 
 vi.mock("./storage.js", () => ({ runStorageDeploy }));
@@ -107,10 +112,14 @@ vi.mock("../connection.js", () => ({
 }));
 vi.mock("../account/funding.js", () => ({
     checkBalance: checkBalanceMock,
+    pickFunder: (...args: unknown[]) => pickFunderMock(args[0], args[1] as bigint),
+    FUNDER_FEE_BUFFER: 1_000_000_000n,
+}));
+vi.mock("../account/funder.js", () => ({
+    FAUCET_URL: "https://faucet.polkadot.io/?network=pah",
 }));
 vi.mock("@polkadot-apps/tx", () => ({
     submitAndWatch: (...args: unknown[]) => submitAndWatchMock(args[0], args[1]),
-    createDevSigner: (...args: unknown[]) => createDevSignerMock(args[0] as string),
 }));
 
 import { runDeploy, type DeployEvent } from "./run.js";
@@ -178,7 +187,12 @@ beforeEach(() => {
     checkBalanceMock.mockReset();
     checkBalanceMock.mockResolvedValue({ free: 100_000_000_000n, sufficient: true });
     submitAndWatchMock.mockClear();
-    createDevSignerMock.mockClear();
+    pickFunderMock.mockReset();
+    pickFunderMock.mockResolvedValue({
+        name: "Alice",
+        address: "5Alice",
+        signer: { __funder: "Alice" },
+    });
 });
 
 describe("runDeploy", () => {
@@ -581,15 +595,22 @@ describe("runDeploy — contracts phase", () => {
         const [, firstSigner] = submitAndWatchMock.mock.calls[0];
         expect(firstSigner).toHaveProperty("signTx");
         expect(firstSigner).toHaveProperty("signBytes");
-        // Dev fallback must NOT have fired.
-        expect(createDevSignerMock).not.toHaveBeenCalledWith("Alice");
+        // Dev-mode funder-chain lookup must NOT have fired.
+        expect(pickFunderMock).not.toHaveBeenCalled();
     });
 
-    it("ensureSessionFunded: underfunded + pure dev mode → uses Alice as funder", async () => {
+    it("ensureSessionFunded: underfunded + pure dev mode → picks a funder from the chain", async () => {
         detectContractsTypeMock.mockReturnValue("foundry");
         const { client } = makeFakeClient();
         getConnectionMock.mockResolvedValue(client);
         checkBalanceMock.mockResolvedValue({ free: 0n, sufficient: false });
+
+        const dedicatedSigner = { __funder: "dedicated" };
+        pickFunderMock.mockResolvedValueOnce({
+            name: "dedicated",
+            address: "5Dedicated",
+            signer: dedicatedSigner,
+        });
 
         const { push } = collectEvents();
         await runDeploy({
@@ -604,10 +625,45 @@ describe("runDeploy — contracts phase", () => {
             onEvent: push,
         });
 
-        expect(createDevSignerMock).toHaveBeenCalledWith("Alice");
-        // Transfer submitted with the Alice dev signer.
+        // Funder-chain was consulted for `SESSION_FUND_AMOUNT + FUNDER_FEE_BUFFER`.
+        expect(pickFunderMock).toHaveBeenCalledTimes(1);
+        const required = pickFunderMock.mock.calls[0][1];
+        expect(required).toBe(50_000_000_000n + 1_000_000_000n);
+
+        // Transfer was submitted with exactly the signer returned by pickFunder.
         const [, funder] = submitAndWatchMock.mock.calls[0];
-        expect(funder).toMatchObject({ __devSigner: "Alice" });
+        expect(funder).toBe(dedicatedSigner);
+    });
+
+    it("ensureSessionFunded: underfunded + dev mode + every funder drained → throws with faucet link", async () => {
+        detectContractsTypeMock.mockReturnValue("foundry");
+        const { client } = makeFakeClient();
+        getConnectionMock.mockResolvedValue(client);
+        checkBalanceMock.mockResolvedValue({ free: 0n, sufficient: false });
+        pickFunderMock.mockResolvedValueOnce(null);
+
+        const { events, push } = collectEvents();
+        await expect(
+            runDeploy({
+                projectDir: "/tmp/proj",
+                buildDir: "/tmp/proj/dist",
+                skipBuild: true,
+                domain: "my-app",
+                mode: "dev",
+                publishToPlayground: false,
+                userSigner: null,
+                deployContracts: true,
+                onEvent: push,
+            }),
+        ).rejects.toThrow(
+            /Dev account balance low\..*mobile signer.*faucet.*https:\/\/faucet\.polkadot\.io/s,
+        );
+
+        // No transfer should have been attempted.
+        expect(submitAndWatchMock).not.toHaveBeenCalled();
+        // The error should have been surfaced as a contracts-phase error event.
+        const err = events.find((e) => e.kind === "error" && e.phase === "contracts");
+        expect(err).toBeDefined();
     });
 
     it("session-key mapping fires Revive.map_account only when created: true", async () => {

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -31,9 +31,10 @@ import {
     type SigningEvent,
 } from "./signingProxy.js";
 import type { DeployLogEvent } from "./progress.js";
-import { checkBalance } from "../account/funding.js";
-import { Enum } from "polkadot-api";
-import { submitAndWatch, createDevSigner } from "@polkadot-apps/tx";
+import { checkBalance, pickFunder, FUNDER_FEE_BUFFER } from "../account/funding.js";
+import { FAUCET_URL } from "../account/funder.js";
+import { Enum, type PolkadotSigner } from "polkadot-api";
+import { submitAndWatch } from "@polkadot-apps/tx";
 import type { ResolvedSigner } from "../signer.js";
 import { getConnection } from "../connection.js";
 import type { Env } from "../../config.js";
@@ -307,13 +308,27 @@ async function ensureSessionFunded(opts: {
 
     emitInfo(`funding session key ${opts.sessionAddress}…`);
 
-    const funder = opts.userSigner
-        ? wrapSignerWithEvents(opts.userSigner.signer, {
-              label: "Fund contract deploy session key",
-              counter: opts.counter,
-              onEvent: (event) => opts.onEvent({ kind: "signing", event }),
-          })
-        : createDevSigner("Alice");
+    // Phone signer: user pays, with a lifecycle event so the TUI numbers the
+    // tap. Pure dev mode: pick the first funder in the chain that has enough
+    // PAS to cover the top-up. If every dev funder is drained, tell the user
+    // to switch to a mobile signer rather than silently falling back to
+    // anything that might race the drainer.
+    let funder: PolkadotSigner;
+    if (opts.userSigner) {
+        funder = wrapSignerWithEvents(opts.userSigner.signer, {
+            label: "Fund contract deploy session key",
+            counter: opts.counter,
+            onEvent: (event) => opts.onEvent({ kind: "signing", event }),
+        });
+    } else {
+        const picked = await pickFunder(opts.client, SESSION_FUND_AMOUNT + FUNDER_FEE_BUFFER);
+        if (!picked) {
+            throw new Error(
+                `Dev account balance low. Please deploy with mobile signer. To top up funds in your mobile signer, go to the faucet at: ${FAUCET_URL}`,
+            );
+        }
+        funder = picked.signer;
+    }
 
     await submitAndWatch(
         opts.client.assetHub.tx.Balances.transfer_keep_alive({


### PR DESCRIPTION
## Summary

- Adds an ordered funder chain (Alice → dedicated seed) for Paseo Asset Hub funding. `ensureFunded` picks the first funder with enough balance; if every funder is below threshold, it throws a typed `AllFundersExhaustedError`.
- Wires `dot init` to surface the faucet link (prefilled with the user's own address) when every dev funder is drained, and `dot deploy --signer dev` to tell the user to switch to the mobile signer instead.
- Adds a scheduled GitHub Actions workflow that files an `[URGENT]` issue (labelled `funder-low-balance`) when the dedicated funder drops below 5000 PAS — idempotent, comments on the open issue on subsequent runs instead of opening duplicates.

## Why

Alice (`//Alice`) has a publicly known SURI baked into every Substrate tool and polkadot.js Apps' account dropdown, and is being actively drained on Paseo. The dedicated seed isn't in anyone's dropdown, so random drainers don't target it — "security through obscurity, testnet-only" per the team convention.

Bulletin's `authorize_account` flow stays on Alice — Bulletin has no fee token, so there's nothing to drain there.

## Dedicated funder

- Address: `5GNodfrdZyb1Fupx2d4tz5GDLSzCKiuY7cFyMdgqDjHf8LZb`
- Topped up ahead of merge; monitoring workflow will ping here if it runs low.

## Test plan

- [x] `pnpm test` — 331/331 passing (6 new tests for funder-chain selection + exhausted path)
- [x] `pnpm format:check` clean
- [x] Balance-check script smoke-tested against live Paseo (`bun run scripts/check-funder-balance.ts`)
- [x] Reviewed via superpowers code-review agent; critical + important findings addressed (jq null-handling bug in workflow fixed; reviewer's heredoc-indent flag verified to be a non-issue via YAML block-scalar semantics)
- [x] End-to-end `dot init` with Alice funded (happy path)
- [x] End-to-end `dot init` with `FUNDER_CHAIN` locally edited to force dedicated-only selection
- [x] End-to-end `dot init` with both funders faked to 0 balance (verifies exhausted-path faucet hint)
- [x] Trigger the balance-check workflow via `workflow_dispatch` with the threshold temporarily raised above the funder's current balance; verify the issue is created on first run and commented on (not duplicated) on the second

## Files

- New: `src/utils/account/errors.ts`, `src/utils/account/funder.ts`, `scripts/check-funder-balance.ts`, `.github/workflows/funder-balance-check.yml`, `.changeset/dedicated-funder-fallback.md`
- Modified: `src/utils/account/funding.{ts,test.ts}`, `src/commands/init/AccountSetup.tsx`, `src/utils/deploy/run.{ts,test.ts}`