### PR TITLE
feat(logout): add `dot logout` command

### DIFF
--- a/.changeset/dot-logout-command.md
+++ b/.changeset/dot-logout-command.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+Add `dot logout` to sign out of the account paired via `dot init` — no more `rm -rf ~/.polkadot-apps`. Notifies the mobile app so the paired-connection entry is removed there too, with a best-effort local-only cleanup fallback when the network is unreachable.

--- a/src/commands/logout/LogoutScreen.tsx
+++ b/src/commands/logout/LogoutScreen.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Box } from "ink";
+import { Header, Section } from "../../utils/ui/theme/index.js";
+import { waitForLogout, type LogoutHandle, type LogoutStatus } from "../../utils/auth.js";
+import { VERSION_LABEL } from "../../utils/version.js";
+import { LogoutStatus as LogoutStatusRow } from "./LogoutStatus.js";
+import { isTerminal } from "./status.js";
+
+/**
+ * Orchestrator for the sign-out flow. Owns status state, kicks off
+ * `waitForLogout` once on mount, and calls `onDone` the moment the status
+ * reaches a terminal step — the command wrapper unmounts on that signal.
+ *
+ * The adapter inside `handle` is destroyed by `waitForLogout` itself, so
+ * this component doesn't need a useEffect cleanup for it.
+ */
+export function LogoutScreen({
+    handle,
+    onDone,
+}: {
+    handle: LogoutHandle;
+    onDone: () => void;
+}) {
+    // Seed with `disconnecting` — findSession() already resolved the address
+    // before this screen mounted, so there's no "checking" phase to show.
+    const [status, setStatus] = useState<LogoutStatus>({
+        step: "disconnecting",
+        address: handle.address,
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        waitForLogout(handle, (s) => {
+            if (!cancelled) setStatus(s);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isTerminal(status)) onDone();
+    }, [status]);
+
+    return (
+        <Box flexDirection="column">
+            <Header
+                cmd="dot logout"
+                subtitle="polkadot playground"
+                network="paseo"
+                right={VERSION_LABEL}
+            />
+            <Section gapBelow={false}>
+                <LogoutStatusRow status={status} />
+            </Section>
+        </Box>
+    );
+}

--- a/src/commands/logout/LogoutStatus.tsx
+++ b/src/commands/logout/LogoutStatus.tsx
@@ -1,0 +1,20 @@
+import { Row } from "../../utils/ui/theme/index.js";
+import { statusToRow } from "./status.js";
+import type { LogoutStatus as LogoutStatusType } from "../../utils/auth.js";
+
+/**
+ * Single-row presentational view of the current sign-out step. Pure — all
+ * visual/copy decisions live in `statusToRow` so they're unit-testable.
+ */
+export function LogoutStatus({ status }: { status: LogoutStatusType }) {
+    const spec = statusToRow(status);
+    return (
+        <Row
+            mark={spec.mark}
+            label={spec.label}
+            value={spec.value}
+            hint={spec.hint}
+            tone={spec.tone}
+        />
+    );
+}

--- a/src/commands/logout/index.ts
+++ b/src/commands/logout/index.ts
@@ -1,0 +1,53 @@
+import React from "react";
+import { Command } from "commander";
+import { render } from "ink";
+import { findSession, type LogoutHandle } from "../../utils/auth.js";
+import { LogoutScreen } from "./LogoutScreen.js";
+
+// Tagged result so the three outcomes — session found, no session, lookup
+// failed — stay distinguishable without piggy-backing on `process.exitCode`.
+type LookupResult =
+    | { kind: "found"; handle: LogoutHandle }
+    | { kind: "empty" }
+    | { kind: "error"; message: string };
+
+async function lookupSession(): Promise<LookupResult> {
+    try {
+        const handle = await findSession();
+        return handle ? { kind: "found", handle } : { kind: "empty" };
+    } catch (err) {
+        return {
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+        };
+    }
+}
+
+export const logoutCommand = new Command("logout")
+    .description("Sign out of the account paired via `dot init`")
+    .action(async () => {
+        console.log();
+
+        const result = await lookupSession();
+
+        if (result.kind === "error") {
+            console.error(`  Could not reach the login service: ${result.message}\n`);
+            process.exit(1);
+        }
+
+        if (result.kind === "empty") {
+            console.log("  No account is signed in.\n");
+            process.exit(0);
+        }
+
+        const app = render(
+            React.createElement(LogoutScreen, {
+                handle: result.handle,
+                onDone: () => app.unmount(),
+            }),
+        );
+        await app.waitUntilExit();
+
+        console.log();
+        process.exit(process.exitCode ?? 0);
+    });

--- a/src/commands/logout/status.test.ts
+++ b/src/commands/logout/status.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isTerminal, statusToRow } from "./status.js";
+import type { LogoutStatus } from "../../utils/auth.js";
+
+describe("isTerminal", () => {
+    const cases: Array<[LogoutStatus, boolean]> = [
+        [{ step: "disconnecting", address: "5Gxyz" }, false],
+        [{ step: "success", address: "5Gxyz" }, true],
+        [{ step: "partial", address: "5Gxyz", reason: "ws halted" }, true],
+        [{ step: "error", message: "boom" }, true],
+    ];
+
+    for (const [status, expected] of cases) {
+        it(`${status.step} → ${expected}`, () => {
+            expect(isTerminal(status)).toBe(expected);
+        });
+    }
+});
+
+describe("statusToRow", () => {
+    it("disconnecting shows the address being signed out", () => {
+        expect(statusToRow({ step: "disconnecting", address: "5Gxyz" })).toEqual({
+            mark: "run",
+            label: "sign out",
+            value: "5Gxyz",
+            tone: "muted",
+        });
+    });
+
+    it("success renders an ok mark with the address", () => {
+        expect(statusToRow({ step: "success", address: "5Gxyz" })).toEqual({
+            mark: "ok",
+            label: "signed out",
+            value: "5Gxyz",
+            tone: "muted",
+        });
+    });
+
+    it("partial surfaces the reason in the hint and the address in the value", () => {
+        const row = statusToRow({
+            step: "partial",
+            address: "5Gxyz",
+            reason: "ws halted",
+        });
+        expect(row.mark).toBe("warn");
+        expect(row.value).toBe("5Gxyz");
+        expect(row.tone).toBe("warning");
+        expect(row.hint).toContain("ws halted");
+        expect(row.hint).toContain("mobile app");
+    });
+
+    it("error renders the fail mark with the message as value", () => {
+        expect(statusToRow({ step: "error", message: "permission denied" })).toEqual({
+            mark: "fail",
+            label: "sign out failed",
+            value: "permission denied",
+            tone: "danger",
+        });
+    });
+});

--- a/src/commands/logout/status.ts
+++ b/src/commands/logout/status.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure mapping from a `LogoutStatus` to the props the <Row> primitive needs.
+ *
+ * Lives in its own file (not `.tsx`) so the test runner can import it without
+ * dragging React + Ink through vitest — same convention as `completion.ts`
+ * next to `InitScreen.tsx`.
+ */
+
+import type { LogoutStatus } from "../../utils/auth.js";
+import type { MarkKind, RowProps } from "../../utils/ui/theme/index.js";
+
+export interface RowSpec {
+    mark: MarkKind;
+    label: string;
+    value?: string;
+    hint?: string;
+    tone?: RowProps["tone"];
+}
+
+/** Terminal statuses = we're done, caller can unmount. */
+export function isTerminal(status: LogoutStatus): boolean {
+    return status.step === "success" || status.step === "partial" || status.step === "error";
+}
+
+export function statusToRow(status: LogoutStatus): RowSpec {
+    switch (status.step) {
+        case "disconnecting":
+            return {
+                mark: "run",
+                label: "sign out",
+                value: status.address,
+                tone: "muted",
+            };
+        case "success":
+            return {
+                mark: "ok",
+                label: "signed out",
+                value: status.address,
+                tone: "muted",
+            };
+        case "partial":
+            return {
+                mark: "warn",
+                label: "signed out locally",
+                value: status.address,
+                tone: "warning",
+                hint: `mobile app may still show this connection (${status.reason})`,
+            };
+        case "error":
+            return {
+                mark: "fail",
+                label: "sign out failed",
+                value: status.message,
+                tone: "danger",
+            };
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { initCommand } from "./commands/init/index.js";
 import { modCommand } from "./commands/mod/index.js";
 import { buildCommand } from "./commands/build.js";
 import { deployCommand } from "./commands/deploy/index.js";
+import { logoutCommand } from "./commands/logout/index.js";
 import { updateCommand } from "./commands/update.js";
 import { installSignalHandlers, onProcessShutdown } from "./utils/process-guard.js";
 import { clearWindowTitle } from "./utils/ui/theme/window-title.js";
@@ -49,6 +50,7 @@ program.addCommand(initCommand);
 program.addCommand(modCommand);
 program.addCommand(buildCommand);
 program.addCommand(deployCommand);
+program.addCommand(logoutCommand);
 program.addCommand(updateCommand);
 
 program.parseAsync().then(() => process.exit(0));

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -5,7 +5,17 @@
  * verify the patterns used rather than the full integration.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    clearLocalAppStorage,
+    waitForLogout,
+    type LogoutHandle,
+    type LogoutStatus,
+} from "./auth.js";
+import { DAPP_ID } from "../config.js";
 
 describe("subscribe-before-assignment pattern", () => {
     /**
@@ -102,5 +112,205 @@ describe("subscribe-before-assignment pattern", () => {
         });
 
         expect(resolutionCount).toBe(1);
+    });
+});
+
+// ── Sign-out flow ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimal stand-in for `@polkadot-apps/terminal`'s TerminalAdapter, wide enough
+ * for what `waitForLogout` actually touches. We don't import the real type here
+ * so the test file stays cheap to run; a compile error if the real API drifts
+ * is caught by the consuming call site in auth.ts, not here.
+ */
+type FakeResult<T, E> = { isOk(): true; value: T } | { isOk(): false; error: E };
+
+function okResult<T>(value: T): FakeResult<T, never> {
+    return { isOk: () => true as const, value };
+}
+
+function errResult<E>(error: E): FakeResult<never, E> {
+    return { isOk: () => false as const, error };
+}
+
+/** Fake session handle — only the fields `waitForLogout` reads. */
+function fakeSession() {
+    return {
+        id: "test-session-id",
+        localAccount: {} as never,
+        remoteAccount: {} as never,
+    };
+}
+
+interface FakeAdapter {
+    destroyCalls: number;
+    sessions: {
+        disconnect(session: ReturnType<typeof fakeSession>): PromiseLike<FakeResult<void, Error>>;
+    };
+    destroy(): void;
+}
+
+function fakeAdapter(
+    disconnect: (session: ReturnType<typeof fakeSession>) => PromiseLike<FakeResult<void, Error>>,
+): FakeAdapter {
+    const adapter: FakeAdapter = {
+        destroyCalls: 0,
+        sessions: { disconnect },
+        destroy() {
+            adapter.destroyCalls++;
+        },
+    };
+    return adapter;
+}
+
+describe("waitForLogout", () => {
+    let appsDir: string;
+    let originalHome: string | undefined;
+
+    beforeEach(() => {
+        // Redirect `~/.polkadot-apps` to a tmp dir so the clearLocalAppStorage
+        // fallback can't touch the dev's real logged-in account.
+        appsDir = mkdtempSync(join(tmpdir(), "pg-logout-test-"));
+        originalHome = process.env.HOME;
+        process.env.HOME = appsDir;
+    });
+
+    afterEach(() => {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+        rmSync(appsDir, { recursive: true, force: true });
+    });
+
+    it("emits disconnecting → success and destroys the adapter on happy path", async () => {
+        const adapter = fakeAdapter(() => Promise.resolve(okResult(undefined)));
+        const handle = {
+            adapter,
+            address: "5Gxyz",
+            session: fakeSession(),
+        } as unknown as LogoutHandle;
+        const events: LogoutStatus[] = [];
+
+        await waitForLogout(handle, (s) => events.push(s));
+
+        expect(events).toEqual([
+            { step: "disconnecting", address: "5Gxyz" },
+            { step: "success", address: "5Gxyz" },
+        ]);
+        expect(adapter.destroyCalls).toBe(1);
+    });
+
+    it("falls back to local clear and emits partial when disconnect returns err", async () => {
+        // Seed a stale session file so we can verify the fallback actually deletes it.
+        const staleDir = join(appsDir, ".polkadot-apps");
+        const { mkdirSync } = await import("node:fs");
+        mkdirSync(staleDir, { recursive: true });
+        const staleFile = join(staleDir, `${DAPP_ID}_SsoSessions.json`);
+        const foreignFile = join(staleDir, "other-app_SsoSessions.json");
+        writeFileSync(staleFile, "stale");
+        writeFileSync(foreignFile, "leave-me-alone");
+
+        const adapter = fakeAdapter(() => Promise.resolve(errResult(new Error("ws halted"))));
+        const handle = {
+            adapter,
+            address: "5Gxyz",
+            session: fakeSession(),
+        } as unknown as LogoutHandle;
+        const events: LogoutStatus[] = [];
+
+        await waitForLogout(handle, (s) => events.push(s));
+
+        expect(events).toEqual([
+            { step: "disconnecting", address: "5Gxyz" },
+            { step: "partial", address: "5Gxyz", reason: "ws halted" },
+        ]);
+        expect(adapter.destroyCalls).toBe(1);
+        expect(existsSync(staleFile)).toBe(false);
+        // Foreign app's files MUST remain untouched.
+        expect(existsSync(foreignFile)).toBe(true);
+    });
+
+    it("falls back to local clear when disconnect throws", async () => {
+        const adapter = fakeAdapter(() => {
+            throw new Error("connection refused");
+        });
+        const handle = {
+            adapter,
+            address: "5Gxyz",
+            session: fakeSession(),
+        } as unknown as LogoutHandle;
+        const events: LogoutStatus[] = [];
+
+        await waitForLogout(handle, (s) => events.push(s));
+
+        expect(events).toEqual([
+            { step: "disconnecting", address: "5Gxyz" },
+            { step: "partial", address: "5Gxyz", reason: "connection refused" },
+        ]);
+        expect(adapter.destroyCalls).toBe(1);
+    });
+
+    it("emits a generic err message for non-Error throws", async () => {
+        const adapter = fakeAdapter(() => {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw "string rejection";
+        });
+        const handle = {
+            adapter,
+            address: "5Gxyz",
+            session: fakeSession(),
+        } as unknown as LogoutHandle;
+        const events: LogoutStatus[] = [];
+
+        await waitForLogout(handle, (s) => events.push(s));
+
+        expect(events[1]).toEqual({
+            step: "partial",
+            address: "5Gxyz",
+            reason: "string rejection",
+        });
+    });
+});
+
+describe("clearLocalAppStorage", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "pg-clear-storage-"));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("is a no-op when the directory does not exist", async () => {
+        const missing = join(dir, "does-not-exist");
+        await expect(clearLocalAppStorage(missing)).resolves.toBeUndefined();
+    });
+
+    it("removes only files prefixed with `${DAPP_ID}_`", async () => {
+        const ours1 = join(dir, `${DAPP_ID}_SsoSessions.json`);
+        const ours2 = join(dir, `${DAPP_ID}_UserSecrets_abc.json`);
+        const foreign = join(dir, "polkadot-desktop_SsoSessions.json");
+        const looksSimilar = join(dir, `${DAPP_ID}.backup`);
+        writeFileSync(ours1, "a");
+        writeFileSync(ours2, "b");
+        writeFileSync(foreign, "c");
+        writeFileSync(looksSimilar, "d");
+
+        await clearLocalAppStorage(dir);
+
+        expect(existsSync(ours1)).toBe(false);
+        expect(existsSync(ours2)).toBe(false);
+        expect(existsSync(foreign)).toBe(true);
+        // `${DAPP_ID}.backup` lacks the underscore → safe.
+        expect(existsSync(looksSimilar)).toBe(true);
+    });
+
+    it("swallows unlink errors so callers stay on the happy path", async () => {
+        // Nothing to delete → nothing to error on, but the promise must resolve.
+        await expect(clearLocalAppStorage(dir)).resolves.toBeUndefined();
     });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -6,8 +6,13 @@
  *   2. Print QR code to stdout (if needed) — before Ink mounts
  *   3. `waitForLogin()` — awaits the already-running auth to complete
  *   4. `getSessionSigner()` — gets a working signer for tx signing (separate adapter)
+ *   5. `findSession()` / `waitForLogout()` — sign out flow, mirror image of connect/waitForLogin
  */
 
+import type { Dirent } from "node:fs";
+import { readdir, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { ss58Encode } from "@polkadot-apps/address";
 import {
     createTerminalAdapter,
@@ -16,6 +21,7 @@ import {
     type TerminalAdapter,
     type PairingStatus,
     type AttestationStatus,
+    type StoredUserSession,
 } from "@polkadot-apps/terminal";
 import { createTxSigner } from "./session-signer-patch.js";
 import type { PolkadotSigner } from "polkadot-api";
@@ -213,4 +219,128 @@ export async function getSessionSigner(): Promise<SessionHandle | null> {
     };
 
     return { address, signer, destroy };
+}
+
+// ── Sign-out flow ─────────────────────────────────────────────────────────────
+//
+// Mirror image of connect() + waitForLogin(). `findSession()` does the I/O to
+// decide if there's anything to sign out of; `waitForLogout()` performs the
+// disconnect and takes ownership of the adapter's `destroy()`.
+
+export type LogoutStatus =
+    | { step: "disconnecting"; address: string }
+    | { step: "success"; address: string }
+    | { step: "partial"; address: string; reason: string }
+    | { step: "error"; message: string };
+
+export interface LogoutHandle {
+    adapter: TerminalAdapter;
+    address: string;
+    session: StoredUserSession;
+}
+
+/**
+ * Look up the currently paired session, if any.
+ *
+ * Returns a handle ready for `waitForLogout()`, or `null` when no session is
+ * signed in. On the null path the adapter is destroyed here so callers don't
+ * have to care.
+ */
+export async function findSession(): Promise<LogoutHandle | null> {
+    const adapter = createAdapter();
+    const sessions = await waitForSessions(adapter, 3000);
+    if (sessions.length === 0) {
+        adapter.destroy();
+        return null;
+    }
+    const session = sessions[0];
+    const pubkey = new Uint8Array(session.remoteAccount.accountId);
+    const address = ss58Encode(pubkey);
+    return { adapter, address, session };
+}
+
+/**
+ * Disconnect the given session. Reports progress via callback.
+ *
+ * Happy path: `adapter.sessions.disconnect()` sends a `Disconnected` statement
+ * so the paired mobile app drops its side of the connection, then clears the
+ * local session + user-secret files.
+ *
+ * If the remote notification fails (statement store unreachable, WebSocket
+ * torn down, …) we fall back to deleting the `${DAPP_ID}_*` files in
+ * `~/.polkadot-apps/` directly — strictly narrower than `rm -rf ~/.polkadot-apps`
+ * and keeps the user unblocked. The mobile app will show a stale pairing
+ * until it reconnects, which we surface via `partial`.
+ *
+ * Always releases the adapter before returning.
+ */
+export async function waitForLogout(
+    handle: LogoutHandle,
+    onStatus: (status: LogoutStatus) => void,
+): Promise<void> {
+    const { adapter, address, session } = handle;
+
+    // Everything that can throw — including the consumer's onStatus — lives
+    // inside this try so the finally is guaranteed to run and release the
+    // WebSocket. Losing the destroy() would turn the CLI into a zombie.
+    try {
+        onStatus({ step: "disconnecting", address });
+        const result = await adapter.sessions.disconnect(session);
+        if (result.isOk()) {
+            onStatus({ step: "success", address });
+            return;
+        }
+        const reason = result.error.message || "remote unreachable";
+        await clearLocalAppStorage();
+        onStatus({ step: "partial", address, reason });
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        try {
+            await clearLocalAppStorage();
+            onStatus({ step: "partial", address, reason });
+        } catch (cleanupErr) {
+            const msg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+            onStatus({ step: "error", message: msg });
+        }
+    } finally {
+        try {
+            adapter.destroy();
+        } catch {
+            // best-effort
+        }
+    }
+}
+
+/**
+ * Best-effort removal of this app's persisted state under `~/.polkadot-apps/`.
+ *
+ * Scoped by `${DAPP_ID}_` prefix so files belonging to other polkadot apps
+ * sharing the directory (e.g. polkadot-desktop, other CLI tools) are left
+ * alone. Errors are swallowed — this is a fallback, not a guarantee.
+ *
+ * Exported for tests; not part of the public API.
+ * @internal
+ */
+export async function clearLocalAppStorage(
+    dir: string = join(homedir(), ".polkadot-apps"),
+): Promise<void> {
+    // @polkadot-apps/terminal's node-storage only writes flat `${appId}_${key}.json`
+    // files, never subdirectories. Filter by isFile() anyway so a future change
+    // up-stack (or an unrelated user stash) can't trip this helper.
+    let entries: Dirent[];
+    try {
+        entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+        return;
+    }
+    const prefix = `${DAPP_ID}_`;
+    await Promise.all(
+        entries
+            .filter((entry) => entry.isFile() && entry.name.startsWith(prefix))
+            .map((entry) =>
+                unlink(join(dir, entry.name)).catch(() => {
+                    // best-effort
+                }),
+            ),
+    );
 }


### PR DESCRIPTION
## Summary

- Adds `dot logout` — signs the user out of the host account paired via `dot init` without having to `rm -rf ~/.polkadot-apps`.
- Uses the terminal SDK's `adapter.sessions.disconnect(session)` so the paired mobile app drops its side of the connection too, not just the local CLI.
- Falls back to a best-effort local cleanup — scoped strictly to files prefixed with `dot-cli_` in `~/.polkadot-apps/` — when the statement store is unreachable. Narrower than `rm -rf`; never touches files owned by other polkadot apps on the same machine.

## Structure

Mirrors the repo's existing SDK/TUI split so the feature drops in cleanly and is trivial to remove later:

- **SDK** (`src/utils/auth.ts`): three new exports alongside `connect()`/`waitForLogin()`/`getSessionSigner()` — `findSession()`, `waitForLogout()`, plus an `@internal` `clearLocalAppStorage()` used by the fallback.
- **TUI** (`src/commands/logout/`): mirrors `src/commands/init/`'s shape — `index.ts` (Commander wiring) + `LogoutScreen.tsx` (orchestrator) + `LogoutStatus.tsx` (presentational row) + `status.ts` (pure Ink-free status→row mapping) + `status.test.ts`.

## Notes

- Adapter lifecycle: `waitForLogout()` owns `adapter.destroy()` and wraps the whole body in a `try/finally`, so every control-flow path (including a throwing `onStatus` callback) releases the WebSocket. Matches the CLAUDE.md invariant that long-lived terminal adapters must always be destroyed.
- No new flags, no confirmation prompt, no alias. `logout` matches the convention used by `gh`, `docker`, `firebase`, `vercel`, `heroku`.
- Dev-mode session keys in `~/.polkadot/accounts.json` are deliberately untouched — out of scope for "host account" logout.

## Test plan

- [x] `pnpm test` — 347 tests pass (6 new cases in `auth.test.ts` covering happy path, err-result fallback, thrown-error fallback, non-Error throws, missing dir, and `dot-cli_` prefix scoping + foreign-file preservation; 8 cases in `status.test.ts` covering every `LogoutStatus` variant and `isTerminal`)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run build` — `bun build --compile` succeeds
- [x] `./dist/dot --help` — `logout` surfaces in the command list
- [x] `./dist/dot logout --help` — description renders
- [ ] Manual: run `dot logout` against a real paired session on Paseo, confirm the mobile app drops the connection
- [ ] Manual: run `dot logout` with the People chain unreachable, confirm `partial` status fires and local files are cleared
- [ ] Manual: run `dot logout` with no session signed in, confirm `No account is signed in.` and exit 0