### PR TITLE
fix(ci): auto-create funder-low-balance label before filing issue

### DIFF
--- a/.github/workflows/funder-balance-check.yml
+++ b/.github/workflows/funder-balance-check.yml
@@ -49,6 +49,15 @@ jobs:
               run: |
                   set -euo pipefail
 
+                  # Ensure the label exists before we try to attach it — `gh
+                  # issue create --label` hard-fails if the label is missing.
+                  # `--force` turns create-if-missing into an idempotent
+                  # create-or-update so repeated runs are safe.
+                  gh label create funder-low-balance \
+                      --color "B60205" \
+                      --description "Dedicated funder balance below threshold" \
+                      --force
+
                   ADDRESS=$(grep '^address=' balance.txt | cut -d= -f2- || echo "unknown")
                   BALANCE=$(grep '^balance=' balance.txt | cut -d= -f2- || echo "unknown")
                   THRESHOLD=$(grep '^threshold=' balance.txt | cut -d= -f2- || echo "5000.00 PAS")


### PR DESCRIPTION
## Summary

- Prepends `gh label create funder-low-balance --force` to the balance-check workflow's issue-filing step. `gh issue create --label` hard-fails if the label doesn't already exist in the repo, which is what just happened on the first scheduled run after #39 merged.
- `--force` makes the call idempotent (create-if-missing, update color/description otherwise), so re-runs are safe.

## Why

Observed failure on the first scheduled run after the dedicated funder dropped below threshold:

```
could not add label: 'funder-low-balance' not found
Error: Process completed with exit code 1.
```

The balance check itself worked — it correctly exited 1 because the funder was drained below 5000 PAS. The follow-up `gh issue create --label funder-low-balance` is what errored out, because no one had created the label in the repo yet.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` once this merges; confirm the label is created and the `[URGENT]` issue gets filed
- [ ] Re-trigger while the issue is still open; confirm the workflow comments on the existing issue rather than opening a second one (idempotence still holds)

No changeset — pure CI/infra fix, no end-user behavior change.