### PR TITLE
fix: dispatch bundled DotNS CLI argv

### DIFF
--- a/.changeset/fix-dotns-dispatch.md
+++ b/.changeset/fix-dotns-dispatch.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix bundled DotNS CLI dispatch so compiled deploys can run DotNS subprocess commands.

--- a/src/dotns-cli-dispatch.ts
+++ b/src/dotns-cli-dispatch.ts
@@ -7,12 +7,25 @@ export function buildDotnsCliArgv(argv: string[], scriptPath = dotnsCliPath): st
 }
 
 export async function runDotnsCliSubprocess(argv: string[]): Promise<number> {
+    const originalExit = process.exit;
+    let resolved = false;
+    const exitCode = new Promise<number>((resolve) => {
+        process.exit = ((code?: string | number | null | undefined) => {
+            const numericCode = typeof code === "number" ? code : 0;
+            if (!resolved) {
+                resolved = true;
+                resolve(numericCode);
+            }
+            return originalExit(numericCode);
+        }) as typeof process.exit;
+    });
+
     process.argv = buildDotnsCliArgv(argv);
-    const mod = (await import(pathToFileURL(dotnsCliPath).href)) as {
-        main?: (argv?: string[]) => Promise<number>;
-    };
-    if (typeof mod.main !== "function") {
-        throw new Error("Embedded DotNS CLI did not export main()");
+    try {
+        // The bundled DotNS CLI auto-runs on import under Bun's compiled binary.
+        await import(pathToFileURL(dotnsCliPath).href);
+        return await exitCode;
+    } finally {
+        process.exit = originalExit;
     }
-    return await mod.main(process.argv);
 }

--- a/src/dotns-cli-dispatch.ts
+++ b/src/dotns-cli-dispatch.ts
@@ -2,12 +2,17 @@ import { pathToFileURL } from "node:url";
 // @ts-expect-error Bun's file import attribute embeds the bundled DotNS CLI file.
 import dotnsCliPath from "../node_modules/@parity/dotns-cli/dist/cli.js" with { type: "file" };
 
+export function buildDotnsCliArgv(argv: string[], scriptPath = dotnsCliPath): string[] {
+    return [process.argv[0] ?? "dot", scriptPath, ...argv];
+}
+
 export async function runDotnsCliSubprocess(argv: string[]): Promise<number> {
+    process.argv = buildDotnsCliArgv(argv);
     const mod = (await import(pathToFileURL(dotnsCliPath).href)) as {
         main?: (argv?: string[]) => Promise<number>;
     };
     if (typeof mod.main !== "function") {
         throw new Error("Embedded DotNS CLI did not export main()");
     }
-    return await mod.main([process.argv[0] ?? "dot", "dotns", ...argv]);
+    return await mod.main(process.argv);
 }

--- a/src/utils/deploy/dotns-cli-dependency.test.ts
+++ b/src/utils/deploy/dotns-cli-dependency.test.ts
@@ -24,6 +24,8 @@ describe("DotNS CLI runtime dependency", () => {
         );
         expect(dispatcherSource).toContain("pathToFileURL(dotnsCliPath)");
         expect(dispatcherSource).toContain('[process.argv[0] ?? "dot", scriptPath, ...argv]');
+        expect(dispatcherSource).toContain("process.exit =");
         expect(dispatcherSource).not.toContain('"dotns", ...argv');
+        expect(dispatcherSource).not.toContain(".main(");
     });
 });

--- a/src/utils/deploy/dotns-cli-dependency.test.ts
+++ b/src/utils/deploy/dotns-cli-dependency.test.ts
@@ -23,5 +23,7 @@ describe("DotNS CLI runtime dependency", () => {
             'from "../node_modules/@parity/dotns-cli/dist/cli.js" with { type: "file" }',
         );
         expect(dispatcherSource).toContain("pathToFileURL(dotnsCliPath)");
+        expect(dispatcherSource).toContain('[process.argv[0] ?? "dot", scriptPath, ...argv]');
+        expect(dispatcherSource).not.toContain('"dotns", ...argv');
     });
 });


### PR DESCRIPTION
## Summary

- Fix the bundled DotNS CLI dispatcher so it rewrites `process.argv` to look like a direct `dotns` invocation before importing the embedded CLI.
- Let the embedded DotNS CLI auto-run exactly once and hand off to its real `process.exit`, avoiding duplicate mutating commands.
- Add regression coverage to prevent passing `"dotns"` into `@parity/dotns-cli`'s own Commander parser or explicitly calling `main()` after import again.
- Add a patch changeset for the deploy regression.

## Root Cause

`@parity/dotns-cli/dist/cli.js` auto-runs its `main()` during import. The compiled `dot` binary was importing that file while `process.argv` still looked like `dot dotns ...`, so DotNS parsed `dotns` as its own subcommand and failed with `unknown command 'dotns'`.

After fixing argv, the wrapper still called the exported `main()` after import. Because the bundle already auto-runs, that executed commands twice. Read-only commands showed duplicate banners; mutating commands like `account map` could submit twice and hit `Invalid/Stale` on the second transaction.

## Verification

- `pnpm test` (`36` files, `412` tests passed)
- `npx tsc --noEmit`
- `pnpm format:check`
- `pnpm build`
- `./dist/dot dotns account address`
- `./dist/dot dotns -v`
- `./dist/dot dotns help account`
