### PR TITLE
test(e2e): use fixed deploy-test domains instead of unique-per-run

### DIFF
--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -35,7 +35,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", "test",
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(frontendOnly),
 			"--playground",
 			"--env", "mainnet",

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -13,10 +13,10 @@
  * - The --contracts flag
  */
 
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect } from "vitest";
 import { resolve } from "node:path";
 import { dot } from "./helpers/dot.js";
-import { SIGNER, BOB, uniqueDomain } from "./fixtures/accounts.js";
+import { SIGNER, BOB, E2E_DOMAINS } from "./fixtures/accounts.js";
 import { fixturePath } from "./fixtures/templates.js";
 
 const frontendOnly = fixturePath("frontend-only");
@@ -51,7 +51,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", uniqueDomain(),
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(foundry),
 			"--no-build",
 			"--contracts",
@@ -70,7 +70,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", uniqueDomain(),
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(hardhat),
 			"--no-build",
 			"--contracts",
@@ -87,7 +87,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", uniqueDomain(),
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(rustCdm),
 			"--no-build",
 			"--contracts",
@@ -104,7 +104,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", uniqueDomain(),
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(multiContract),
 			"--no-build",
 			"--contracts",
@@ -121,7 +121,7 @@ describe("dot deploy — preflight and validation", () => {
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
-			"--domain", uniqueDomain(),
+			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(frontendOnly),
 			"--no-build",
 			"--contracts",
@@ -134,7 +134,7 @@ describe("dot deploy — preflight and validation", () => {
 	});
 
 	test("domain availability check runs before build/upload", { timeout: 300_000 }, async () => {
-		const domain = uniqueDomain();
+		const domain = E2E_DOMAINS.preflight;
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
@@ -151,13 +151,8 @@ describe("dot deploy — preflight and validation", () => {
 });
 
 describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", () => {
-	let domain: string;
-
-	beforeEach(() => {
-		domain = uniqueDomain();
-	});
-
 	test("frontend-only deploy completes end-to-end", { timeout: 450_000 }, async () => {
+		const domain = E2E_DOMAINS.storage;
 		const result = await dot([
 			"deploy",
 			"--signer", "dev",
@@ -178,6 +173,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 	});
 
 	test("re-deploy same domain succeeds for same owner", { timeout: 900_000 }, async () => {
+		const domain = E2E_DOMAINS.redeploy;
 		const first = await dot([
 			"deploy",
 			"--signer", "dev",
@@ -208,6 +204,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 	});
 
 	test("domain taken by another account shows unavailable", { timeout: 900_000 }, async () => {
+		const domain = E2E_DOMAINS.collision;
 		const ownerDeploy = await dot([
 			"deploy",
 			"--signer", "dev",

--- a/e2e/cli/fixtures/accounts.ts
+++ b/e2e/cli/fixtures/accounts.ts
@@ -72,10 +72,20 @@ export const BOB: TestAccount = devAccount("Bob");
  *
  * Use a separate domain per test that exercises a meaningfully different
  * publish path (storage / re-deploy / cross-owner collision); reuse a single
- * domain for the preflight tests, which never reach publish.
+ * domain for the preflight / validation tests.
+ *
+ * NOTE: do not assert on the registry state of `preflight` — it's shared by
+ * six tests in the same file and the metadata at any moment reflects whichever
+ * one ran last. Stdout assertions are fine. If you need to assert on registry
+ * state for a new test, give it its own dedicated domain here.
  */
 export const E2E_DOMAINS = {
-	/** Used by all preflight / validation tests — they exit before publish. */
+	/**
+	 * Shared by the validation tests in `dot deploy — preflight and validation`.
+	 * `--no-build` only skips the build step, not the publish — so some of these
+	 * tests do reach `registry.publish`. SIGNER ends up owning this domain
+	 * regardless; subsequent runs are same-owner re-publishes.
+	 */
 	preflight: "e2e-cli-preflight",
 	/** Used by the storage-phase happy path. */
 	storage: "e2e-cli-storage",

--- a/e2e/cli/fixtures/accounts.ts
+++ b/e2e/cli/fixtures/accounts.ts
@@ -65,11 +65,22 @@ export const ALICE: TestAccount = devAccount("Alice");
 export const BOB: TestAccount = devAccount("Bob");
 
 /**
- * Generate a unique .dot domain name for deploy tests.
- * Format mirrors `<word>-dev<NN>`.
+ * Fixed `.dot` domain names for deploy tests. SIGNER owns all of these after
+ * the first CI run; subsequent runs re-publish to the same domains, which the
+ * registry contract permits for the same owner. This keeps the playground
+ * registry from accumulating a new entry on every CI run.
+ *
+ * Use a separate domain per test that exercises a meaningfully different
+ * publish path (storage / re-deploy / cross-owner collision); reuse a single
+ * domain for the preflight tests, which never reach publish.
  */
-export function uniqueDomain(): string {
-	const rand = Math.random().toString(36).slice(2, 6);
-	const suffix = String(Date.now()).slice(-2);
-	return `e2e${rand}-dev${suffix}`;
-}
+export const E2E_DOMAINS = {
+	/** Used by all preflight / validation tests — they exit before publish. */
+	preflight: "e2e-cli-preflight",
+	/** Used by the storage-phase happy path. */
+	storage: "e2e-cli-storage",
+	/** Used by the same-owner re-deploy test. */
+	redeploy: "e2e-cli-redeploy",
+	/** Used by the cross-owner collision test (BOB tries to take SIGNER's). */
+	collision: "e2e-cli-collision",
+} as const;


### PR DESCRIPTION
## Summary

The deploy e2e suite was calling `uniqueDomain()` (e.g. `e2el7cq-dev83`) for every test, and `dot deploy --playground` permanently registers each name on the playground-registry contract. After many CI runs, the live registry browsed by users was filling up with test entries.

This PR replaces `uniqueDomain()` with four fixed names (`E2E_DOMAINS.{preflight,storage,redeploy,collision}`) reused across runs. `SIGNER` owns them after the first CI run; the registry contract permits same-owner re-publish, so subsequent runs just update metadata in place.

**Net effect:** at most 4 permanent test entries total in the registry, instead of up to 9 new entries per CI run (5 contract-detection preflight + 1 availability check + 3 full-pipeline).

Same idea as the playground-app e2e suite, which uses one fixed fixture domain (`playground-e2e-app.dot`) for the same reason.

## Why this is safe

- The "re-deploy same domain succeeds for same owner" test already proves the registry permits same-owner re-publish; verified directly in `contracts/registry/lib.rs` (the `publish` method updates metadata in place when `caller == owner`).
- The "domain taken by another account" test still works: once `SIGNER` owns `e2e-cli-collision`, `BOB` fails to take it on every run — that's exactly what the test asserts.
- Parallel CI runs don't collide: `SIGNER` is the same key across every PR, so concurrent re-publishes are all same-owner re-publishes.
- `vitest.config.ts` has `fileParallelism: false` and tests within a file run sequentially, so the six tests sharing `e2e-cli-preflight` won't race against each other.

## Caveats documented in code

- `--no-build` only skips the build step, not the publish — so some preflight tests do reach `registry.publish`. The comment in `accounts.ts` explains this and notes that SIGNER owns the domain regardless.
- The shared `preflight` domain shouldn't be used for registry-state assertions (six tests overwrite each other's metadata sequentially). A warning comment in `accounts.ts` discourages that pattern; new tests that need registry-state isolation should get their own dedicated domain.

## Follow-up (separate)

The existing pollution in the registry (`e2e<rand>-dev<NN>` entries) will remain visible in the playground-app until either (a) someone admin-deletes them or (b) the playground-app frontend filters them by pattern. Tracking that on the playground-app side, not here.

## Test plan

- [ ] Trigger the e2e workflow on this branch — confirm all deploy tests pass with fixed domains
- [ ] After merge, verify only the four `e2e-cli-*` entries appear in the registry on subsequent CI runs (no new `e2e<rand>-dev<NN>` entries)