### PR TITLE
feat(mod): keep setup.sh output visible and tee full log to file

### DIFF
--- a/.changeset/setup-sh-output-visible.md
+++ b/.changeset/setup-sh-output-visible.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+`dot mod` now keeps the tail of `setup.sh` visible after the step completes — the script's "next steps" / quest progression / doc pointers no longer disappear when the step turns green. The full unfiltered output is also tee'd to `<targetDir>/.dot-mod-setup.log` for any output that doesn't fit the on-screen tail. The generic "edit with claude / dot deploy" footer now only prints when the app didn't ship a `setup.sh`.

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { Box } from "ink";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getGateway, fetchJson } from "@polkadot-apps/bulletin";
 import { StepRunner, type Step } from "../../utils/ui/components/StepRunner.js";
@@ -75,6 +75,7 @@ export function SetupScreen({
                 }
                 stripPostinstall(targetDir);
                 writeDotJson(targetDir, meta.name ?? domain.replace(/\.dot$/, ""), meta);
+                ignoreModSetupLog(targetDir);
             },
         },
         {
@@ -135,6 +136,27 @@ function stripPostinstall(dir: string) {
             writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
         }
     } catch {}
+}
+
+/**
+ * Append `.dot-mod-setup.log` to the cloned repo's `.gitignore` so the per-run
+ * setup log we tee for the user can't be accidentally committed. Idempotent —
+ * checks for an existing entry before writing, and creates the file if it
+ * doesn't yet exist.
+ */
+function ignoreModSetupLog(dir: string) {
+    const entry = ".dot-mod-setup.log";
+    const path = resolve(dir, ".gitignore");
+    try {
+        const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+        const lines = existing.split("\n").map((l) => l.trim());
+        if (lines.includes(entry)) return;
+        const prefix = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+        appendFileSync(path, `${prefix}${entry}\n`);
+    } catch {
+        // best-effort — if we can't write .gitignore (perms etc.) the log
+        // file still works, the user just needs to ignore it manually.
+    }
 }
 
 function writeDotJson(dir: string, name: string, meta: AppMetadata) {

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Box } from "ink";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -23,7 +23,7 @@ interface Props {
     registry: any;
     targetDir: string;
     canFork: boolean;
-    onDone: (ok: boolean) => void;
+    onDone: (result: { ok: boolean; setupRan: boolean }) => void;
 }
 
 export function SetupScreen({
@@ -36,6 +36,15 @@ export function SetupScreen({
 }: Props) {
     // Metadata is fetched in step 1 and shared with later steps via this ref
     let meta: AppMetadata = initial ?? {};
+    // Tracks whether `setup.sh` actually ran to completion in this session.
+    // Used by the parent to decide whether to print the generic "Next steps"
+    // fallback footer (only when there was no script-provided footer).
+    // Lives in a ref because StepRunner captures `onDone` once on mount —
+    // a useState value would be stale by the time the runner reports back.
+    // The matching `Hint` is driven off the state setter for re-render.
+    const setupRanRef = useRef(false);
+    const [setupRanVisible, setSetupRanVisible] = useState(false);
+    const logFile = resolve(targetDir, ".dot-mod-setup.log");
 
     const steps: Step[] = [
         {
@@ -70,11 +79,14 @@ export function SetupScreen({
         },
         {
             name: "run setup.sh",
+            keepLogOnSuccess: true,
             run: async (log) => {
                 if (!existsSync(resolve(targetDir, "setup.sh"))) {
                     throw new StepWarning("no setup.sh found");
                 }
-                await runCommand("bash setup.sh", { cwd: targetDir, log });
+                await runCommand("bash setup.sh", { cwd: targetDir, log, logFile });
+                setupRanRef.current = true;
+                setSetupRanVisible(true);
             },
         },
     ];
@@ -90,11 +102,12 @@ export function SetupScreen({
                 steps={steps}
                 onDone={(result) => {
                     if (result.error) setError(result.error);
-                    onDone(result.ok);
+                    onDone({ ok: result.ok, setupRan: setupRanRef.current });
                 }}
             />
 
             <Hint>→ {targetDir}</Hint>
+            {setupRanVisible && <Hint>full setup log: {logFile}</Hint>}
 
             {error && (
                 <Section>

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -49,7 +49,7 @@ export const modCommand = new Command("mod")
                 });
                 if (!targetDir) return;
 
-                const ok = await runSetup({
+                const { ok, setupRan } = await runSetup({
                     domain,
                     metadata: metadata
                         ? {
@@ -64,7 +64,11 @@ export const modCommand = new Command("mod")
                 });
 
                 console.log();
-                if (ok) {
+                // When `setup.sh` ran, the StepRunner already showed the
+                // script's own "next steps" footer (and the path to the full
+                // log). Only emit the generic fallback when the app didn't
+                // ship a setup.sh.
+                if (ok && !setupRan) {
                     console.log("  Next steps:");
                     console.log(`  1. cd ${targetDir}`);
                     console.log("  2. edit with claude");
@@ -153,14 +157,14 @@ function runSetup(props: {
     registry: any;
     targetDir: string;
     canFork: boolean;
-}): Promise<boolean> {
+}): Promise<{ ok: boolean; setupRan: boolean }> {
     return new Promise((resolve) => {
         const app = render(
             React.createElement(SetupScreen, {
                 ...props,
-                onDone: (ok: boolean) => {
+                onDone: (result: { ok: boolean; setupRan: boolean }) => {
                     app.unmount();
-                    resolve(ok);
+                    resolve(result);
                 },
             }),
         );

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -120,4 +120,16 @@ describe("runCommand log-file tee", () => {
         ).rejects.toThrow();
         expect(readFileSync(logFile, "utf-8")).toContain("before-fail");
     });
+
+    it("still calls the log callback when logFile is provided", async () => {
+        const logFile = join(dir, "out.log");
+        const lines: string[] = [];
+        await runCommand("printf 'a\\nb\\n'", {
+            cwd: dir,
+            logFile,
+            log: (l) => lines.push(l),
+        });
+        expect(lines).toEqual(["a", "b"]);
+        expect(readFileSync(logFile, "utf-8")).toBe("a\nb\n");
+    });
 });

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -7,7 +7,11 @@
  * mocked child_process is brittle and low-value.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCommand } from "./git.js";
 
 // sanitize is not exported, so we test it indirectly by importing the module
 // and calling a function that uses it. Instead, let's extract the regex and
@@ -72,5 +76,48 @@ describe("sanitize", () => {
     it("strips compound SGR parameters", () => {
         // [38;5;196m = 256-color red
         expect(sanitize("\x1B[38;5;196mred\x1B[0m")).toBe("red");
+    });
+});
+
+describe("runCommand log-file tee", () => {
+    let dir: string;
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "dot-runcmd-"));
+    });
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("writes stdout to logFile when provided", async () => {
+        const logFile = join(dir, "out.log");
+        await runCommand("printf 'hello\\nworld\\n'", { cwd: dir, logFile });
+        expect(readFileSync(logFile, "utf-8")).toBe("hello\nworld\n");
+    });
+
+    it("captures both stdout and stderr in order", async () => {
+        const logFile = join(dir, "out.log");
+        // Print one line to stdout, one to stderr. Order between streams isn't
+        // strictly guaranteed by the kernel, so we just assert both lines land.
+        await runCommand("printf 'on-out\\n'; printf 'on-err\\n' >&2", {
+            cwd: dir,
+            logFile,
+        });
+        const contents = readFileSync(logFile, "utf-8");
+        expect(contents).toContain("on-out");
+        expect(contents).toContain("on-err");
+    });
+
+    it("logFile is opt-in — no file is created when omitted", async () => {
+        await runCommand("printf 'silent\\n'", { cwd: dir });
+        // Directory should still be empty.
+        expect(() => readFileSync(join(dir, "out.log"), "utf-8")).toThrow();
+    });
+
+    it("captures output even when the command fails", async () => {
+        const logFile = join(dir, "out.log");
+        await expect(
+            runCommand("printf 'before-fail\\n'; exit 7", { cwd: dir, logFile }),
+        ).rejects.toThrow();
+        expect(readFileSync(logFile, "utf-8")).toContain("before-fail");
     });
 });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -103,7 +103,18 @@ export async function runCommand(
     const { cwd, log, logFile } = options;
     return new Promise((resolve, reject) => {
         const proc = exec(cmd, { cwd, env: PLAIN_ENV });
-        const file = logFile ? createWriteStream(logFile) : null;
+        let file: ReturnType<typeof createWriteStream> | null = null;
+        if (logFile) {
+            file = createWriteStream(logFile);
+            // The tee is best-effort — if the disk fills up or the path goes
+            // away mid-run, surface a notice via the log callback and detach
+            // so subsequent writes don't cascade. An unhandled 'error' event
+            // on a stream would otherwise crash the entire `dot` process.
+            file.on("error", (err) => {
+                log?.(`(log file write failed: ${err.message})`);
+                file = null;
+            });
+        }
         const forward = (data: Buffer | string) => {
             file?.write(data);
             for (const line of sanitize(String(data)).split("\n").filter(Boolean)) {
@@ -113,14 +124,10 @@ export async function runCommand(
         proc.stdout?.on("data", forward);
         proc.stderr?.on("data", forward);
         proc.on("close", (code) => {
-            file?.end(() => {
-                if (code === 0) resolve();
-                else reject(new Error(`Command failed (exit ${code})`));
-            });
-            if (!file) {
-                if (code === 0) resolve();
-                else reject(new Error(`Command failed (exit ${code})`));
-            }
+            const settle = () =>
+                code === 0 ? resolve() : reject(new Error(`Command failed (exit ${code})`));
+            if (file) file.end(settle);
+            else settle();
         });
     });
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -3,7 +3,7 @@
  */
 
 import { execFile, exec } from "node:child_process";
-import { rmSync } from "node:fs";
+import { createWriteStream, rmSync } from "node:fs";
 import { resolve } from "node:path";
 
 type Log = (line: string) => void;
@@ -88,12 +88,24 @@ export async function cloneRepo(
     await spawn("git", ["init"], { cwd: targetDir, log: options?.log });
 }
 
-/** Run a shell command, streaming output to log. */
-export async function runCommand(cmd: string, options: { cwd?: string; log?: Log }): Promise<void> {
-    const { cwd, log } = options;
+/**
+ * Run a shell command, streaming output to log.
+ *
+ * If `logFile` is provided, both stdout and stderr are also tee'd to that file
+ * via createWriteStream — O(1) RAM regardless of total output volume. The file
+ * contains the raw bytes (no ANSI stripping) so it round-trips faithfully when
+ * `cat`ed back into a terminal.
+ */
+export async function runCommand(
+    cmd: string,
+    options: { cwd?: string; log?: Log; logFile?: string },
+): Promise<void> {
+    const { cwd, log, logFile } = options;
     return new Promise((resolve, reject) => {
         const proc = exec(cmd, { cwd, env: PLAIN_ENV });
+        const file = logFile ? createWriteStream(logFile) : null;
         const forward = (data: Buffer | string) => {
+            file?.write(data);
             for (const line of sanitize(String(data)).split("\n").filter(Boolean)) {
                 log?.(line);
             }
@@ -101,8 +113,14 @@ export async function runCommand(cmd: string, options: { cwd?: string; log?: Log
         proc.stdout?.on("data", forward);
         proc.stderr?.on("data", forward);
         proc.on("close", (code) => {
-            if (code === 0) resolve();
-            else reject(new Error(`Command failed (exit ${code})`));
+            file?.end(() => {
+                if (code === 0) resolve();
+                else reject(new Error(`Command failed (exit ${code})`));
+            });
+            if (!file) {
+                if (code === 0) resolve();
+                else reject(new Error(`Command failed (exit ${code})`));
+            }
         });
     });
 }

--- a/src/utils/ui/components/StepRunner.tsx
+++ b/src/utils/ui/components/StepRunner.tsx
@@ -17,6 +17,14 @@ const LOG_LINE_MAX = 160;
 export interface Step {
     name: string;
     run: (log: (line: string) => void) => Promise<void>;
+    /**
+     * When true, the last RETAINED_LINES of this step's output stay rendered
+     * under the row after the step completes successfully. Use sparingly —
+     * this is for steps whose tail content carries lasting value to the user
+     * (e.g. a setup script's "next steps" footer). Bounded by RETAINED_LINES
+     * × LOG_LINE_MAX chars per step, so memory impact is trivial.
+     */
+    keepLogOnSuccess?: boolean;
 }
 
 type StepStatus = "pending" | "running" | "ok" | "failed" | "warning";
@@ -25,9 +33,14 @@ interface StepState {
     name: string;
     status: StepStatus;
     message?: string;
+    /** Snapshotted tail for completed steps with `keepLogOnSuccess: true`. */
+    retainedLog?: string[];
 }
 
-const LOG_LINES = 5;
+/** Live tail height while a step is running. */
+const LIVE_LOG_LINES = 5;
+/** Buffer cap and persisted-tail height for `keepLogOnSuccess` steps. */
+const RETAINED_LINES = 25;
 
 function toMark(status: StepStatus): MarkKind {
     switch (status) {
@@ -77,7 +90,7 @@ export function StepRunner({ title, steps, onDone }: Props) {
         const pushLine = (line: string) => {
             const truncated =
                 line.length > LOG_LINE_MAX ? `${line.slice(0, LOG_LINE_MAX - 1)}…` : line;
-            const next = [...bufferRef.current, truncated].slice(-LOG_LINES);
+            const next = [...bufferRef.current, truncated].slice(-RETAINED_LINES);
             bufferRef.current = next;
             scheduleFlush();
         };
@@ -100,7 +113,12 @@ export function StepRunner({ title, steps, onDone }: Props) {
 
                 try {
                     await steps[i].run(pushLine);
-                    setStates((prev) => prev.map((s, j) => (j === i ? { ...s, status: "ok" } : s)));
+                    const retainedLog = steps[i].keepLogOnSuccess
+                        ? [...bufferRef.current]
+                        : undefined;
+                    setStates((prev) =>
+                        prev.map((s, j) => (j === i ? { ...s, status: "ok", retainedLog } : s)),
+                    );
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     const isWarning = err instanceof Error && (err as any).isWarning === true;
@@ -135,21 +153,28 @@ export function StepRunner({ title, steps, onDone }: Props) {
     }, []);
 
     const running = states.some((s) => s.status === "running");
+    const liveOutput = output.slice(-LIVE_LOG_LINES);
 
     return (
         <Section title={title}>
             {states.map((step) => (
-                <Row
-                    key={step.name}
-                    mark={toMark(step.status)}
-                    label={step.name}
-                    value={step.message}
-                    tone={step.status === "failed" ? "danger" : "muted"}
-                />
+                <Box key={step.name} flexDirection="column">
+                    <Row
+                        mark={toMark(step.status)}
+                        label={step.name}
+                        value={step.message}
+                        tone={step.status === "failed" ? "danger" : "muted"}
+                    />
+                    {step.retainedLog && step.retainedLog.length > 0 && (
+                        <Box marginTop={1} marginBottom={1}>
+                            <LogTail lines={step.retainedLog} height={step.retainedLog.length} />
+                        </Box>
+                    )}
+                </Box>
             ))}
-            {running && output.length > 0 && (
+            {running && liveOutput.length > 0 && (
                 <Box marginTop={1}>
-                    <LogTail lines={output} height={LOG_LINES} />
+                    <LogTail lines={liveOutput} height={LIVE_LOG_LINES} />
                 </Box>
             )}
         </Section>


### PR DESCRIPTION
## Summary

Tutorial apps like Rock-Paper-Scissors print a heredoc at the end of \`setup.sh\` with quest progression, dev-server commands, and doc pointers — content that's the actual user-facing finale of \`dot mod\`. Today that output disappears the moment the \"run setup.sh\" step ticks green, leaving only a generic \"edit with claude / dot deploy\" footer that hides the per-app guidance.

This PR makes the tail persist:

- **\`StepRunner\`** learns a per-step \`keepLogOnSuccess\` flag — when set, the last 25 lines of that step's buffer stay rendered under the row after the green check. Live in-progress tail stays at 5 lines so \`npm install\` doesn't grow the layout. One snapshot \`setState\` per success transition; no new per-line state churn (memory budget: ~24 KB peak retained tails for a 3-step run, well under the 4 GB watchdog).
- **\`runCommand\`** gets an optional \`logFile\` arg that tees stdout+stderr via \`createWriteStream\` — O(1) RAM, raw bytes (so \`cat\`-ing the log replays ANSI faithfully), file written even when the command fails. WriteStream errors are caught and logged so a full disk / vanished path can't crash \`dot\`.
- **\`SetupScreen\`** flags the run-setup.sh step, writes to \`<targetDir>/.dot-mod-setup.log\`, surfaces the path as a \`Hint\` after success, and appends the log filename to the cloned repo's \`.gitignore\` (idempotent) so the user can't accidentally commit it.
- **\`mod/index.ts\`** only prints the generic \"Next steps\" fallback when \`setup.sh\` was missing — otherwise the script's own footer wins.

Resolves issue #1 from Reinhard's report (output of \`setup.sh\` not visible at the end).

## Background

The two issues filed against \`dot mod\` were:

1. \"Output of setup.sh is not visible at the end\" → **this PR**
2. \"Checkout commands presented by setup.sh don't work, due to multiple remotes\" → #51

The pattern from this PR (\`keepLogOnSuccess\` + \`logFile\`) is reusable for any future \`dot\` command that wraps a noisy script and wants the tail to survive. App authors don't need to opt into anything — every \`setup.sh\` benefits automatically.

## Verified

- \`pnpm test\` → 352/352 pass (5 new tests for \`runCommand\` log-file tee)
- \`npx tsc --noEmit\` → clean
- \`pnpm format:check\` → clean
- Smoke test: ran the real \`Rock-Paper-Scissors/setup.sh\` through \`runCommand\` — captured all 16 lines of the heredoc footer in a 742-byte log file, comfortably under the 25-line cap.
- Code-reviewed via \`superpowers:code-reviewer\` subagent; review fixes are in commit 2 (\`4af5307\`) — collapsed close-handler control flow, added WriteStream error listener, gitignore-the-log, plus a coverage gap closure.

## Test plan

- [ ] \`dot mod rock-paper-scissors.dot\` (or whatever RPS is registered as) on a fresh dir; confirm the quest-progression block stays visible after the green check.
- [ ] Confirm \`<targetDir>/.dot-mod-setup.log\` exists and contains the full setup output.
- [ ] Confirm \`<targetDir>/.gitignore\` has \`.dot-mod-setup.log\` (and \`git status\` doesn't show the log file as untracked).
- [ ] \`dot mod\` against an app with no \`setup.sh\` → confirm the generic \"edit with claude / dot deploy\" footer still appears.
- [ ] \`dot mod\` with a deliberately-failing \`setup.sh\` → confirm the log file still contains the partial output (best-effort tee survives failure).