### PR TITLE
fix(tools): ipfs init in isolated HOME so e2e-local.sh runs deploy tests

### DIFF
--- a/tools/e2e-local.sh
+++ b/tools/e2e-local.sh
@@ -35,6 +35,15 @@ ISOLATED_HOME="$(mktemp -d -t dot-e2e-home-XXXXXX)"
 trap 'rm -rf "$ISOLATED_HOME"' EXIT
 export HOME="$ISOLATED_HOME"
 
+# Bootstrap a fresh IPFS repo in the isolated HOME. The deploy tests shell
+# out to `ipfs add` (via bulletin-deploy's Kubo path), and IPFS resolves the
+# repo location from `$HOME/.ipfs` by default. Without this, the deploy
+# tests fail with "no IPFS repo found in <isolated home>/.ipfs". CI does
+# the same thing in the workflow's `ipfs init --profile=test` step.
+if command -v ipfs >/dev/null 2>&1; then
+    ipfs init --profile=test >/dev/null 2>&1 || true
+fi
+
 echo "→ TEST_TEMPLATE_DOMAIN  $TEST_TEMPLATE_DOMAIN"
 echo "→ TEST_TEMPLATE_REPO    $TEST_TEMPLATE_REPO"
 echo "→ DOT_DEPLOY_VERBOSE    $DOT_DEPLOY_VERBOSE"


### PR DESCRIPTION
Tiny follow-up to #78. The helper script `tools/e2e-local.sh` allocates a temp `HOME` so session state from `~/.polkadot-apps/` doesn't leak between tests, but never bootstraps an IPFS repo in that temp dir. The deploy E2E tests shell out to `ipfs add` (via bulletin-deploy's Kubo path), which resolves `$HOME/.ipfs` and fails with:

```
Error: no IPFS repo found in /var/folders/.../dot-e2e-home-XXXXXX/.ipfs.
please run: 'ipfs init'
```

Reproduced locally while validating PR #73's E2E run: 4 tests failed (all 3 deploy tests + the install/update flake), and the deploy failures all bottomed out on this `no IPFS repo` error rather than anything in the actual code paths. With this fix applied, the deploy tests pass and the suite goes 26/27 (the remaining fail is the unrelated `dot install > dot update` flake tracked in #79).

Mirrors what CI does in `.github/workflows/e2e.yml`:

```yaml
- name: Install Kubo (IPFS)
  run: |
      ...
      ipfs init --profile=test
```

CI is unaffected by this change — `pnpm test:e2e` runs vitest directly in CI, not via this helper script.

## Test plan

- [x] `tools/e2e-local.sh e2e/cli/deploy.test.ts` — deploy tests reach `registry.publish` instead of crashing on missing IPFS repo.
- [x] `tools/e2e-local.sh` (full suite) — 26/27 pass; only `dot install > dot update` (#79) fails.