### PR TITLE
feat(deploy): add --manifest for machine-readable deploy output

### DIFF
--- a/.changeset/deploy-manifest-output.md
+++ b/.changeset/deploy-manifest-output.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+Add `dot deploy --manifest <path>` to write a machine-readable JSON manifest on successful deploy (versioned; contains domain, app URL, CIDs, and deployed contract addresses). Also fixes a display gap: deployed contract addresses are now shown in the final summary of both the TUI and the headless (`--signer … --domain … --buildDir … --playground`) output — previously they were computed and discarded.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,23 @@ Flags:
 - `--playground` — publish to the playground registry so the app appears under "my apps". Interactive prompt (default: no) if omitted.
 - `--suri <suri>` — override signer with a dev secret URI (e.g. `//Alice`). Useful for CI.
 - `--env <env>` — `testnet` (default) or `mainnet` (not yet supported).
+- `--manifest <path>` — on success, write a JSON manifest with the domain, app URL, CIDs, and deployed contract addresses to `<path>`. Directory is created if needed. Intended for CI / template generators / downstream tooling that needs the deployment output without parsing the TUI.
 
 Passing all four of `--signer`, `--domain`, `--buildDir`, and `--playground` runs in fully non-interactive mode. Any absent flag is filled in by the TUI prompt.
+
+The manifest format is versioned (`{ "version": 1, ... }`) — field names mirror the final TUI summary:
+
+```json
+{
+    "version": 1,
+    "fullDomain": "my-app.dot",
+    "appUrl": "https://my-app.dot.li",
+    "appCid": "bafy…",
+    "ipfsCid": "bafy…",
+    "metadataCid": "bafy…",
+    "contracts": [{ "name": "ProofOfExistence", "address": "0x…" }]
+}
+```
 
 **Requirement**: the `ipfs` CLI (Kubo) must be on `PATH`. `dot init` installs it; if you skipped init you can install it manually (`brew install ipfs` or follow [docs.ipfs.tech/install](https://docs.ipfs.tech/install/)). This is a temporary requirement while `bulletin-deploy`'s pure-JS merkleizer has a bug that makes the browser fallback unusable.
 

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -883,6 +883,9 @@ function FinalResult({
                     {outcome.metadataCid && (
                         <Row label="metadata cid" value={outcome.metadataCid} />
                     )}
+                    {outcome.contracts.map((c) => (
+                        <Row key={c.address} label={c.name} value={c.address} />
+                    ))}
                 </Section>
             </Box>
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -28,6 +28,7 @@ import { loadDetectInput } from "../../utils/build/runner.js";
 import { readSessionAccount, SESSION_MIN_BALANCE } from "../../utils/deploy/session-account.js";
 import { checkBalance } from "../../utils/account/funding.js";
 import { DEFAULT_BUILD_DIR, type Env } from "../../config.js";
+import { buildManifest, writeManifest } from "../../utils/deploy/manifest.js";
 
 interface DeployOpts {
     suri?: string;
@@ -48,6 +49,12 @@ interface DeployOpts {
     env?: Env;
     /** Project root. Hidden — defaults to cwd. */
     dir?: string;
+    /**
+     * Write a machine-readable deploy manifest (JSON) to this path on success.
+     * Intended for downstream tooling (CIs, template generators) that needs
+     * the deployed contract addresses and CIDs without parsing the TUI.
+     */
+    manifest?: string;
 }
 
 export const deployCommand = new Command("deploy")
@@ -77,6 +84,10 @@ export const deployCommand = new Command("deploy")
             .default("testnet"),
     )
     .option("--dir <path>", "Project directory", process.cwd())
+    .option(
+        "--manifest <path>",
+        "Write a JSON deploy manifest (domain, CIDs, contract addresses) to this path on success",
+    )
     .action(async (opts: DeployOpts) => {
         const projectDir = resolve(opts.dir ?? process.cwd());
         const env: Env = (opts.env as Env) ?? "testnet";
@@ -128,10 +139,26 @@ export const deployCommand = new Command("deploy")
 
         try {
             const nonInteractive = isFullySpecified(opts);
-            if (nonInteractive) {
-                await runHeadless({ projectDir, env, userSigner, opts });
-            } else {
-                await runInteractive({ projectDir, env, userSigner, opts });
+            const outcome = nonInteractive
+                ? await runHeadless({ projectDir, env, userSigner, opts })
+                : await runInteractive({ projectDir, env, userSigner, opts });
+
+            // Emit the machine-readable manifest after a successful deploy.
+            // Done here (outside both dispatch branches) so the format is
+            // identical whether the user ran the TUI or passed every flag.
+            if (outcome && opts.manifest) {
+                const manifestPath = resolve(opts.manifest);
+                try {
+                    writeManifest(manifestPath, buildManifest(outcome));
+                    process.stdout.write(`  Manifest    ${manifestPath}\n\n`);
+                } catch (err) {
+                    // Don't fail the deploy just because we couldn't write the
+                    // manifest — the on-chain work is already done. Surface the
+                    // write failure clearly on stderr so callers notice.
+                    process.stderr.write(
+                        `\n⚠ Deploy succeeded but failed to write manifest to ${manifestPath}: ${formatError(err)}\n`,
+                    );
+                }
             }
         } catch (err) {
             process.stderr.write(`\n✖ ${formatError(err)}\n`);
@@ -234,7 +261,7 @@ async function runHeadless(ctx: {
     env: Env;
     userSigner: ResolvedSigner | null;
     opts: DeployOpts;
-}) {
+}): Promise<DeployOutcome> {
     const mode = ctx.opts.signer as SignerMode;
     const publishToPlayground = Boolean(ctx.opts.playground);
     const domain = ctx.opts.domain as string;
@@ -308,6 +335,7 @@ async function runHeadless(ctx: {
     });
 
     printFinalResult(outcome);
+    return outcome;
 }
 
 /** Best-effort contract-project detection; null on any I/O error. */
@@ -346,7 +374,7 @@ function runInteractive(ctx: {
     env: Env;
     userSigner: ResolvedSigner | null;
     opts: DeployOpts;
-}): Promise<void> {
+}): Promise<DeployOutcome> {
     const contractsType = safeDetectContractsType(ctx.projectDir);
     return new Promise((resolvePromise, rejectPromise) => {
         let settled = false;
@@ -373,7 +401,7 @@ function runInteractive(ctx: {
                         process.exitCode = 1;
                         rejectPromise(new Error("Deploy was cancelled or failed."));
                     } else {
-                        resolvePromise();
+                        resolvePromise(outcome);
                     }
                 },
             }),
@@ -428,6 +456,9 @@ function printFinalResult(outcome: DeployOutcome) {
     process.stdout.write(`  App CID     ${outcome.appCid}\n`);
     if (outcome.ipfsCid) process.stdout.write(`  IPFS CID    ${outcome.ipfsCid}\n`);
     if (outcome.metadataCid) process.stdout.write(`  Metadata CID ${outcome.metadataCid}\n`);
+    for (const contract of outcome.contracts) {
+        process.stdout.write(`  ${contract.name.padEnd(11)} ${contract.address}\n`);
+    }
     process.stdout.write("\n");
 }
 

--- a/src/utils/deploy/manifest.test.ts
+++ b/src/utils/deploy/manifest.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildManifest, writeManifest, type DeployManifest } from "./manifest.js";
+import type { DeployOutcome } from "./run.js";
+
+const baseOutcome: DeployOutcome = {
+    fullDomain: "my-app.dot",
+    appCid: "bafybeiexampleappcid",
+    ipfsCid: "bafybeiexampleipfscid",
+    metadataCid: "bafybeiexamplemetadatacid",
+    appUrl: "https://my-app.dot.li",
+    approvalsRequested: [],
+    contracts: [
+        {
+            name: "ProofOfExistence",
+            address: "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`,
+        },
+        {
+            name: "Counter",
+            address: "0xabcdef1234567890abcdef1234567890abcdef12" as `0x${string}`,
+        },
+    ],
+};
+
+describe("buildManifest", () => {
+    it("carries all outcome fields into a versioned manifest", () => {
+        const manifest = buildManifest(baseOutcome);
+
+        expect(manifest.version).toBe(1);
+        expect(manifest.fullDomain).toBe("my-app.dot");
+        expect(manifest.appUrl).toBe("https://my-app.dot.li");
+        expect(manifest.appCid).toBe("bafybeiexampleappcid");
+        expect(manifest.ipfsCid).toBe("bafybeiexampleipfscid");
+        expect(manifest.metadataCid).toBe("bafybeiexamplemetadatacid");
+        expect(manifest.contracts).toEqual([
+            {
+                name: "ProofOfExistence",
+                address: "0x1234567890abcdef1234567890abcdef12345678",
+            },
+            { name: "Counter", address: "0xabcdef1234567890abcdef1234567890abcdef12" },
+        ]);
+    });
+
+    it("omits ipfsCid and metadataCid when they are undefined (stable JSON)", () => {
+        const manifest = buildManifest({
+            ...baseOutcome,
+            ipfsCid: undefined,
+            metadataCid: undefined,
+        });
+
+        expect("ipfsCid" in manifest).toBe(false);
+        expect("metadataCid" in manifest).toBe(false);
+    });
+
+    it("produces an empty contracts array when no contracts were deployed", () => {
+        const manifest = buildManifest({ ...baseOutcome, contracts: [] });
+        expect(manifest.contracts).toEqual([]);
+    });
+
+    it("preserves contract order from the outcome", () => {
+        const manifest = buildManifest(baseOutcome);
+        expect(manifest.contracts.map((c) => c.name)).toEqual(["ProofOfExistence", "Counter"]);
+    });
+});
+
+describe("writeManifest", () => {
+    let tmp: string;
+
+    beforeEach(() => {
+        tmp = mkdtempSync(join(tmpdir(), "pg-manifest-"));
+    });
+
+    afterEach(() => {
+        rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it("writes valid JSON with a trailing newline that round-trips", () => {
+        const path = join(tmp, "deploy.json");
+        const manifest = buildManifest(baseOutcome);
+        writeManifest(path, manifest);
+
+        const raw = readFileSync(path, "utf8");
+        expect(raw.endsWith("\n")).toBe(true);
+        const parsed: DeployManifest = JSON.parse(raw);
+        expect(parsed).toEqual(manifest);
+    });
+
+    it("creates parent directories if they don't exist", () => {
+        const path = join(tmp, "nested", "deep", "deploy.json");
+        const manifest = buildManifest(baseOutcome);
+        writeManifest(path, manifest);
+
+        expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(manifest);
+    });
+});

--- a/src/utils/deploy/manifest.ts
+++ b/src/utils/deploy/manifest.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { HexString } from "polkadot-api";
+import type { DeployOutcome } from "./run.js";
+
+/**
+ * Machine-readable manifest emitted at the end of `dot deploy` when
+ * `--manifest <path>` is set. Stable, versioned contract for downstream
+ * tooling (CIs, template generators, package scripts) that wants to pick up
+ * deployed contract addresses and CIDs without parsing the TUI.
+ */
+export interface DeployManifest {
+    /** Schema version; bump on any breaking change to field names/semantics. */
+    version: 1;
+    /** Canonical `<label>.dot` name. */
+    fullDomain: string;
+    /** Resolvable URL the app is live at. */
+    appUrl: string;
+    /** Bulletin Chain CID of the app bundle. */
+    appCid: string;
+    /** IPFS CID of the directory root, if computed. */
+    ipfsCid?: string;
+    /** Metadata CID when the deploy also published to Playground. */
+    metadataCid?: string;
+    /** Deployed contracts, in the order they were compiled and deployed. */
+    contracts: Array<{ name: string; address: HexString }>;
+}
+
+export function buildManifest(outcome: DeployOutcome): DeployManifest {
+    const manifest: DeployManifest = {
+        version: 1,
+        fullDomain: outcome.fullDomain,
+        appUrl: outcome.appUrl,
+        appCid: outcome.appCid,
+        contracts: outcome.contracts.map((c) => ({ name: c.name, address: c.address })),
+    };
+    if (outcome.ipfsCid !== undefined) manifest.ipfsCid = outcome.ipfsCid;
+    if (outcome.metadataCid !== undefined) manifest.metadataCid = outcome.metadataCid;
+    return manifest;
+}
+
+/** Write a manifest to disk, creating parent directories as needed. */
+export function writeManifest(path: string, manifest: DeployManifest): void {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+}


### PR DESCRIPTION
## Summary

- **Adds `dot deploy --manifest <path>`** — writes a versioned JSON manifest on success with domain, app URL, CIDs, and deployed contract addresses
- **Fixes a display gap**: deployed contracts were silently dropped from the final summary in both the TUI and the headless output even though the orchestrator already collected them
- **New module** `src/utils/deploy/manifest.ts` (React/Ink-free per the SDK invariant) + 6 tests

## Why

`dot deploy --contracts` deploys contracts to Asset Hub and the orchestrator already knows their addresses — `DeployOutcome.contracts: Array<{ name; address }>` is populated by `maybeRunContracts` in `run.ts`. But nothing crossed the process boundary:

- The TUI `FinalResult` component only rendered URL / domain / appCid / ipfsCid / metadataCid.
- The headless `printFinalResult` printed the same set; no contracts line.
- There was no JSON / manifest output of any kind.

Downstream tooling (template generators, CIs that wire contract addresses into a frontend build) had two bad options:
1. Parse the Ink TUI — fragile, shouldn't be a contract.
2. Re-query the chain for `Revive.Instantiated` events from the deployer's address and disambiguate by code hash — requires re-deriving what the CLI already had.

Every comparable Solidity deploy tool writes a deployment manifest as a standard part of its flow: `hardhat-deploy` writes `deployments/<network>/<name>.json`, Hardhat Ignition writes `ignition/deployments/<id>/deployed_addresses.json`, Foundry writes `broadcast/<Script>.s.sol/<chainId>/run-latest.json`. Ignition is the closest precedent — also a CLI, also has to expose state across a process boundary — and its manifest shape is what this PR models on.

## Manifest shape

```json
{
    "version": 1,
    "fullDomain": "my-app.dot",
    "appUrl": "https://my-app.dot.li",
    "appCid": "bafy…",
    "ipfsCid": "bafy…",
    "metadataCid": "bafy…",
    "contracts": [{ "name": "ProofOfExistence", "address": "0x…" }]
}
```

`ipfsCid` and `metadataCid` are omitted (not `null`) when absent, so schema consumers can rely on `in` checks. Versioned so future shape changes are non-breaking additions or get a `version: 2` bump.

## Error behaviour

If the manifest write fails (e.g. unwritable path), we log a warning to stderr but do **not** fail the deploy — the on-chain work is done by the time we write, so blowing up the exit code would mislead CI into retrying a deploy that actually succeeded.

## Changes

| File | What |
|---|---|
| `src/utils/deploy/manifest.ts` | New — `DeployManifest` type, `buildManifest`, `writeManifest`. Stays React/Ink-free per the deploy-SDK invariant. |
| `src/utils/deploy/manifest.test.ts` | New — 6 tests covering field carry-through, absent-field omission, order preservation, round-trip, nested directory creation. |
| `src/commands/deploy/index.ts` | Adds `--manifest` option; both dispatch branches (`runHeadless` + `runInteractive`) now return `DeployOutcome` so the write happens in one place, identically, regardless of how the user invoked `dot deploy`. `printFinalResult` also now prints the deployed contracts. |
| `src/commands/deploy/DeployScreen.tsx` | `FinalResult` now lists `{ name: address }` rows for each deployed contract. |
| `README.md` | Documents `--manifest` with the format. |
| `.changeset/deploy-manifest-output.md` | `minor` changeset. |

## Test plan

- [x] `pnpm format:check` clean
- [x] `npx tsc --noEmit` clean
- [x] `pnpm test` — 353 passed (up from 347; +6 for manifest)
- [x] `pnpm build` — `bun build --compile` produces `./dist/dot`
- [ ] Manual smoke: `dot deploy --signer dev --domain test-xx --buildDir dist --manifest /tmp/deploy.json` in a hardhat project, verify `/tmp/deploy.json` contains the two deployed contracts