### PR TITLE
Resolve playground registry address live

### DIFF
--- a/.changeset/live-registry-resolution.md
+++ b/.changeset/live-registry-resolution.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Resolve the Playground registry address from the live CDM meta-registry before publishing or browsing apps.

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,8 +19,6 @@ export interface ChainConfig {
     bulletinRpc: string;
     /** WebSocket endpoints for the People chain (SSO / session discovery). */
     peopleEndpoints: string[];
-    /** Playground registry contract on Asset Hub. Backing store for myApps. */
-    playgroundRegistryAddress: `0x${string}`;
     /** Viewer URL shown to users after a successful deploy. */
     appViewerOrigin: string;
 }
@@ -29,7 +27,6 @@ const TESTNET: ChainConfig = {
     assetHubRpc: "wss://asset-hub-paseo-rpc.n.dwellir.com",
     bulletinRpc: "wss://paseo-bulletin-rpc.polkadot.io",
     peopleEndpoints: ["wss://paseo-people-next-rpc.polkadot.io"],
-    playgroundRegistryAddress: "0x279585Cb8E8971e34520A3ebbda3E0C4D77C3d97",
     appViewerOrigin: "https://dot.li",
 };
 
@@ -41,6 +38,9 @@ export function getChainConfig(env: Env = DEFAULT_ENV): ChainConfig {
     }
     return TESTNET;
 }
+
+/** Fixed CDM meta-registry contract on Asset Hub. Source: @dotdm/utils REGISTRY_ADDRESS. */
+export const CDM_REGISTRY_ADDRESS = "0xae344f7f0f91d3a2176032af2990abcc7606c7d4";
 
 /** Identifier the terminal adapter reports during SSO. Kept stable so mobile pairings persist across releases. */
 export const DAPP_ID = "dot-cli";

--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -37,6 +37,7 @@ describe("expected CLI errors", () => {
         expect(isExpectedCliError("GitHub CLI is not authenticated")).toBe(true);
         expect(isExpectedCliError('Invalid domain "bad_domain"')).toBe(true);
         expect(isExpectedCliError("No foundry/hardhat/cdm project was detected")).toBe(true);
+        expect(isExpectedCliError("BadRegistryLookup: CDM registry unavailable")).toBe(true);
     });
 
     it("treats ambiguous runtime failures as unexpected", async () => {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -69,7 +69,7 @@ export function sanitizeSentryTransaction<T extends Record<string, unknown>>(eve
 }
 
 export function isExpectedCliError(message: string): boolean {
-    return /signer.*not available|run "dot init"|account is not mapped|storage allowance is exhausted|invalid domain|already owned|reserved|insufficient balance|github cli is not authenticated|no foundry\/hardhat\/cdm project was detected|github api returned|download failed/i.test(
+    return /badregistrylookup|signer.*not available|run "dot init"|account is not mapped|storage allowance is exhausted|invalid domain|already owned|reserved|insufficient balance|github cli is not authenticated|no foundry\/hardhat\/cdm project was detected|github api returned|download failed/i.test(
         message,
     );
 }

--- a/src/utils/contractManifest.test.ts
+++ b/src/utils/contractManifest.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { CdmJson } from "@polkadot-apps/contracts";
+import { CDM_REGISTRY_ADDRESS } from "../config.js";
+
+const { createContractFromClientMock, getAddressQueryMock } = vi.hoisted(() => ({
+    createContractFromClientMock: vi.fn(),
+    getAddressQueryMock: vi.fn(),
+}));
+
+vi.mock("@polkadot-apps/contracts", () => ({
+    createContractFromClient: (...args: unknown[]) => createContractFromClientMock(...args),
+}));
+
+import {
+    PLAYGROUND_REGISTRY_CONTRACT,
+    resolveLiveContractAddresses,
+    withLiveContractAddresses,
+} from "./contractManifest.js";
+
+const snapshotAddress = "0x1111111111111111111111111111111111111111";
+const liveAddress = "0x2222222222222222222222222222222222222222";
+
+function manifest(): CdmJson {
+    return {
+        targets: {
+            target1: {
+                "asset-hub": "wss://asset-hub.example",
+                bulletin: "https://bulletin.example/ipfs",
+            },
+        },
+        dependencies: {
+            target1: {
+                [PLAYGROUND_REGISTRY_CONTRACT]: "latest",
+            },
+        },
+        contracts: {
+            target1: {
+                [PLAYGROUND_REGISTRY_CONTRACT]: {
+                    version: 6,
+                    address: snapshotAddress,
+                    abi: [],
+                    metadataCid: "bafyregistry",
+                },
+                "@example/other": {
+                    version: 1,
+                    address: "0x3333333333333333333333333333333333333333",
+                    abi: [],
+                    metadataCid: "bafyother",
+                },
+            },
+        },
+    };
+}
+
+beforeEach(() => {
+    createContractFromClientMock.mockReset();
+    getAddressQueryMock.mockReset();
+    createContractFromClientMock.mockResolvedValue({
+        getAddress: { query: getAddressQueryMock },
+    });
+});
+
+describe("resolveLiveContractAddresses", () => {
+    it("queries the fixed CDM registry for requested libraries", async () => {
+        getAddressQueryMock.mockResolvedValue({
+            success: true,
+            value: { isSome: true, value: liveAddress },
+        });
+
+        const assetHub = {} as any;
+        const addresses = await resolveLiveContractAddresses(assetHub, [
+            PLAYGROUND_REGISTRY_CONTRACT,
+        ]);
+
+        expect(addresses).toEqual({ [PLAYGROUND_REGISTRY_CONTRACT]: liveAddress });
+        expect(createContractFromClientMock).toHaveBeenCalledWith(
+            assetHub,
+            CDM_REGISTRY_ADDRESS,
+            expect.arrayContaining([
+                expect.objectContaining({ name: "getAddress", type: "function" }),
+            ]),
+        );
+        expect(getAddressQueryMock).toHaveBeenCalledWith(PLAYGROUND_REGISTRY_CONTRACT);
+    });
+
+    it("omits libraries when the live registry has no address", async () => {
+        getAddressQueryMock.mockResolvedValue({
+            success: true,
+            value: { isSome: false, value: snapshotAddress },
+        });
+
+        await expect(
+            resolveLiveContractAddresses({} as any, [PLAYGROUND_REGISTRY_CONTRACT]),
+        ).resolves.toEqual({});
+    });
+});
+
+describe("withLiveContractAddresses", () => {
+    it("patches only the resolved contract address and leaves the snapshot untouched", async () => {
+        getAddressQueryMock.mockResolvedValue({
+            success: true,
+            value: { isSome: true, value: liveAddress },
+        });
+        const original = manifest();
+
+        const patched = await withLiveContractAddresses(original, {} as any, [
+            PLAYGROUND_REGISTRY_CONTRACT,
+        ]);
+
+        expect(patched).not.toBe(original);
+        expect(patched.contracts?.target1[PLAYGROUND_REGISTRY_CONTRACT].address).toBe(liveAddress);
+        expect(original.contracts?.target1[PLAYGROUND_REGISTRY_CONTRACT].address).toBe(
+            snapshotAddress,
+        );
+        expect(patched.contracts?.target1["@example/other"].address).toBe(
+            "0x3333333333333333333333333333333333333333",
+        );
+    });
+
+    it("returns the original manifest when no live address is available", async () => {
+        getAddressQueryMock.mockResolvedValue({ success: false, value: null });
+        const original = manifest();
+
+        await expect(
+            withLiveContractAddresses(original, {} as any, [PLAYGROUND_REGISTRY_CONTRACT]),
+        ).resolves.toBe(original);
+    });
+});

--- a/src/utils/contractManifest.test.ts
+++ b/src/utils/contractManifest.test.ts
@@ -15,6 +15,7 @@ import {
     PLAYGROUND_REGISTRY_CONTRACT,
     resolveLiveContractAddresses,
     withLiveContractAddresses,
+    withRequiredLiveContractAddresses,
 } from "./contractManifest.js";
 
 const snapshotAddress = "0x1111111111111111111111111111111111111111";
@@ -124,5 +125,15 @@ describe("withLiveContractAddresses", () => {
         await expect(
             withLiveContractAddresses(original, {} as any, [PLAYGROUND_REGISTRY_CONTRACT]),
         ).resolves.toBe(original);
+    });
+
+    it("throws when a required live address is unavailable", async () => {
+        getAddressQueryMock.mockResolvedValue({ success: false, value: null });
+
+        await expect(
+            withRequiredLiveContractAddresses(manifest(), {} as any, [
+                PLAYGROUND_REGISTRY_CONTRACT,
+            ]),
+        ).rejects.toThrow(/CDM meta-registry did not return live address/);
     });
 });

--- a/src/utils/contractManifest.ts
+++ b/src/utils/contractManifest.ts
@@ -1,0 +1,81 @@
+import { createContractFromClient, type AbiEntry, type CdmJson } from "@polkadot-apps/contracts";
+import type { HexString, PolkadotClient } from "polkadot-api";
+import { CDM_REGISTRY_ADDRESS } from "../config.js";
+
+export const PLAYGROUND_REGISTRY_CONTRACT = "@w3s/playground-registry";
+
+const LIVE_CONTRACTS = [PLAYGROUND_REGISTRY_CONTRACT] as const;
+
+// Keep this ABI local so live address resolution does not depend on CDM's
+// higher-level runtime package shape.
+const CDM_REGISTRY_ABI: AbiEntry[] = [
+    {
+        type: "function",
+        name: "getAddress",
+        inputs: [{ name: "contract_name", type: "string" }],
+        outputs: [
+            {
+                name: "",
+                type: "tuple",
+                components: [
+                    { name: "isSome", type: "bool" },
+                    { name: "value", type: "address" },
+                ],
+            },
+        ],
+        stateMutability: "view",
+    },
+];
+
+type OptionAddress = { isSome: boolean; value: HexString };
+
+function defaultTargetHash(manifest: CdmJson): string {
+    const [targetHash] = Object.keys(manifest.targets);
+    if (!targetHash) throw new Error("No targets found in cdm.json");
+    return targetHash;
+}
+
+export async function resolveLiveContractAddresses(
+    assetHub: PolkadotClient,
+    libraries: readonly string[] = LIVE_CONTRACTS,
+): Promise<Record<string, HexString>> {
+    const registry = await createContractFromClient(
+        assetHub,
+        CDM_REGISTRY_ADDRESS,
+        CDM_REGISTRY_ABI,
+    );
+    const entries = await Promise.all(
+        libraries.map(async (library): Promise<readonly [string, HexString | null]> => {
+            const result = await registry.getAddress.query(library);
+            if (!result.success) return [library, null];
+            const address = result.value as OptionAddress;
+            return [library, address.isSome ? address.value : null];
+        }),
+    );
+
+    const addresses: Record<string, HexString> = {};
+    for (const [library, address] of entries) {
+        if (address) addresses[library] = address;
+    }
+    return addresses;
+}
+
+export async function withLiveContractAddresses(
+    manifest: CdmJson,
+    assetHub: PolkadotClient,
+    libraries: readonly string[] = LIVE_CONTRACTS,
+): Promise<CdmJson> {
+    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries);
+    if (Object.keys(liveAddresses).length === 0) return manifest;
+
+    const patched = structuredClone(manifest);
+    const contracts = patched.contracts?.[defaultTargetHash(patched)];
+    if (!contracts) return manifest;
+
+    for (const [library, address] of Object.entries(liveAddresses)) {
+        const contract = contracts[library];
+        if (contract) contract.address = address;
+    }
+
+    return patched;
+}

--- a/src/utils/contractManifest.ts
+++ b/src/utils/contractManifest.ts
@@ -35,6 +35,24 @@ function defaultTargetHash(manifest: CdmJson): string {
     return targetHash;
 }
 
+function patchContractAddresses(
+    manifest: CdmJson,
+    liveAddresses: Record<string, HexString>,
+): CdmJson {
+    if (Object.keys(liveAddresses).length === 0) return manifest;
+
+    const patched = structuredClone(manifest);
+    const contracts = patched.contracts?.[defaultTargetHash(patched)];
+    if (!contracts) return manifest;
+
+    for (const [library, address] of Object.entries(liveAddresses)) {
+        const contract = contracts[library];
+        if (contract) contract.address = address;
+    }
+
+    return patched;
+}
+
 export async function resolveLiveContractAddresses(
     assetHub: PolkadotClient,
     libraries: readonly string[] = LIVE_CONTRACTS,
@@ -66,16 +84,19 @@ export async function withLiveContractAddresses(
     libraries: readonly string[] = LIVE_CONTRACTS,
 ): Promise<CdmJson> {
     const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries);
-    if (Object.keys(liveAddresses).length === 0) return manifest;
+    return patchContractAddresses(manifest, liveAddresses);
+}
 
-    const patched = structuredClone(manifest);
-    const contracts = patched.contracts?.[defaultTargetHash(patched)];
-    if (!contracts) return manifest;
-
-    for (const [library, address] of Object.entries(liveAddresses)) {
-        const contract = contracts[library];
-        if (contract) contract.address = address;
+export async function withRequiredLiveContractAddresses(
+    manifest: CdmJson,
+    assetHub: PolkadotClient,
+    libraries: readonly string[] = LIVE_CONTRACTS,
+): Promise<CdmJson> {
+    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries);
+    const missing = libraries.filter((library) => !liveAddresses[library]);
+    if (missing.length > 0) {
+        throw new Error(`CDM meta-registry did not return live address for ${missing.join(", ")}`);
     }
 
-    return patched;
+    return patchContractAddresses(manifest, liveAddresses);
 }

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { ResolvedSigner } from "./signer.js";
+import cdmJson from "../../cdm.json";
+
+const { captureWarningMock, fromClientMock, getContractMock, withLiveContractAddressesMock } =
+    vi.hoisted(() => ({
+        captureWarningMock: vi.fn(),
+        fromClientMock: vi.fn(),
+        getContractMock: vi.fn(),
+        withLiveContractAddressesMock: vi.fn(),
+    }));
+
+vi.mock("@polkadot-apps/contracts", () => ({
+    ContractManager: {
+        fromClient: (...args: unknown[]) => fromClientMock(...args),
+    },
+}));
+
+vi.mock("./contractManifest.js", () => ({
+    PLAYGROUND_REGISTRY_CONTRACT: "@w3s/playground-registry",
+    withLiveContractAddresses: (...args: unknown[]) => withLiveContractAddressesMock(...args),
+}));
+
+vi.mock("../telemetry.js", () => ({
+    captureWarning: (...args: unknown[]) => captureWarningMock(...args),
+}));
+
+import { getRegistryContract } from "./registry.js";
+
+const fakeSigner: ResolvedSigner = {
+    signer: {} as any,
+    address: "5Fake",
+    source: "session",
+    destroy: () => {},
+};
+
+beforeEach(() => {
+    captureWarningMock.mockReset();
+    fromClientMock.mockReset();
+    getContractMock.mockReset();
+    withLiveContractAddressesMock.mockReset();
+    getContractMock.mockReturnValue({ publish: { tx: vi.fn() } });
+    fromClientMock.mockResolvedValue({ getContract: getContractMock });
+});
+
+describe("getRegistryContract", () => {
+    it("builds the manager with a live-patched manifest", async () => {
+        const patchedManifest = { ...cdmJson, marker: "patched" };
+        withLiveContractAddressesMock.mockResolvedValue(patchedManifest);
+        const rawClient = {} as any;
+
+        await getRegistryContract(rawClient, fakeSigner);
+
+        expect(withLiveContractAddressesMock).toHaveBeenCalledWith(cdmJson, rawClient, [
+            "@w3s/playground-registry",
+        ]);
+        expect(fromClientMock).toHaveBeenCalledWith(patchedManifest, rawClient, {
+            defaultSigner: fakeSigner.signer,
+            defaultOrigin: fakeSigner.address,
+        });
+        expect(getContractMock).toHaveBeenCalledWith("@w3s/playground-registry");
+    });
+
+    it("falls back to the cdm.json snapshot and warns when live lookup fails", async () => {
+        withLiveContractAddressesMock.mockRejectedValue(new Error("registry unavailable"));
+        const rawClient = {} as any;
+
+        await getRegistryContract(rawClient, fakeSigner);
+
+        expect(captureWarningMock).toHaveBeenCalledWith(
+            "Live playground registry address lookup failed; using cdm.json snapshot",
+            { error: "registry unavailable" },
+        );
+        expect(fromClientMock).toHaveBeenCalledWith(cdmJson, rawClient, {
+            defaultSigner: fakeSigner.signer,
+            defaultOrigin: fakeSigner.address,
+        });
+    });
+});

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import type { ResolvedSigner } from "./signer.js";
 import cdmJson from "../../cdm.json";
 
-const { captureWarningMock, fromClientMock, getContractMock, withLiveContractAddressesMock } =
-    vi.hoisted(() => ({
-        captureWarningMock: vi.fn(),
+const { fromClientMock, getContractMock, withRequiredLiveContractAddressesMock } = vi.hoisted(
+    () => ({
         fromClientMock: vi.fn(),
         getContractMock: vi.fn(),
-        withLiveContractAddressesMock: vi.fn(),
-    }));
+        withRequiredLiveContractAddressesMock: vi.fn(),
+    }),
+);
 
 vi.mock("@polkadot-apps/contracts", () => ({
     ContractManager: {
@@ -18,11 +18,8 @@ vi.mock("@polkadot-apps/contracts", () => ({
 
 vi.mock("./contractManifest.js", () => ({
     PLAYGROUND_REGISTRY_CONTRACT: "@w3s/playground-registry",
-    withLiveContractAddresses: (...args: unknown[]) => withLiveContractAddressesMock(...args),
-}));
-
-vi.mock("../telemetry.js", () => ({
-    captureWarning: (...args: unknown[]) => captureWarningMock(...args),
+    withRequiredLiveContractAddresses: (...args: unknown[]) =>
+        withRequiredLiveContractAddressesMock(...args),
 }));
 
 import { getRegistryContract } from "./registry.js";
@@ -35,10 +32,9 @@ const fakeSigner: ResolvedSigner = {
 };
 
 beforeEach(() => {
-    captureWarningMock.mockReset();
     fromClientMock.mockReset();
     getContractMock.mockReset();
-    withLiveContractAddressesMock.mockReset();
+    withRequiredLiveContractAddressesMock.mockReset();
     getContractMock.mockReturnValue({ publish: { tx: vi.fn() } });
     fromClientMock.mockResolvedValue({ getContract: getContractMock });
 });
@@ -46,12 +42,12 @@ beforeEach(() => {
 describe("getRegistryContract", () => {
     it("builds the manager with a live-patched manifest", async () => {
         const patchedManifest = { ...cdmJson, marker: "patched" };
-        withLiveContractAddressesMock.mockResolvedValue(patchedManifest);
+        withRequiredLiveContractAddressesMock.mockResolvedValue(patchedManifest);
         const rawClient = {} as any;
 
         await getRegistryContract(rawClient, fakeSigner);
 
-        expect(withLiveContractAddressesMock).toHaveBeenCalledWith(cdmJson, rawClient, [
+        expect(withRequiredLiveContractAddressesMock).toHaveBeenCalledWith(cdmJson, rawClient, [
             "@w3s/playground-registry",
         ]);
         expect(fromClientMock).toHaveBeenCalledWith(patchedManifest, rawClient, {
@@ -61,19 +57,14 @@ describe("getRegistryContract", () => {
         expect(getContractMock).toHaveBeenCalledWith("@w3s/playground-registry");
     });
 
-    it("falls back to the cdm.json snapshot and warns when live lookup fails", async () => {
-        withLiveContractAddressesMock.mockRejectedValue(new Error("registry unavailable"));
+    it("throws a clear error when live lookup fails", async () => {
+        withRequiredLiveContractAddressesMock.mockRejectedValue(new Error("registry unavailable"));
         const rawClient = {} as any;
 
-        await getRegistryContract(rawClient, fakeSigner);
-
-        expect(captureWarningMock).toHaveBeenCalledWith(
-            "Live playground registry address lookup failed; using cdm.json snapshot",
-            { error: "registry unavailable" },
+        await expect(getRegistryContract(rawClient, fakeSigner)).rejects.toThrow(
+            /Could not resolve the live Playground registry contract address.*registry unavailable/,
         );
-        expect(fromClientMock).toHaveBeenCalledWith(cdmJson, rawClient, {
-            defaultSigner: fakeSigner.signer,
-            defaultOrigin: fakeSigner.address,
-        });
+
+        expect(fromClientMock).not.toHaveBeenCalled();
     });
 });

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -62,7 +62,7 @@ describe("getRegistryContract", () => {
         const rawClient = {} as any;
 
         await expect(getRegistryContract(rawClient, fakeSigner)).rejects.toThrow(
-            /Could not resolve the live Playground registry contract address.*registry unavailable/,
+            /BadRegistryLookup/,
         );
 
         expect(fromClientMock).not.toHaveBeenCalled();

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -4,8 +4,10 @@
 
 import { ContractManager, type CdmJson } from "@polkadot-apps/contracts";
 import type { ResolvedSigner } from "./signer.js";
-import { PLAYGROUND_REGISTRY_CONTRACT, withLiveContractAddresses } from "./contractManifest.js";
-import { captureWarning } from "../telemetry.js";
+import {
+    PLAYGROUND_REGISTRY_CONTRACT,
+    withRequiredLiveContractAddresses,
+} from "./contractManifest.js";
 
 import cdmJson from "../../cdm.json";
 
@@ -18,13 +20,15 @@ export async function getRegistryContract(
 ) {
     let manifest: CdmJson = cdmJson;
     try {
-        manifest = await withLiveContractAddresses(cdmJson, rawClient, [
+        manifest = await withRequiredLiveContractAddresses(cdmJson, rawClient, [
             PLAYGROUND_REGISTRY_CONTRACT,
         ]);
     } catch (err) {
-        captureWarning("Live playground registry address lookup failed; using cdm.json snapshot", {
-            error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
-        });
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `Could not resolve the live Playground registry contract address from the CDM meta-registry. Refusing to use the cdm.json snapshot because it may be stale. ${msg}`,
+            { cause: err instanceof Error ? err : undefined },
+        );
     }
 
     const manager = await ContractManager.fromClient(manifest, rawClient, {

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -2,8 +2,10 @@
  * Playground registry contract access.
  */
 
-import { ContractManager } from "@polkadot-apps/contracts";
+import { ContractManager, type CdmJson } from "@polkadot-apps/contracts";
 import type { ResolvedSigner } from "./signer.js";
+import { PLAYGROUND_REGISTRY_CONTRACT, withLiveContractAddresses } from "./contractManifest.js";
+import { captureWarning } from "../telemetry.js";
 
 import cdmJson from "../../cdm.json";
 
@@ -14,9 +16,20 @@ export async function getRegistryContract(
     rawClient: Parameters<typeof ContractManager.fromClient>[1],
     signer: ResolvedSigner,
 ) {
-    const manager = await ContractManager.fromClient(cdmJson, rawClient, {
+    let manifest: CdmJson = cdmJson;
+    try {
+        manifest = await withLiveContractAddresses(cdmJson, rawClient, [
+            PLAYGROUND_REGISTRY_CONTRACT,
+        ]);
+    } catch (err) {
+        captureWarning("Live playground registry address lookup failed; using cdm.json snapshot", {
+            error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+        });
+    }
+
+    const manager = await ContractManager.fromClient(manifest, rawClient, {
         defaultSigner: signer.signer,
         defaultOrigin: signer.address,
     });
-    return manager.getContract("@w3s/playground-registry");
+    return manager.getContract(PLAYGROUND_REGISTRY_CONTRACT);
 }

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -18,7 +18,7 @@ export async function getRegistryContract(
     rawClient: Parameters<typeof ContractManager.fromClient>[1],
     signer: ResolvedSigner,
 ) {
-    let manifest: CdmJson = cdmJson;
+    let manifest: CdmJson;
     try {
         manifest = await withRequiredLiveContractAddresses(cdmJson, rawClient, [
             PLAYGROUND_REGISTRY_CONTRACT,

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -26,7 +26,7 @@ export async function getRegistryContract(
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(
-            `Could not resolve the live Playground registry contract address from the CDM meta-registry. Refusing to use the cdm.json snapshot because it may be stale. ${msg}`,
+            `BadRegistryLookup: Could not resolve the live Playground registry contract address from the CDM meta-registry. Refusing to use the cdm.json snapshot because it may be stale. ${msg}`,
             { cause: err instanceof Error ? err : undefined },
         );
     }


### PR DESCRIPTION
## Summary

Updates playground-cli so Playground registry contract access resolves through the live CDM meta-registry at runtime instead of trusting the address snapshotted in `cdm.json`.

This keeps the committed `cdm.json` as the ABI snapshot, but patches the registry contract address immediately before constructing the `ContractManager` handle. That means an installed CLI can follow compatible Playground registry address upgrades without requiring a new CLI install.

## What changed

- Added live contract manifest resolution for `@w3s/playground-registry`.
- Updated `getRegistryContract()` so all production CLI registry access uses the live-resolved address.
- Made live registry lookup required: if the CDM meta-registry lookup fails or does not return the registry address, the CLI fails before using the stale `cdm.json` snapshot.
- Added the stable `BadRegistryLookup:` error prefix and classified it as expected CLI control flow for telemetry.
- Removed the stale static Playground registry address from config.
- Added focused unit coverage for live manifest patching, required lookup failures, and registry handle creation.

## Registry coverage

The production CLI paths that interact with the Playground registry now go through `getRegistryContract()`:

- `dot deploy --playground` publishes metadata via `registry.publish(...)`.
- `dot mod` browses and fetches app metadata from the registry.

`AppBrowser` and `SetupScreen` receive the already-resolved registry handle from `dot mod`, so they use the same live-resolved contract.

## Notes

- This only handles address changes for a compatible registry ABI.
- If the registry ABI changes, `cdm.json` still needs to be refreshed and the CLI republished.
- The CLI intentionally refuses to fall back to the `cdm.json` registry address when live lookup fails, to avoid silently publishing to or reading from a stale registry.

## Testing

- `pnpm test`
- `npx tsc --noEmit`
- `pnpm build`