### PR TITLE
fix(e2e): unbreak dot mod test against live registry contract

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,6 @@ jobs:
             - name: Run E2E tests
               run: pnpm test:e2e
               env:
-                  TEST_TEMPLATE_DOMAIN: rock-paper-scissors.dot
+                  TEST_TEMPLATE_DOMAIN: dot-cli-mod-fixture.dot
                   TEST_TEMPLATE_REPO: https://github.com/paritytech/Rock-Paper-Scissors
                   DOT_DEPLOY_VERBOSE: "1"

--- a/e2e/cli/fixtures/registry.ts
+++ b/e2e/cli/fixtures/registry.ts
@@ -8,6 +8,11 @@ import { ContractManager } from "@polkadot-apps/contracts";
 import { createDevSigner, getDevPublicKey } from "@polkadot-apps/tx";
 import { ss58Encode } from "@polkadot-apps/address";
 import { getTestClient } from "../helpers/chain.js";
+import {
+	PLAYGROUND_REGISTRY_CONTRACT,
+	suppressReviveTraceNoise,
+	withRequiredLiveContractAddresses,
+} from "../../../src/utils/contractManifest.js";
 
 import cdmJson from "../../../cdm.json";
 
@@ -27,11 +32,19 @@ async function getRegistry(): Promise<Registry> {
 			const client = await getTestClient();
 			const aliceSigner = createDevSigner("Alice");
 			const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
-			const manager = await ContractManager.fromClient(cdmJson, client.raw.assetHub, {
+			// Mirror src/utils/registry.ts — query the CDM meta-registry for the
+			// live address before binding, so the helper reads from the same
+			// contract `dot mod` and `dot deploy` actually use. Without this,
+			// reads land on the cdm.json snapshot and silently diverge from the
+			// command paths after a registry redeploy. See issue #74.
+			const manifest = await withRequiredLiveContractAddresses(cdmJson, client.raw.assetHub, [
+				PLAYGROUND_REGISTRY_CONTRACT,
+			]);
+			const manager = await ContractManager.fromClient(manifest, client.raw.assetHub, {
 				defaultSigner: aliceSigner,
 				defaultOrigin: aliceAddress,
 			});
-			return manager.getContract("@w3s/playground-registry");
+			return suppressReviveTraceNoise(manager.getContract(PLAYGROUND_REGISTRY_CONTRACT));
 		})().catch((err) => {
 			// Reset so the next call can retry instead of replaying the error
 			registryPromise = null;
@@ -44,16 +57,21 @@ async function getRegistry(): Promise<Registry> {
 /**
  * Query the registry for an app entry by domain.
  * Returns null if not found.
+ *
+ * `getMetadataUri` returns an `Option<String>` shaped as `{ isSome, value }` —
+ * always a truthy object regardless of registration. The `isSome` flag is the
+ * real discriminator; check it explicitly. (See cdm.json's getMetadataUri ABI.)
  */
 export async function getApp(domain: string): Promise<AppEntry | null> {
 	try {
 		const registry = await getRegistry();
 		const res = await registry.getMetadataUri.query(domain);
-		if (!res.value) return null;
+		const tuple = res.value as { isSome?: boolean; value?: string } | undefined;
+		if (!tuple?.isSome) return null;
 		return {
 			domain,
 			owner: "",
-			metadataUri: String(res.value),
+			metadataUri: String(tuple.value ?? ""),
 		};
 	} catch {
 		return null;

--- a/tools/e2e-local.sh
+++ b/tools/e2e-local.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Launch the E2E suite locally with the same env defaults CI uses.
+#
+# Mirrors .github/workflows/e2e.yml so a local run reproduces CI bit-for-bit:
+#   - sets TEST_TEMPLATE_DOMAIN / TEST_TEMPLATE_REPO so the chain-dependent
+#     mod test isn't silently skipped via test.skipIf(!TEST_DOMAIN);
+#   - sets DOT_DEPLOY_VERBOSE=1 to surface deploy-pipeline detail on failure;
+#   - allocates a temp HOME so session state from ~/.polkadot-apps/ doesn't
+#     leak into tests (matches the runner's clean home).
+#
+# Usage:
+#   tools/e2e-local.sh                          # full suite
+#   tools/e2e-local.sh e2e/cli/mod.test.ts      # filter (forwarded to vitest)
+#   tools/e2e-local.sh -t "registry-miss"       # name filter
+#
+# Override any default by exporting it before invoking, e.g.:
+#   TEST_TEMPLATE_DOMAIN=foo.dot tools/e2e-local.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v ipfs >/dev/null 2>&1; then
+    echo "warning: ipfs (kubo) not found on PATH — deploy-pipeline tests that publish to Bulletin will fail." >&2
+    echo "         install with: brew install ipfs   (macOS), or follow https://docs.ipfs.tech/install/" >&2
+    echo "" >&2
+fi
+
+export TEST_TEMPLATE_DOMAIN="${TEST_TEMPLATE_DOMAIN:-dot-cli-mod-fixture.dot}"
+export TEST_TEMPLATE_REPO="${TEST_TEMPLATE_REPO:-https://github.com/paritytech/Rock-Paper-Scissors}"
+export DOT_DEPLOY_VERBOSE="${DOT_DEPLOY_VERBOSE:-1}"
+
+ISOLATED_HOME="$(mktemp -d -t dot-e2e-home-XXXXXX)"
+trap 'rm -rf "$ISOLATED_HOME"' EXIT
+export HOME="$ISOLATED_HOME"
+
+echo "→ TEST_TEMPLATE_DOMAIN  $TEST_TEMPLATE_DOMAIN"
+echo "→ TEST_TEMPLATE_REPO    $TEST_TEMPLATE_REPO"
+echo "→ DOT_DEPLOY_VERBOSE    $DOT_DEPLOY_VERBOSE"
+echo "→ HOME                  $HOME (isolated, removed on exit)"
+echo
+
+# Invoke vitest directly. Going through `pnpm test:e2e -- <filter>` swallows
+# the positional filter (the trailing `--` reaches vitest as end-of-options
+# and the filter never narrows the run).
+exec pnpm exec vitest run --config e2e/vitest.config.ts "$@"

--- a/tools/list-registry-apps.ts
+++ b/tools/list-registry-apps.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Enumerate apps on the live playground-registry contract on Paseo Asset Hub,
+ * and check whether each one's `metadata.repository` is reachable as a public
+ * GitHub repo. Useful for picking a stable e2e test target for `dot mod`.
+ *
+ * Usage:
+ *   bun tools/list-registry-apps.ts
+ */
+
+import { ContractManager, type CdmJson } from "@polkadot-apps/contracts";
+import { createDevSigner, getDevPublicKey } from "@polkadot-apps/tx";
+import { ss58Encode } from "@polkadot-apps/address";
+import { getGateway, fetchJson } from "@polkadot-apps/bulletin";
+import type { HexString } from "polkadot-api";
+import { getConnection, destroyConnection } from "../src/utils/connection.js";
+import {
+    PLAYGROUND_REGISTRY_CONTRACT,
+    withRequiredLiveContractAddresses,
+    withoutReviveTraceNoise,
+} from "../src/utils/contractManifest.js";
+import cdmJson from "../cdm.json";
+
+interface AppMetadata {
+    name?: string;
+    description?: string;
+    repository?: string;
+    branch?: string;
+}
+
+interface RegistryEntry {
+    domain: string;
+    metadata_uri: string;
+    owner: HexString;
+}
+
+async function probePublicGithub(repoUrl: string): Promise<{ ok: boolean; status: number }> {
+    const match = repoUrl.match(/github\.com[:/]+([^/]+)\/([^/.]+)/);
+    if (!match) return { ok: false, status: 0 };
+    const [, owner, repo] = match;
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+        headers: { Accept: "application/vnd.github.v3+json" },
+    });
+    return { ok: res.ok, status: res.status };
+}
+
+async function main(): Promise<number> {
+    const client = await getConnection();
+    try {
+        const manifest = await withRequiredLiveContractAddresses(
+            cdmJson as unknown as CdmJson,
+            client.raw.assetHub,
+        );
+        const aliceSigner = createDevSigner("Alice");
+        const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
+        const manager = await ContractManager.fromClient(manifest, client.raw.assetHub, {
+            defaultSigner: aliceSigner,
+            defaultOrigin: aliceAddress,
+        });
+        const registry = manager.getContract(PLAYGROUND_REGISTRY_CONTRACT);
+
+        const res = await withoutReviveTraceNoise(() => registry.getApps.query(0, 100));
+        const value = res.value as { entries: RegistryEntry[]; total: number };
+        console.log(`live registry has ${value.total} app(s); inspecting up to 100:\n`);
+
+        const gateway = getGateway("paseo");
+        for (const entry of value.entries) {
+            let meta: AppMetadata = {};
+            let metaErr = "";
+            try {
+                meta = await fetchJson<AppMetadata>(entry.metadata_uri, gateway);
+            } catch (e) {
+                metaErr = e instanceof Error ? e.message.slice(0, 60) : String(e).slice(0, 60);
+            }
+            const repo = meta.repository ?? "";
+            let probe = "—";
+            if (repo) {
+                try {
+                    const r = await probePublicGithub(repo);
+                    probe = r.ok ? "PUBLIC ✓" : `${r.status}`;
+                } catch {
+                    probe = "fetch-err";
+                }
+            }
+            console.log(
+                `  ${entry.domain.padEnd(36)}  repo=${(repo || metaErr || "<no repo>").padEnd(60)}  github=${probe}`,
+            );
+        }
+        return 0;
+    } finally {
+        destroyConnection();
+    }
+}
+
+main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+        console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+        process.exit(2);
+    });

--- a/tools/probe-registry-resolution.ts
+++ b/tools/probe-registry-resolution.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+/**
+ * Diagnostic probe for issue paritytech/playground-cli#74.
+ *
+ * Compares the playground-registry address that the CDM meta-registry
+ * currently resolves to (the path `dot mod` takes since 2026-04-30) against
+ * the address baked into `cdm.json` (the path the e2e setup helper still
+ * uses), and reports whether a target domain is registered against each.
+ *
+ * Usage:
+ *   bun tools/probe-registry-resolution.ts                 # default domain
+ *   bun tools/probe-registry-resolution.ts foo.dot         # custom domain
+ *
+ * Exit codes:
+ *   0  probe completed (regardless of registration outcome)
+ *   2  unexpected error (RPC down, type error, etc.)
+ */
+
+import { ContractManager, type CdmJson } from "@polkadot-apps/contracts";
+import { createDevSigner, getDevPublicKey } from "@polkadot-apps/tx";
+import { ss58Encode } from "@polkadot-apps/address";
+import type { HexString } from "polkadot-api";
+import { getConnection, destroyConnection } from "../src/utils/connection.js";
+import {
+    PLAYGROUND_REGISTRY_CONTRACT,
+    resolveLiveContractAddresses,
+    withoutReviveTraceNoise,
+} from "../src/utils/contractManifest.js";
+import cdmJson from "../cdm.json";
+
+const DEFAULT_DOMAIN = "rock-paper-scissors.dot";
+
+function bakedAddress(manifest: CdmJson): HexString {
+    const target = Object.keys(manifest.targets)[0];
+    if (!target) throw new Error("cdm.json has no targets");
+    const contract = manifest.contracts?.[target]?.[PLAYGROUND_REGISTRY_CONTRACT];
+    if (!contract) throw new Error(`cdm.json has no ${PLAYGROUND_REGISTRY_CONTRACT} entry`);
+    return contract.address as HexString;
+}
+
+function withAddressOverride(manifest: CdmJson, address: HexString): CdmJson {
+    const patched = structuredClone(manifest);
+    const target = Object.keys(patched.targets)[0]!;
+    const contract = patched.contracts?.[target]?.[PLAYGROUND_REGISTRY_CONTRACT];
+    if (contract) contract.address = address;
+    return patched;
+}
+
+interface ProbeResult {
+    success: boolean;
+    isSome: boolean;
+    value: string;
+}
+
+async function queryDomain(
+    rawClient: Parameters<typeof ContractManager.fromClient>[1],
+    address: HexString,
+    domain: string,
+): Promise<ProbeResult> {
+    const manifest = withAddressOverride(cdmJson as unknown as CdmJson, address);
+    const aliceSigner = createDevSigner("Alice");
+    const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
+    const manager = await ContractManager.fromClient(manifest, rawClient, {
+        defaultSigner: aliceSigner,
+        defaultOrigin: aliceAddress,
+    });
+    const registry = manager.getContract(PLAYGROUND_REGISTRY_CONTRACT);
+    const res = await withoutReviveTraceNoise(() => registry.getMetadataUri.query(domain));
+    const tuple = res.value as { isSome?: boolean; value?: string } | undefined;
+    return {
+        success: (res as { success?: boolean }).success ?? true,
+        isSome: tuple?.isSome ?? false,
+        value: tuple?.value ?? "",
+    };
+}
+
+async function main(): Promise<number> {
+    const domain = process.argv[2] ?? process.env.DOMAIN ?? DEFAULT_DOMAIN;
+    const baked = bakedAddress(cdmJson as unknown as CdmJson);
+
+    console.log(`probing ${PLAYGROUND_REGISTRY_CONTRACT}`);
+    console.log(`  network    paseo asset hub`);
+    console.log(`  domain     ${domain}`);
+    console.log(`  cdm.json   ${baked}`);
+
+    const client = await getConnection();
+    try {
+        const liveMap = await resolveLiveContractAddresses(client.raw.assetHub);
+        const live = liveMap[PLAYGROUND_REGISTRY_CONTRACT] ?? null;
+        console.log(`  meta→live  ${live ?? "<none>"}`);
+        console.log();
+
+        if (!live) {
+            console.log("meta-registry returned None — dot mod would throw BadRegistryLookup.");
+        } else if (live.toLowerCase() === baked.toLowerCase()) {
+            console.log("addresses match — dot mod and cdm.json snapshot point at the same contract.");
+        } else {
+            console.log("addresses DIVERGE — dot mod and cdm.json snapshot point at different contracts.");
+        }
+        console.log();
+
+        const bakedRes = await queryDomain(client.raw.assetHub, baked, domain);
+        console.log(`getMetadataUri(${domain}) @ baked  ${baked}`);
+        console.log(`  isSome  = ${bakedRes.isSome}`);
+        if (bakedRes.isSome) console.log(`  value   = ${bakedRes.value}`);
+
+        if (live && live.toLowerCase() !== baked.toLowerCase()) {
+            const liveRes = await queryDomain(client.raw.assetHub, live, domain);
+            console.log();
+            console.log(`getMetadataUri(${domain}) @ live   ${live}`);
+            console.log(`  isSome  = ${liveRes.isSome}`);
+            if (liveRes.isSome) console.log(`  value   = ${liveRes.value}`);
+        }
+
+        return 0;
+    } finally {
+        destroyConnection();
+    }
+}
+
+main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+        console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+        process.exit(2);
+    });

--- a/tools/register-mod-fixture.ts
+++ b/tools/register-mod-fixture.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+/**
+ * Register a domain on the live playground-registry contract with metadata
+ * that points at a public GitHub repo, so `dot mod <domain>` has a stable
+ * happy-path target for E2E tests.
+ *
+ * Defaults register `dot-cli-mod-fixture.dot` → `paritytech/Rock-Paper-Scissors`
+ * signed by the dedicated E2E deployer (SIGNER from e2e/cli/fixtures/accounts.ts).
+ * Same-owner re-publish is permitted by the registry contract, so subsequent
+ * runs of this tool simply update the metadata in place.
+ *
+ * Usage:
+ *   bun tools/register-mod-fixture.ts                                         # all defaults
+ *   bun tools/register-mod-fixture.ts --domain foo.dot --repo https://...     # override
+ *   bun tools/register-mod-fixture.ts --suri //Alice                          # custom signer
+ *
+ * Auto-tops-up SIGNER from the CLI's funder chain if balance is too low to
+ * cover the publish extrinsic, matching the e2e setup behavior.
+ */
+
+import { resolveSigner } from "../src/utils/signer.js";
+import { publishToPlayground } from "../src/utils/deploy/playground.js";
+import { getConnection, destroyConnection } from "../src/utils/connection.js";
+import { ensureFunded, checkBalance, MIN_BALANCE } from "../src/utils/account/funding.js";
+import {
+    DEDICATED_E2E_DEPLOYER_MNEMONIC,
+} from "../e2e/cli/fixtures/accounts.js";
+
+const DEFAULT_DOMAIN = "dot-cli-mod-fixture.dot";
+const DEFAULT_REPO = "https://github.com/paritytech/Rock-Paper-Scissors";
+const DEFAULT_SURI = `${DEDICATED_E2E_DEPLOYER_MNEMONIC}//e2e-deployer`;
+
+const DOT = 10_000_000_000n;
+/** Top-up target if SIGNER is short. Same as e2e setup. */
+const TOPUP_TARGET = 500n * DOT;
+const TOPUP_AMOUNT = 1000n * DOT;
+
+interface Args {
+    domain: string;
+    repo: string;
+    suri: string;
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = { domain: DEFAULT_DOMAIN, repo: DEFAULT_REPO, suri: DEFAULT_SURI };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        const next = argv[i + 1];
+        if (arg === "--domain" && next) {
+            args.domain = next;
+            i++;
+        } else if (arg === "--repo" && next) {
+            args.repo = next;
+            i++;
+        } else if (arg === "--suri" && next) {
+            args.suri = next;
+            i++;
+        } else if (arg === "--help" || arg === "-h") {
+            console.log("Usage: bun tools/register-mod-fixture.ts [--domain X] [--repo Y] [--suri Z]");
+            process.exit(0);
+        } else {
+            throw new Error(`Unknown arg: ${arg}`);
+        }
+    }
+    return args;
+}
+
+async function main(): Promise<number> {
+    const args = parseArgs(process.argv.slice(2));
+
+    console.log(`registering mod fixture`);
+    console.log(`  domain  ${args.domain}`);
+    console.log(`  repo    ${args.repo}`);
+
+    const signer = await resolveSigner({ suri: args.suri });
+    console.log(`  signer  ${signer.address} (${signer.source})`);
+    console.log();
+
+    try {
+        const client = await getConnection();
+        const balance = await checkBalance(client, signer.address, TOPUP_TARGET);
+        console.log(`signer balance: ${balance.free / DOT} DOT`);
+        if (!balance.sufficient) {
+            console.log(`balance below ${TOPUP_TARGET / DOT} DOT — topping up by ${TOPUP_AMOUNT / DOT} DOT…`);
+            await ensureFunded(client, signer.address, TOPUP_TARGET, TOPUP_AMOUNT);
+            const after = await checkBalance(client, signer.address, MIN_BALANCE);
+            console.log(`topped up: ${after.free / DOT} DOT`);
+        }
+        console.log();
+
+        const result = await publishToPlayground({
+            domain: args.domain,
+            publishSigner: signer,
+            repositoryUrl: args.repo,
+            onLogEvent: (event) => {
+                if (event.kind === "info") console.log(`  • ${event.message}`);
+            },
+        });
+
+        console.log();
+        console.log(`✓ published ${result.fullDomain}`);
+        console.log(`  metadataCid  ${result.metadataCid}`);
+        console.log(`  metadata     ${JSON.stringify(result.metadata)}`);
+        console.log();
+        console.log(`verify with: bun tools/probe-registry-resolution.ts ${result.fullDomain}`);
+        return 0;
+    } finally {
+        signer.destroy();
+        destroyConnection();
+    }
+}
+
+main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+        console.error(err instanceof Error ? (err.stack ?? err.message) : String(err));
+        process.exit(2);
+    });


### PR DESCRIPTION
## Summary

Fixes #74. The `dot mod` E2E test has been failing on every CI run since 2026-04-30. Three compounding issues, all addressed here.

### What was wrong

1. **Address divergence.** `dot mod` resolves the live `@w3s/playground-registry` address through the CDM meta-registry (currently `0xc227f0BFCc5CD42FBa0aF92BAf7f7E857e977918`). The e2e setup helper (`e2e/cli/fixtures/registry.ts`) still talked straight to the snapshot address baked into `cdm.json` (`0x4A37B123b0BA2A894cA5953f472264921d44e298`). The two contracts have diverged: the legacy snapshot still has `rock-paper-scissors.dot`, the live contract does not. Setup logged \"Template verified in registry\" against a contract `dot mod` no longer reads from.

2. **Latent shape bug in `getApp()`.** `getMetadataUri` returns an `Option<String>` shaped as `{ isSome, value }`. The helper checked `if (!res.value) return null` — but `res.value` is the tuple object itself, always truthy regardless of registration. `ensureTemplateRegistered()` was a silent no-op for years; the divergence above just made it visible.

3. **No registered domain pointed at a public modable repo.** Even after fixes 1 and 2, the only on-chain entry with a `repository` field (`playgroundtest.dot`) pointed at `paritytech/playground-app`, which is 404. None of the SIGNER-owned `e2e-cli-*` domains have a `repository` field.

### What this PR does

- **`e2e/cli/fixtures/registry.ts`**: register helper now goes through `withRequiredLiveContractAddresses` so reads land on the same contract `dot mod` and `dot deploy` use; `getApp()` unwraps the `isSome` flag explicitly; `suppressReviveTraceNoise` wraps the contract handle so setup logs aren't polluted by the harmless `ReviveApi_trace_call` stack.
- **One on-chain action (already executed)**: registered `dot-cli-mod-fixture.dot` against the live contract with metadata `{\"repository\":\"https://github.com/paritytech/Rock-Paper-Scissors\"}`, owned by SIGNER. Same-owner re-publish is permitted, so future updates are idempotent.
- **`.github/workflows/e2e.yml`**: workflow now points at the new fixture domain.
- **New tools (`tools/`)** to make the next regression diagnosable in seconds rather than three CI runs:
    - `probe-registry-resolution.ts` — print cdm.json vs meta-registry-resolved address, run `getMetadataUri` against both for any domain.
    - `list-registry-apps.ts` — enumerate the live registry and HEAD each app's GitHub repo for reachability.
    - `register-mod-fixture.ts` — idempotent re-publish of the mod fixture; run after any future contract redeploy. Auto-tops-up SIGNER from the funder chain when low.
    - `e2e-local.sh` — run the suite with CI-mirrored env defaults (`TEST_TEMPLATE_DOMAIN`, `TEST_TEMPLATE_REPO`, `DOT_DEPLOY_VERBOSE`) and an isolated `HOME`. Calls vitest directly so positional filters propagate (the `pnpm test:e2e -- <filter>` form silently drops the filter, which is why local runs of PR #73 \"passed\" — the failing test was just being skipped).

### Verification

```
tools/e2e-local.sh e2e/cli/mod.test.ts
…
[e2e setup] Template \"dot-cli-mod-fixture.dot\" verified in registry
 ✓ dot mod > clones the registered template into a fresh directory  29991ms
 ✓ dot mod > reports a registry-miss for an unknown domain            883ms
 ✓ dot mod > exits non-zero with signer suggestion when no signer     3443ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Operational note

`dot-cli-mod-fixture.dot` is now permanent shared state on Paseo Asset Hub. If the registry contract is ever redeployed (which is what triggered #74 in the first place), the fixture won't survive the migration. Re-run `bun tools/register-mod-fixture.ts` to re-establish it, or `bun tools/probe-registry-resolution.ts dot-cli-mod-fixture.dot` to check status.

### Out of scope — separate follow-up

Four other E2E failures remain on `main` and are not addressed here: a flake on `dot install > dot update` and three deploy-pipeline tests (`storage` / `redeploy` / `collision` first-publish). The deploy ones are likely the live-registry equivalent of #74 inside the deploy path, but they need their own diagnosis. Filing a separate issue.

## Test plan

- [x] `tools/e2e-local.sh e2e/cli/mod.test.ts` — 3/3 mod tests pass.
- [x] Fixture verified on-chain via `tools/probe-registry-resolution.ts dot-cli-mod-fixture.dot` — Some at live address with the expected CID.
- [ ] CI E2E run on this PR — confirm the mod test goes from 3-runs-of-failure to green.