### PR TITLE
chore(deps): refresh remaining @polkadot-apps/* deps to latest

### DIFF
--- a/.changeset/refresh-polkadot-apps.md
+++ b/.changeset/refresh-polkadot-apps.md
@@ -1,0 +1,10 @@
+---
+"playground-cli": patch
+---
+
+Refresh remaining `@polkadot-apps/*` direct dependencies to their current latest. PR #44 narrowly bumped `chain-client`; this widens to pick up the siblings that the monorepo had already co-released via its `workspace:*` + changesets patch cascade:
+
+- `@polkadot-apps/bulletin` 0.6.9 → 0.6.10
+- `@polkadot-apps/contracts` 0.3.2 → 0.4.0
+
+Also eliminates the duplicate `chain-client@2.0.4` that was being pulled transitively by the old bulletin — single resolved version now (`2.0.5`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,13 +19,13 @@ importers:
         version: 0.4.0(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/bulletin':
         specifier: latest
-        version: 0.6.9(postcss@8.5.10)(rxjs@7.8.2)
+        version: 0.6.10(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/chain-client':
         specifier: latest
         version: 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/contracts':
         specifier: latest
-        version: 0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
+        version: 0.4.0(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       '@polkadot-apps/descriptors':
         specifier: latest
         version: 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
@@ -1054,22 +1054,16 @@ packages:
   '@polkadot-apps/address@0.4.0':
     resolution: {integrity: sha512-afBbT7/13CZLAClx+SdnJmDag0m70aXbvoZY8TmNL8mKoHJQEKnMHMzZEeSuiQ9A+otbFLC90UX7180SioJDFA==}
 
-  '@polkadot-apps/bulletin@0.6.9':
-    resolution: {integrity: sha512-QkSBlcaQ1Ts3M3427C9GfGUWFrD0hJ2RbYRkmTE40JvTL4NnPNsCkG4Hnkzsi9v+8/siZiYDRtZIH4YvDtO3Fg==}
+  '@polkadot-apps/bulletin@0.6.10':
+    resolution: {integrity: sha512-HEjVChYYv1pRDWWGFRFoPBVVniOxHK9d7GIC2NPdFl6mkv5WjWTR6Oi0z6pRj1FGTS/cRPZgq+DuSAd8kNL3nQ==}
     peerDependencies:
       '@novasamatech/product-sdk': '>=0.1.0'
     peerDependenciesMeta:
       '@novasamatech/product-sdk':
         optional: true
 
-  '@polkadot-apps/chain-client@2.0.4':
-    resolution: {integrity: sha512-wBjWsi6hBNfcXVHiyoVzcChNmoxzsA9fkdA4sMbqeJ62rwohslq0liUbC14my+lofhE815jaVCeeQeoNX5vs2g==}
-
   '@polkadot-apps/chain-client@2.0.5':
     resolution: {integrity: sha512-lPmHSJyll0c7fCXwmMgctoD2HpfMCcBAFMtiPer4CSSP3uR0xjVQH3ULu8Xtbh/Aiq7TRirPBfL5ovvQhs4TJg==}
-
-  '@polkadot-apps/contracts@0.3.2':
-    resolution: {integrity: sha512-V8deSU5BP9lzdNbthnprKB+LQR2NsD9N+G6Rl68jfEoS1fBCCaWf9GlcOitgog3Ve1XxzoSa6Gl1GjYuiy/J2w==}
 
   '@polkadot-apps/contracts@0.4.0':
     resolution: {integrity: sha512-2W8Yvn0NtmteJ/IpjXqA/UwSEP/PehiL7N8XL7kX2KTMwbM+XCOzeiZP6KJ7Z2VMVARFTLmsCz1dieDzaagrKQ==}
@@ -3237,7 +3231,7 @@ snapshots:
       '@dotdm/env': 1.0.0(postcss@8.5.10)(rxjs@7.8.2)
       '@dotdm/utils': 0.3.1
       '@noble/hashes': 2.2.0
-      '@polkadot-apps/bulletin': 0.6.9(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/bulletin': 0.6.10(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/chain-client': 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/contracts': 0.4.0(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)
       '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
@@ -4293,9 +4287,9 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-apps/bulletin@0.6.9(postcss@8.5.10)(rxjs@7.8.2)':
+  '@polkadot-apps/bulletin@0.6.10(postcss@8.5.10)(rxjs@7.8.2)':
     dependencies:
-      '@polkadot-apps/chain-client': 2.0.4(postcss@8.5.10)(rxjs@7.8.2)
+      '@polkadot-apps/chain-client': 2.0.5(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
       '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
       '@polkadot-apps/logger': 0.1.5
@@ -4305,24 +4299,6 @@ snapshots:
       polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
-      - '@swc/core'
-      - bufferutil
-      - jiti
-      - postcss
-      - rxjs
-      - supports-color
-      - tsx
-      - utf-8-validate
-      - yaml
-
-  '@polkadot-apps/chain-client@2.0.4(postcss@8.5.10)(rxjs@7.8.2)':
-    dependencies:
-      '@polkadot-apps/descriptors': 1.0.1(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))
-      '@polkadot-apps/host': 0.5.1(postcss@8.5.10)(rxjs@7.8.2)
-      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@novasamatech/product-sdk'
       - '@swc/core'
       - bufferutil
       - jiti
@@ -4350,32 +4326,6 @@ snapshots:
       - tsx
       - utf-8-validate
       - yaml
-
-  '@polkadot-apps/contracts@0.3.2(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)':
-    dependencies:
-      '@polkadot-api/sdk-ink': 0.6.2(@polkadot-api/ink-contracts@0.6.1)(polkadot-api@1.23.3(postcss@8.5.10)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
-      '@polkadot-apps/keys': 0.4.4(postcss@8.5.10)(rxjs@7.8.2)
-      '@polkadot-apps/logger': 0.1.5
-      '@polkadot-apps/signer': 1.1.0(@novasamatech/host-api@0.6.17)(postcss@8.5.10)(rxjs@7.8.2)
-      '@polkadot-apps/tx': 0.3.5(postcss@8.5.10)(rxjs@7.8.2)
-      '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 1.23.3(postcss@8.5.10)(rxjs@7.8.2)
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@novasamatech/host-api'
-      - '@novasamatech/product-sdk'
-      - '@polkadot-api/ink-contracts'
-      - '@swc/core'
-      - bufferutil
-      - jiti
-      - postcss
-      - rxjs
-      - supports-color
-      - tsx
-      - typescript
-      - utf-8-validate
-      - yaml
-      - zod
 
   '@polkadot-apps/contracts@0.4.0(@novasamatech/host-api@0.6.17)(@polkadot-api/ink-contracts@0.6.1)(postcss@8.5.10)(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Follows up #44, which narrowly bumped `@polkadot-apps/chain-client`. Widens the refresh to the sibling packages the monorepo had already co-released alongside it:

- `@polkadot-apps/bulletin`  0.6.9  → 0.6.10
- `@polkadot-apps/contracts` 0.3.2  → 0.4.0

## Why

Upstream (`paritytech/polkadot-apps`) keeps its packages in version lockstep via `workspace:*` + changesets with `updateInternalDependencies: "patch"`. When `chain-client` went 2.0.4 → 2.0.5, bulletin cascaded 0.6.9 → 0.6.10 in the same release train so it consumed the new chain-client internally. #44's narrow `pnpm update @polkadot-apps/chain-client` didn't refresh bulletin, so our lockfile had:

- `@polkadot-apps/bulletin@0.6.9` (old) → pulling `chain-client@2.0.4` transitively
- `@polkadot-apps/chain-client@2.0.5` (new, direct)

…two resolved chain-client versions at the same time.

This PR uses `pnpm update "@polkadot-apps/*"` to refresh every direct dep in one pass. Now a single resolved chain-client version (2.0.5), and both direct deps match what the monorepo published together.

## Verified
- [x] `pnpm why @polkadot-apps/chain-client` → "Found 1 version"
- [x] `pnpm test` — 332/332 pass
- [x] `npx tsc --noEmit` — clean

## Note on polkadot-apps itself

No changes needed in `paritytech/polkadot-apps` — the monorepo already enforces "all internal deps always on latest" via `workspace:*` for every inter-package dep, plus the changesets patch cascade. The cascade is what produced bulletin@0.6.10 automatically when chain-client bumped. The fix required was only on the consumer side (here).