### PR TITLE
fix(deploy): load signer for playground publish

### DIFF
--- a/.changeset/load-playground-signer.md
+++ b/.changeset/load-playground-signer.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Load the logged-in account for `dot deploy --signer dev --playground` so Playground registry publishes can be signed by the app owner.

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -22,7 +22,26 @@ vi.mock("../../utils/connection.js", () => ({
     destroyConnection: vi.fn(),
 }));
 
-const { safeDetectContractsType, computeContractsFundingNeeded } = await import("./index.js");
+const { safeDetectContractsType, computeContractsFundingNeeded, shouldResolveUserSigner } =
+    await import("./index.js");
+
+describe("shouldResolveUserSigner", () => {
+    it("skips signer lookup for pure dev deploys", () => {
+        expect(shouldResolveUserSigner({ mode: "dev" })).toBe(false);
+    });
+
+    it("loads the logged-in signer for dev deploys that publish to playground", () => {
+        expect(shouldResolveUserSigner({ mode: "dev", publishToPlayground: true })).toBe(true);
+    });
+
+    it("loads a signer for phone mode", () => {
+        expect(shouldResolveUserSigner({ mode: "phone" })).toBe(true);
+    });
+
+    it("loads a signer when a suri is supplied", () => {
+        expect(shouldResolveUserSigner({ mode: "dev", suri: "//Alice" })).toBe(true);
+    });
+});
 
 describe("safeDetectContractsType", () => {
     let tmp: string;

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -131,7 +131,13 @@ export const deployCommand = new Command("deploy")
                         "cli.deploy.preflight",
                         "deploy preflight",
                         { "cli.deploy.env": env },
-                        () => preflight({ env, suri: opts.suri, mode: opts.signer }),
+                        () =>
+                            preflight({
+                                env,
+                                suri: opts.suri,
+                                mode: opts.signer,
+                                publishToPlayground: opts.playground === true,
+                            }),
                     );
                 } catch (err) {
                     process.stderr.write(`\n✖ ${formatError(err)}\n`);
@@ -190,20 +196,21 @@ async function preflight(opts: {
     env: Env;
     suri?: string;
     mode?: SignerMode;
+    publishToPlayground?: boolean;
 }): Promise<ResolvedSigner | null> {
     // If the user explicitly asked for dev mode with no --playground and no
     // --suri, we don't need a signer at all.
-    const mayNeedSigner = opts.mode !== "dev" || opts.suri !== undefined;
-    if (!mayNeedSigner) return null;
+    if (!shouldResolveUserSigner(opts)) return null;
 
     let signer: ResolvedSigner;
     try {
         signer = await resolveSigner({ suri: opts.suri });
     } catch (err) {
         if (err instanceof SignerNotAvailableError) {
-            // Dev mode: we can still run without a signer as long as --playground
-            // wasn't asked for. The caller validates that separately.
-            if (opts.mode === "dev") return null;
+            // Pure dev mode can still run without a signer, but playground
+            // publish needs the logged-in account so registry ownership lands
+            // on the user instead of a shared dev key.
+            if (opts.mode === "dev" && !opts.publishToPlayground) return null;
             throw err;
         }
         throw err;
@@ -243,6 +250,14 @@ async function preflight(opts: {
     }
 
     return signer;
+}
+
+export function shouldResolveUserSigner(opts: {
+    suri?: string;
+    mode?: SignerMode;
+    publishToPlayground?: boolean;
+}): boolean {
+    return opts.mode !== "dev" || opts.suri !== undefined || opts.publishToPlayground === true;
 }
 
 // ── Dispatch ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Load the logged-in session signer when `dot deploy --signer dev --playground` is used
- Keep pure dev deploys without Playground publish on the no-session path
- Add coverage for the signer-resolution decision

## Testing

- `pnpm vitest run src/commands/deploy/index.test.ts`
- `npx tsc --noEmit`
- `pnpm format:check`