### PR TITLE
Title: Run unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,15 @@ jobs:
                   node-version: "22"
             - run: pnpm install
             - run: pnpm format:check
+
+    unit-tests:
+        name: Unit Tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+            - run: pnpm install
+            - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .cdm/
 docs-internal/
 .worktrees/
+reference-repos/


### PR DESCRIPTION
## Summary

- Add a dedicated `Unit Tests` job to the main CI workflow.
- Run `pnpm test` on pull requests, pushes to `main`, and manual CI dispatches.
- Ignore `reference-repos/` so local reference checkouts do not get picked up by repo tooling.

## Testing

- `pnpm test`
- `pnpm format:check`