### PR TITLE
chore(deps): bump @polkadot-apps/chain-client to 2.0.5

### DIFF
--- a/.changeset/bump-chain-client-2-0-5.md
+++ b/.changeset/bump-chain-client-2-0-5.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Bump `@polkadot-apps/chain-client` to 2.0.5, which rotates the Paseo Asset Hub preset RPC list to live endpoints. Fixes `dot init` hanging on the funding step with repeated "Unable to connect to …" errors when both previously-configured endpoints (Dwellir, `sys.ibp.network`) were simultaneously unhealthy.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.6.9(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/chain-client':
         specifier: latest
-        version: 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
+        version: 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/contracts':
         specifier: latest
         version: 0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
@@ -1064,6 +1064,9 @@ packages:
 
   '@polkadot-apps/chain-client@2.0.4':
     resolution: {integrity: sha512-wBjWsi6hBNfcXVHiyoVzcChNmoxzsA9fkdA4sMbqeJ62rwohslq0liUbC14my+lofhE815jaVCeeQeoNX5vs2g==}
+
+  '@polkadot-apps/chain-client@2.0.5':
+    resolution: {integrity: sha512-lPmHSJyll0c7fCXwmMgctoD2HpfMCcBAFMtiPer4CSSP3uR0xjVQH3ULu8Xtbh/Aiq7TRirPBfL5ovvQhs4TJg==}
 
   '@polkadot-apps/contracts@0.3.2':
     resolution: {integrity: sha512-V8deSU5BP9lzdNbthnprKB+LQR2NsD9N+G6Rl68jfEoS1fBCCaWf9GlcOitgog3Ve1XxzoSa6Gl1GjYuiy/J2w==}
@@ -3235,7 +3238,7 @@ snapshots:
       '@dotdm/utils': 0.3.1
       '@noble/hashes': 2.2.0
       '@polkadot-apps/bulletin': 0.6.9(postcss@8.5.10)(rxjs@7.8.2)
-      '@polkadot-apps/chain-client': 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/chain-client': 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/contracts': 0.4.0(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
       '@polkadot-apps/tx': 0.3.5(postcss@8.5.10)(rxjs@7.8.2)
@@ -3261,7 +3264,7 @@ snapshots:
   '@dotdm/env@1.0.0(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
       '@dotdm/utils': 0.3.1
-      '@polkadot-apps/chain-client': 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/chain-client': 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
       '@polkadot-labs/hdkd': 0.0.26
       '@polkadot-labs/hdkd-helpers': 0.0.27
@@ -4313,6 +4316,24 @@ snapshots:
       - yaml
 
   '@polkadot-apps/chain-client@2.0.4(postcss@8.5.10)(rxjs@7.8.2)':
+    dependencies:
+      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
+      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
+      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@novasamatech/product-sdk'
+      - '@swc/core'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - utf-8-validate
+      - yaml
+
+  '@polkadot-apps/chain-client@2.0.5(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
       '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
       '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)


### PR DESCRIPTION
## Summary

Picks up the Paseo Asset Hub preset RPC rotation from [paritytech/polkadot-apps#106](https://github.com/paritytech/polkadot-apps/pull/106). `@polkadot-apps/chain-client` goes 2.0.4 → 2.0.5.

Resolves the `dot init` hang on the funding step — both endpoints in the old 2.0.4 preset were returning non-101 to WS upgrade (Dwellir → 405, `sys.ibp.network/asset-hub-paseo` → 502), so polkadot-api's ws-provider looped forever printing "Unable to connect to …".

## What changed

Only `pnpm-lock.yaml`. Our `package.json` pin is `"@polkadot-apps/chain-client": "latest"`; `pnpm update @polkadot-apps/chain-client` refreshed the lockfile to 2.0.5.

New Paseo Asset Hub endpoint list (live-first, from the upstream preset):
1. `wss://asset-hub-paseo.ibp.network`
2. `wss://asset-hub-paseo.dotters.network`
3. `wss://sys.turboflakes.io/asset-hub-paseo`
4. `wss://asset-hub-paseo-rpc.n.dwellir.com` (fallback)

## Known transitive

`@polkadot-apps/bulletin@0.6.9` still pulls `chain-client@2.0.4` transitively. That path only uses the Bulletin chain (`BULLETIN_RPCS.paseo` preset), not the Asset Hub preset we rotated, so it's unaffected by this fix. Can be cleaned up whenever bulletin publishes a version that consumes chain-client 2.0.5.

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm test` — 332/332 pass
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm list @polkadot-apps/chain-client --depth=0` → 2.0.5
- [x] Manual `dot init` to confirm funding step connects on first endpoint (~240 ms) with no "Unable to connect" spam