### PR TITLE
remove upstream remote to simplify git commands on user side

### DIFF
--- a/.changeset/fork-remove-upstream.md
+++ b/.changeset/fork-remove-upstream.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`dot mod` no longer leaves an `upstream` remote behind after fork+clone, so `git checkout quest/level-N` (and the commands printed by tutorial `setup.sh` scripts) work without `--track origin/<name>` workarounds.

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -63,7 +63,14 @@ export async function forkAndClone(
     const args = ["repo", "fork", repo, "--clone", "--fork-name", targetDir];
     if (options?.branch) args.push("--", "--branch", options.branch);
     await spawn("gh", args, { log: options?.log });
-    await spawn("git", ["remote", "remove", "upstream"], { cwd: targetDir, log: options?.log });
+    // gh repo fork --clone registers the upstream as a second remote, which makes
+    // `git checkout <branch>` ambiguous when the same branches exist on the fork.
+    // Tolerate a missing remote so a fork+clone that already succeeded isn't
+    // marked failed by a stray non-zero exit here.
+    await spawn("git", ["remote", "remove", "upstream"], {
+        cwd: targetDir,
+        log: options?.log,
+    }).catch(() => {});
 }
 
 /** Clone a repo with fresh git history. Streams git output to log. */

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -63,6 +63,7 @@ export async function forkAndClone(
     const args = ["repo", "fork", repo, "--clone", "--fork-name", targetDir];
     if (options?.branch) args.push("--", "--branch", options.branch);
     await spawn("gh", args, { log: options?.log });
+    await spawn("git", ["remote", "remove", "upstream"], { cwd: targetDir, log: options?.log });
 }
 
 /** Clone a repo with fresh git history. Streams git output to log. */


### PR DESCRIPTION
Remove upstream repo after fork, so user doesn't need to deal with multiple origins.