### PR TITLE
ci: E2E suite Phase 1 — reporting + tagging

### DIFF
--- a/.changeset/e2e-phase-1-reporting.md
+++ b/.changeset/e2e-phase-1-reporting.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+CI now posts a sticky E2E test-pass comment on every PR with per-test pass/fail counts and Sentry triage links. Nightly schedule failures auto-open a GitHub issue. Per-cell forensic logs (`dot-runs.log`) and JUnit XML are uploaded as workflow artefacts. Test traffic is tagged with `cli.tag:e2e-ci-{pr|nightly|dispatch}` so production Sentry dashboards can filter it out.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,6 +74,16 @@ jobs:
                   DOT_TAG: ${{ steps.tag.outputs.tag }}
                   DOT_TELEMETRY: "1"
 
+            - name: Upload forensic artefacts
+              if: always()
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-reports-current
+                  path: e2e-reports/
+                  retention-days: 7
+                  if-no-files-found: ignore
+
     report:
         name: E2E Report
         needs: [test]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,8 @@ jobs:
               id: tag
               shell: bash
               run: |
+                  # Phase 1 triggers: pull_request / push:main / schedule / workflow_dispatch.
+                  # Phase 7 will add `release` (with TAG=e2e-ci-release).
                   case "${{ github.event_name }}" in
                       schedule)            TAG=e2e-ci-nightly  ;;
                       workflow_dispatch)   TAG=e2e-ci-dispatch ;;
@@ -92,6 +94,9 @@ jobs:
         timeout-minutes: 5
         steps:
             - name: Download JUnit + forensic artefacts
+              # Phase 1 has one upload (e2e-reports-current). When Phase 4 adds
+              # the matrix, drop `merge-multiple: true` and parse per-cell sub-dirs
+              # so per-leg junit.xml don't collide on the same flat path.
               uses: actions/download-artifact@v4
               with:
                   pattern: e2e-reports-*
@@ -204,7 +209,10 @@ jobs:
                   fi
 
                   # ---- Part 3: Sentry traces link ----
-                  # Only the traces URL — works against any cli.tag value.
+                  # Project ID 4511298552135760 mirrors src/telemetry-config.ts (PLAYGROUND_SENTRY_DSN
+                  # → o4511059872841728 / 4511298552135760) and sentry/dashboards/2143100.json.
+                  # If the project is ever rotated, update all three together.
+                  # Only the traces URL is emitted — it works against any cli.tag value.
                   # The "E2E Health dashboard" link is intentionally NOT emitted in
                   # Phase 1 (requires manual one-time dashboard creation per spec §9a).
                   {
@@ -263,14 +271,9 @@ jobs:
               shell: /usr/bin/bash -euo pipefail {0}
               run: |
                   TODAY=$(date -u +%Y-%m-%d)
-                  case "$TAG" in
-                      e2e-ci-release)  TITLE="Release E2E failure: ${{ github.event.release.tag_name }}" ;;
-                      *)               TITLE="Nightly E2E failure: $TODAY" ;;
-                  esac
+                  TITLE="Nightly E2E failure: $TODAY"
                   CONTEXT="Nightly E2E failed on $TODAY (tag \`$TAG\`)."
-                  case "$TAG" in
-                      e2e-ci-release)  CONTEXT="Release E2E failed for ${{ github.event.release.tag_name }}." ;;
-                  esac
+                  # Release-trigger branches will be added in Phase 7 (post-Phase-4).
 
                   {
                       echo "$CONTEXT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,11 +9,22 @@ on:
         - cron: "0 6 * * *"
     workflow_dispatch:
 
+permissions:
+    pull-requests: write     # sticky PR comment posting
+    issues: write            # auto-issue on schedule fail
+    actions: read            # /runs/{id}/jobs API for per-leg fetch
+
+concurrency:
+    group: e2e-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-    e2e:
-        name: E2E Tests
+    test:
+        name: "E2E · current"
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        outputs:
+            tag: ${{ steps.tag.outputs.tag }}
         steps:
             - uses: actions/checkout@v4
 
@@ -62,3 +73,15 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.tag.outputs.tag }}
                   DOT_TELEMETRY: "1"
+
+    report:
+        name: E2E Report
+        needs: [test]
+        if: always()
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Placeholder — implemented in Tasks 6–8
+              run: |
+                  echo "test job result: ${{ needs.test.result }}"
+                  echo "(report job logic added in subsequent tasks)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,8 +49,13 @@ jobs:
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                   echo "Resolved DOT_TAG=$TAG (event=${{ github.event_name }})"
 
-            - name: Run E2E tests
-              run: pnpm test:e2e
+            - name: Run E2E tests (one retry on transient testnet failures)
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 25
+                  max_attempts: 2
+                  retry_wait_seconds: 30
+                  command: pnpm test:e2e
               env:
                   TEST_TEMPLATE_DOMAIN: dot-cli-mod-fixture.dot
                   TEST_TEMPLATE_REPO: https://github.com/paritytech/Rock-Paper-Scissors

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,11 @@ on:
     schedule:
         - cron: "0 6 * * *"
     workflow_dispatch:
+        inputs:
+            simulate_failure:
+                description: "[temporary, Phase 1 verification only] Force the auto-issue path to fire"
+                type: boolean
+                default: false
 
 permissions:
     pull-requests: write     # sticky PR comment posting
@@ -206,3 +211,76 @@ jobs:
                   echo ""
                   echo "---- writing to step summary ----"
                   cat /tmp/body.md >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Post or update PR comment
+              if: github.event_name == 'pull_request'
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('fs');
+                      const body = fs.readFileSync('/tmp/body.md', 'utf8');
+                      const marker = '<!-- e2e-pr-report -->';
+                      const prNumber = context.issue.number;
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: prNumber,
+                      });
+                      const existing = comments.find(c => c.body && c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                          console.log(`Updated existing comment ${existing.id}`);
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: prNumber,
+                              body,
+                          });
+                          console.log("Created new comment");
+                      }
+
+            - name: Open failure issue
+              if: >
+                  (
+                    (github.event_name == 'schedule' || github.event_name == 'release') &&
+                    needs.test.result != 'success'
+                  ) ||
+                  (github.event_name == 'workflow_dispatch' && inputs.simulate_failure == true)
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG: ${{ needs.test.outputs.tag }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  API_URL: ${{ github.api_url }}
+                  REPO: ${{ github.repository }}
+              shell: /usr/bin/bash -euo pipefail {0}
+              run: |
+                  TODAY=$(date -u +%Y-%m-%d)
+                  case "$TAG" in
+                      e2e-ci-release)  TITLE="Release E2E failure: ${{ github.event.release.tag_name }}" ;;
+                      *)               TITLE="Nightly E2E failure: $TODAY" ;;
+                  esac
+                  CONTEXT="Nightly E2E failed on $TODAY (tag \`$TAG\`)."
+                  case "$TAG" in
+                      e2e-ci-release)  CONTEXT="Release E2E failed for ${{ github.event.release.tag_name }}." ;;
+                  esac
+
+                  {
+                      echo "$CONTEXT"
+                      echo ""
+                      cat /tmp/body.md
+                      echo ""
+                      echo "- Run: $RUN_URL"
+                  } > /tmp/issue-body.md
+
+                  BODY=$(cat /tmp/issue-body.md)
+                  curl -fsSL -X POST \
+                      -H "Authorization: bearer $GITHUB_TOKEN" \
+                      -H "Accept: application/vnd.github+json" \
+                      "$API_URL/repos/$REPO/issues" \
+                      -d "$(jq -n --arg title "$TITLE" --arg body "$BODY" '{title: $title, body: $body}')"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,11 +37,23 @@ jobs:
 
             - run: pnpm install
 
+            - name: Resolve DOT_TAG from trigger
+              id: tag
+              shell: bash
+              run: |
+                  case "${{ github.event_name }}" in
+                      schedule)            TAG=e2e-ci-nightly  ;;
+                      workflow_dispatch)   TAG=e2e-ci-dispatch ;;
+                      *)                   TAG=e2e-ci-pr       ;;
+                  esac
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                  echo "Resolved DOT_TAG=$TAG (event=${{ github.event_name }})"
+
             - name: Run E2E tests
               run: pnpm test:e2e
               env:
                   TEST_TEMPLATE_DOMAIN: dot-cli-mod-fixture.dot
                   TEST_TEMPLATE_REPO: https://github.com/paritytech/Rock-Paper-Scissors
                   DOT_DEPLOY_VERBOSE: "1"
-                  DOT_TAG: e2e-ci
+                  DOT_TAG: ${{ steps.tag.outputs.tag }}
                   DOT_TELEMETRY: "1"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,11 +8,6 @@ on:
     schedule:
         - cron: "0 6 * * *"
     workflow_dispatch:
-        inputs:
-            simulate_failure:
-                description: "[temporary, Phase 1 verification only] Force the auto-issue path to fire"
-                type: boolean
-                default: false
 
 permissions:
     pull-requests: write     # sticky PR comment posting
@@ -247,11 +242,8 @@ jobs:
 
             - name: Open failure issue
               if: >
-                  (
-                    (github.event_name == 'schedule' || github.event_name == 'release') &&
-                    needs.test.result != 'success'
-                  ) ||
-                  (github.event_name == 'workflow_dispatch' && inputs.simulate_failure == true)
+                  (github.event_name == 'schedule' || github.event_name == 'release') &&
+                  needs.test.result != 'success'
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   TAG: ${{ needs.test.outputs.tag }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,128 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
-            - name: Placeholder — implemented in Tasks 6–8
+            - name: Download JUnit + forensic artefacts
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: e2e-reports-*
+                  path: artefacts/
+                  merge-multiple: true
+
+            - name: Install xmlstarlet (for JUnit parsing)
+              run: sudo apt-get update -q && sudo apt-get install -y -q xmlstarlet
+
+            - name: Fetch per-leg job conclusions
+              id: legs
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              shell: /usr/bin/bash -euo pipefail {0}
               run: |
-                  echo "test job result: ${{ needs.test.result }}"
-                  echo "(report job logic added in subsequent tasks)"
+                  curl -fsSL \
+                      -H "Authorization: bearer $GITHUB_TOKEN" \
+                      -H "Accept: application/vnd.github+json" \
+                      "${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+                      | jq -r '.jobs[] | select(.name | startswith("E2E · ")) | "\(.name)\t\(.conclusion)\t\((.completed_at // now | fromdateiso8601) - (.started_at | fromdateiso8601))"' \
+                      > /tmp/legs.tsv
+                  if [ ! -s /tmp/legs.tsv ]; then
+                      echo "::error::No 'E2E · …' jobs found in run ${{ github.run_id }}; matrix-job naming may have changed."
+                      exit 1
+                  fi
+                  echo "Per-leg conclusions:"
+                  cat /tmp/legs.tsv
+
+            - name: Parse JUnit and render report body
+              env:
+                  AGGREGATE: ${{ needs.test.result }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  TAG: ${{ needs.test.outputs.tag }}
+              shell: /usr/bin/bash -euo pipefail {0}
+              run: |
+                  emoji() { case "$1" in
+                      success)   echo "✅ PASS";;
+                      failure)   echo "❌ FAIL";;
+                      skipped)   echo "⏭️ SKIP";;
+                      cancelled) echo "🚫 CANCEL";;
+                      *)         echo "❓ $1";;
+                  esac; }
+
+                  BRANCH="${{ github.head_ref || github.ref_name }}"
+                  SHA_SHORT="${GITHUB_SHA:0:7}"
+                  TAG_LABEL="${TAG:-e2e-ci-pr}"
+
+                  # ---- Part 1: per-cell summary table ----
+                  {
+                      echo "<!-- e2e-pr-report -->"
+                      echo "## E2E Test Pass · $(emoji "$AGGREGATE")"
+                      echo ""
+                      echo "Tag: \`$TAG_LABEL\` · Branch: \`$BRANCH\` · Commit: \`$SHA_SHORT\` · [Run logs]($RUN_URL)"
+                      echo ""
+                      echo "| Cell | Result | Time |"
+                      echo "|------|--------|------|"
+                      while IFS=$'\t' read -r name conclusion duration; do
+                          dur_min=$(awk -v d="$duration" 'BEGIN{ printf "%dm%02ds", int(d/60), int(d%60) }')
+                          echo "| \`${name#E2E · }\` | $(emoji "$conclusion") | $dur_min |"
+                      done < /tmp/legs.tsv
+                      echo ""
+                  } > /tmp/body.md
+
+                  # ---- Part 2: failures detail block (only if any test failed) ----
+                  FAILS_FILE=/tmp/failures.tsv
+                  : > "$FAILS_FILE"
+
+                  # nullglob so non-matching globs expand to nothing.
+                  shopt -s nullglob
+                  XML_FILES=( artefacts/junit*.xml artefacts/*/junit*.xml )
+                  shopt -u nullglob
+
+                  if command -v xmlstarlet >/dev/null 2>&1; then
+                      for xml in "${XML_FILES[@]}"; do
+                          xmlstarlet sel -t -m "//testcase[failure or error]" \
+                              -v "concat(@classname, ' › ', @name)" -o $'\t' \
+                              -v "failure/@message | error/@message" -n "$xml" \
+                              >> "$FAILS_FILE" || true
+                      done
+                  else
+                      for xml in "${XML_FILES[@]}"; do
+                          grep -E '<testcase|<failure|<error' "$xml" \
+                              | awk '/<testcase/{name=$0} /<failure|<error/{print name "\t" $0}' \
+                              >> "$FAILS_FILE" || true
+                      done
+                  fi
+
+                  if [ -s "$FAILS_FILE" ]; then
+                      FAIL_COUNT=$(wc -l < "$FAILS_FILE")
+                      MAX_LINES=100
+                      TRUNCATED=$([ "$FAIL_COUNT" -gt "$MAX_LINES" ] && echo "1" || echo "0")
+                      {
+                          echo "<details><summary>❌ Failed tests ($FAIL_COUNT)</summary>"
+                          echo ""
+                          head -n "$MAX_LINES" "$FAILS_FILE" | while IFS=$'\t' read -r name msg; do
+                              msg_clean=$(echo "$msg" | sed -E 's/<[^>]+>//g; s/&quot;/"/g; s/&amp;/\&/g; s/&lt;/</g; s/&gt;/>/g')
+                              msg_first3=$(echo "$msg_clean" | head -3 | sed 's/^/  /')
+                              echo "- \`$name\`"
+                              echo "$msg_first3"
+                          done
+                          if [ "$TRUNCATED" = "1" ]; then
+                              REMAINING=$((FAIL_COUNT - MAX_LINES))
+                              echo ""
+                              echo "... and $REMAINING more failures (see [run logs]($RUN_URL))"
+                          fi
+                          echo ""
+                          echo "</details>"
+                          echo ""
+                      } >> /tmp/body.md
+                  fi
+
+                  # ---- Part 3: Sentry traces link ----
+                  # Only the traces URL — works against any cli.tag value.
+                  # The "E2E Health dashboard" link is intentionally NOT emitted in
+                  # Phase 1 (requires manual one-time dashboard creation per spec §9a).
+                  {
+                      echo "**Sentry traces:** [view spans for this run](https://paritytech.sentry.io/explore/traces/?project=4511298552135760&query=cli.tag%3A$TAG_LABEL)"
+                  } >> /tmp/body.md
+
+                  echo "Rendered body:"
+                  cat /tmp/body.md
+                  echo ""
+                  echo "---- writing to step summary ----"
+                  cat /tmp/body.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,7 +101,7 @@ jobs:
                       -H "Authorization: bearer $GITHUB_TOKEN" \
                       -H "Accept: application/vnd.github+json" \
                       "${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
-                      | jq -r '.jobs[] | select(.name | startswith("E2E · ")) | "\(.name)\t\(.conclusion)\t\((.completed_at // now | fromdateiso8601) - (.started_at | fromdateiso8601))"' \
+                      | jq -r '.jobs[] | select(.name | startswith("E2E · ")) | "\(.name)\t\(.conclusion)\t\((.completed_at // now | fromdateiso8601) - (.started_at // now | fromdateiso8601))"' \
                       > /tmp/legs.tsv
                   if [ ! -s /tmp/legs.tsv ]; then
                       echo "::error::No 'E2E · …' jobs found in run ${{ github.run_id }}; matrix-job naming may have changed."
@@ -177,7 +177,7 @@ jobs:
                           echo "<details><summary>❌ Failed tests ($FAIL_COUNT)</summary>"
                           echo ""
                           head -n "$MAX_LINES" "$FAILS_FILE" | while IFS=$'\t' read -r name msg; do
-                              msg_clean=$(echo "$msg" | sed -E 's/<[^>]+>//g; s/&quot;/"/g; s/&amp;/\&/g; s/&lt;/</g; s/&gt;/>/g')
+                              msg_clean=$(echo "$msg" | sed -E 's/<[^>]+>//g; s/&quot;/"/g; s/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g')
                               msg_first3=$(echo "$msg_clean" | head -3 | sed 's/^/  /')
                               echo "- \`$name\`"
                               echo "$msg_first3"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
     test:
         name: "E2E · current"
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 55
         outputs:
             tag: ${{ steps.tag.outputs.tag }}
         steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs-internal/
 .worktrees/
 reference-repos/
 .tokensave
+e2e-reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,16 @@ These are things that aren't self-evident from reading the code and have bitten 
   - `2216067.json` — **Playground CLI Failures** (per-error-type drill-downs).
   - `2216096.json` — **Playground CLI E2E Health** (inverse filter, `cli.tag:e2e-*`).
 - **Workflow:** run `./sentry/backup-dashboards.sh` BEFORE any change. Use `./sentry/patch-dashboard.py <id> <patch.json>` for surgical edits (supports `replace`, `patch_query`, `set_description` ops) or full widget replacement. Use `./sentry/create-dashboard.py <payload.json>` for new dashboards. Per spec §15f, do NOT include a `projects` field in POST payloads. Per spec §15g, PUT replaces the whole widget list — backup first.
-- **E2E tagging:** every spawn from `e2e/cli/helpers/dot.ts` injects `DOT_TAG=e2e-local` (default) and `DOT_TELEMETRY=1`. CI sets `DOT_TAG=e2e-ci` in `.github/workflows/e2e.yml` so production health widgets filter cleanly via `!cli.tag:e2e-*`.
+- **E2E tagging:** every spawn from `e2e/cli/helpers/dot.ts` injects `DOT_TAG=e2e-local` (fallback) and `DOT_TELEMETRY=1`. `tools/e2e-local.sh` overrides that to `e2e-local-{smoke|pr|nightly}` based on the mode argument. CI sets `DOT_TAG=e2e-ci-{pr|nightly|dispatch}` in `.github/workflows/e2e.yml` so production health widgets filter cleanly via `!cli.tag:e2e-*`.
 - **SAD% propagation** is verified by a regression test in `src/telemetry.test.ts` ("SAD% propagation through transaction envelope"). It confirms `captureWarning` flips `cli.sad="true"` on the root transaction. If that test fails, the SAD% dashboard widget on Dashboard 1 will silently degrade to a duplicate of the unexpected-failure rate.
+
+## E2E Tests
+
+- **Local launcher:** `tools/e2e-local.sh [smoke|pr|nightly]` — also callable via `pnpm test:e2e:smoke`, `pnpm test:e2e:pr`, `pnpm test:e2e:nightly`.
+- **CI workflow:** `.github/workflows/e2e.yml` — runs on PR / push:main / cron 06:00 UTC / workflow_dispatch.
+- **Test files:** `e2e/cli/*.test.ts` (vitest, spawned via `bun run src/index.ts`).
+- **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
+- **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.
+- **CI report job name:** `E2E Report` — aggregates per-leg conclusions, posts a sticky PR comment with marker `<!-- e2e-pr-report -->`, opens an auto-issue on schedule/release fail.
+- **Bootstrap:** see `tools/register-mod-fixture.ts` for the mod-test fixture; full bootstrap doc TBD in a later phase.
+- **Design spec:** `docs-internal/2026-05-02-e2e-test-suite-design.md`.

--- a/README.md
+++ b/README.md
@@ -193,4 +193,3 @@ pnpm format:check  # check only
 - **Bulletin delegation** — all storage-side hardening (pool management, chunk retry, nonce fallback, DAG-PB verification, DotNS commit-reveal) stays inside `bulletin-deploy`. We call `deploy(..., { jsMerkle: true })` so the flow stays binary-free and runs unchanged in a WebContainer.
 - **Signing proxy** (`src/utils/deploy/signingProxy.ts`) — wraps the user's `PolkadotSigner` to emit `sign-request`/`-complete`/`-error` lifecycle events. The TUI renders these as "📱 Check your phone" panels with live step counts.
 - **Playground publish is ours** (`src/utils/deploy/playground.ts`) — we deliberately do NOT use `bulletin-deploy`'s `--playground` flag. We call the registry contract from `src/utils/registry.ts` with the user's signer so the contract records their `env::caller()` as the owner — required for the Playground app's "my apps" view.
-

--- a/README.md
+++ b/README.md
@@ -193,3 +193,4 @@ pnpm format:check  # check only
 - **Bulletin delegation** — all storage-side hardening (pool management, chunk retry, nonce fallback, DAG-PB verification, DotNS commit-reveal) stays inside `bulletin-deploy`. We call `deploy(..., { jsMerkle: true })` so the flow stays binary-free and runs unchanged in a WebContainer.
 - **Signing proxy** (`src/utils/deploy/signingProxy.ts`) — wraps the user's `PolkadotSigner` to emit `sign-request`/`-complete`/`-error` lifecycle events. The TUI renders these as "📱 Check your phone" panels with live step counts.
 - **Playground publish is ours** (`src/utils/deploy/playground.ts`) — we deliberately do NOT use `bulletin-deploy`'s `--playground` flag. We call the registry contract from `src/utils/registry.ts` with the user's signer so the contract records their `env::caller()` as the owner — required for the Playground app's "my apps" view.
+

--- a/e2e/cli/helpers/dot.ts
+++ b/e2e/cli/helpers/dot.ts
@@ -6,6 +6,7 @@
  */
 
 import { execa as execaFn } from "execa";
+import { appendFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../../");
@@ -74,6 +75,7 @@ async function run(args: string[], options?: DotOptions): Promise<DotResult> {
 		env.HOME = options.home;
 	}
 
+	const startedAt = Date.now();
 	try {
 		const result = await execaFn("bun", ["run", CLI_ENTRY, ...args], {
 			cwd: options?.cwd ?? REPO_ROOT,
@@ -81,13 +83,39 @@ async function run(args: string[], options?: DotOptions): Promise<DotResult> {
 			timeout: options?.timeout ?? DEFAULT_TIMEOUT,
 			reject: false,
 		});
-		return {
+		const dotResult: DotResult = {
 			stdout: result.stdout,
 			stderr: result.stderr,
 			exitCode: result.exitCode ?? 1,
 		};
+		appendForensicLog(args, dotResult, Date.now() - startedAt);
+		return dotResult;
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
-		return { stdout: "", stderr: msg, exitCode: 1 };
+		const dotResult: DotResult = { stdout: "", stderr: msg, exitCode: 1 };
+		appendForensicLog(args, dotResult, Date.now() - startedAt);
+		return dotResult;
+	}
+}
+
+function appendForensicLog(args: string[], result: DotResult, durationMs: number): void {
+	// Best-effort: only write if e2e-reports/ exists. Don't create the dir
+	// eagerly — tests that don't care about forensic capture shouldn't get
+	// a stray dir in their cwd.
+	const reportsDir = resolve(REPO_ROOT, "e2e-reports");
+	if (!existsSync(reportsDir)) return;
+	try {
+		const entry = [
+			`# ${new Date().toISOString()}  exit=${result.exitCode}  durationMs=${durationMs}`,
+			`# args: ${args.map((a) => (/\s/.test(a) ? `'${a}'` : a)).join(" ")}`,
+			`--- stdout ---`,
+			result.stdout,
+			`--- stderr ---`,
+			result.stderr,
+			``,
+		].join("\n");
+		appendFileSync(resolve(reportsDir, "dot-runs.log"), entry);
+	} catch {
+		// Forensic logging must never fail a test. Swallow.
 	}
 }

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+const isCI = process.env.CI === "true";
+
 export default defineConfig({
     test: {
         include: ["e2e/**/*.test.ts"],
@@ -10,5 +12,10 @@ export default defineConfig({
         // Chain client WebSockets may keep the event loop alive after teardown.
         // Force exit after tests complete rather than hanging.
         teardownTimeout: 5_000,
+        // Always emit JUnit XML for the report job. Add a human-readable
+        // streaming reporter on local runs so developers see live progress;
+        // CI runs strip it because the run logs are noisy enough already.
+        reporters: isCI ? ["junit"] : ["default", "junit"],
+        outputFile: { junit: "e2e-reports/junit.xml" },
     },
 });

--- a/package.json
+++ b/package.json
@@ -1,74 +1,77 @@
 {
-    "name": "playground-cli",
-    "description": "CLI for Polkadot Playground",
-    "version": "0.15.4",
-    "private": true,
-    "type": "module",
-    "packageManager": "pnpm@10.32.1",
-    "bin": {
-        "dot": "./src/index.ts"
+  "name": "playground-cli",
+  "description": "CLI for Polkadot Playground",
+  "version": "0.15.4",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.32.1",
+  "bin": {
+    "dot": "./src/index.ts"
+  },
+  "scripts": {
+    "postinstall": "bash node_modules/@polkadot-apps/terminal/scripts/patch-wasm.sh",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "build": "bun build --compile src/index.ts --outfile ./dist/dot",
+    "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "vitest run --config e2e/vitest.config.ts",
+    "test:e2e:smoke": "tools/e2e-local.sh smoke",
+    "test:e2e:pr": "tools/e2e-local.sh pr",
+    "test:e2e:nightly": "tools/e2e-local.sh nightly"
+  },
+  "dependencies": {
+    "@dotdm/contracts": "latest",
+    "@parity/dotns-cli": "0.5.6",
+    "@polkadot-api/sdk-ink": "^0.6.2",
+    "@polkadot-apps/address": "latest",
+    "@polkadot-apps/bulletin": "latest",
+    "@polkadot-apps/chain-client": "latest",
+    "@polkadot-apps/contracts": "latest",
+    "@polkadot-apps/descriptors": "latest",
+    "@polkadot-apps/keys": "latest",
+    "@polkadot-apps/storage": "^0.2.8",
+    "@polkadot-apps/terminal": "latest",
+    "@polkadot-apps/tx": "latest",
+    "@polkadot-apps/utils": "latest",
+    "@sentry/node": "^9.47.1",
+    "bulletin-deploy": "0.7.6",
+    "commander": "^12.0.0",
+    "ink": "^5.2.1",
+    "polkadot-api": "^1.23.3",
+    "react": "^18.3.1",
+    "react-devtools-core": "file:stubs/react-devtools-core",
+    "tar": "^7.5.13"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@changesets/cli": "^2.29.8",
+    "@types/node": "^22.15.3",
+    "@types/react": "^18.3.18",
+    "execa": "^9.6.1",
+    "@types/tar": "^7.0.87",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@biomejs/biome"
+    ],
+    "overrides": {
+      "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub"
     },
-    "scripts": {
-        "postinstall": "bash node_modules/@polkadot-apps/terminal/scripts/patch-wasm.sh",
-        "format": "biome format --write .",
-        "format:check": "biome format .",
-        "build": "bun build --compile src/index.ts --outfile ./dist/dot",
-        "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "test:e2e": "vitest run --config e2e/vitest.config.ts"
-    },
-    "dependencies": {
-        "@dotdm/contracts": "latest",
-        "@parity/dotns-cli": "0.5.6",
-        "@polkadot-api/sdk-ink": "^0.6.2",
-        "@polkadot-apps/address": "latest",
-        "@polkadot-apps/bulletin": "latest",
-        "@polkadot-apps/chain-client": "latest",
-        "@polkadot-apps/contracts": "latest",
-        "@polkadot-apps/descriptors": "latest",
-        "@polkadot-apps/keys": "latest",
-        "@polkadot-apps/storage": "^0.2.8",
-        "@polkadot-apps/terminal": "latest",
-        "@polkadot-apps/tx": "latest",
-        "@polkadot-apps/utils": "latest",
-        "@sentry/node": "^9.47.1",
-        "bulletin-deploy": "0.7.6",
-        "commander": "^12.0.0",
-        "ink": "^5.2.1",
-        "polkadot-api": "^1.23.3",
-        "react": "^18.3.1",
-        "react-devtools-core": "file:stubs/react-devtools-core",
-        "tar": "^7.5.13"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
-        "@changesets/cli": "^2.29.8",
-        "@types/node": "^22.15.3",
-        "@types/react": "^18.3.18",
-        "execa": "^9.6.1",
-        "@types/tar": "^7.0.87",
-        "typescript": "^5.9.3",
-        "vitest": "^3.2.1"
-    },
-    "pnpm": {
-        "onlyBuiltDependencies": [
-            "@biomejs/biome"
-        ],
-        "overrides": {
-            "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub"
-        },
-        "packageExtensions": {
-            "bulletin-deploy@0.7.6": {
-                "dependencies": {
-                    "@polkadot/util": "13.5.9"
-                }
-            },
-            "@parity/dotns-cli@0.5.6": {
-                "dependencies": {
-                    "@polkadot/util": "14.0.3"
-                }
-            }
+    "packageExtensions": {
+      "bulletin-deploy@0.7.6": {
+        "dependencies": {
+          "@polkadot/util": "13.5.9"
         }
+      },
+      "@parity/dotns-cli@0.5.6": {
+        "dependencies": {
+          "@polkadot/util": "14.0.3"
+        }
+      }
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,77 +1,77 @@
 {
-  "name": "playground-cli",
-  "description": "CLI for Polkadot Playground",
-  "version": "0.15.4",
-  "private": true,
-  "type": "module",
-  "packageManager": "pnpm@10.32.1",
-  "bin": {
-    "dot": "./src/index.ts"
-  },
-  "scripts": {
-    "postinstall": "bash node_modules/@polkadot-apps/terminal/scripts/patch-wasm.sh",
-    "format": "biome format --write .",
-    "format:check": "biome format .",
-    "build": "bun build --compile src/index.ts --outfile ./dist/dot",
-    "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:e2e": "vitest run --config e2e/vitest.config.ts",
-    "test:e2e:smoke": "tools/e2e-local.sh smoke",
-    "test:e2e:pr": "tools/e2e-local.sh pr",
-    "test:e2e:nightly": "tools/e2e-local.sh nightly"
-  },
-  "dependencies": {
-    "@dotdm/contracts": "latest",
-    "@parity/dotns-cli": "0.5.6",
-    "@polkadot-api/sdk-ink": "^0.6.2",
-    "@polkadot-apps/address": "latest",
-    "@polkadot-apps/bulletin": "latest",
-    "@polkadot-apps/chain-client": "latest",
-    "@polkadot-apps/contracts": "latest",
-    "@polkadot-apps/descriptors": "latest",
-    "@polkadot-apps/keys": "latest",
-    "@polkadot-apps/storage": "^0.2.8",
-    "@polkadot-apps/terminal": "latest",
-    "@polkadot-apps/tx": "latest",
-    "@polkadot-apps/utils": "latest",
-    "@sentry/node": "^9.47.1",
-    "bulletin-deploy": "0.7.6",
-    "commander": "^12.0.0",
-    "ink": "^5.2.1",
-    "polkadot-api": "^1.23.3",
-    "react": "^18.3.1",
-    "react-devtools-core": "file:stubs/react-devtools-core",
-    "tar": "^7.5.13"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@changesets/cli": "^2.29.8",
-    "@types/node": "^22.15.3",
-    "@types/react": "^18.3.18",
-    "execa": "^9.6.1",
-    "@types/tar": "^7.0.87",
-    "typescript": "^5.9.3",
-    "vitest": "^3.2.1"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome"
-    ],
-    "overrides": {
-      "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub"
+    "name": "playground-cli",
+    "description": "CLI for Polkadot Playground",
+    "version": "0.15.4",
+    "private": true,
+    "type": "module",
+    "packageManager": "pnpm@10.32.1",
+    "bin": {
+        "dot": "./src/index.ts"
     },
-    "packageExtensions": {
-      "bulletin-deploy@0.7.6": {
-        "dependencies": {
-          "@polkadot/util": "13.5.9"
+    "scripts": {
+        "postinstall": "bash node_modules/@polkadot-apps/terminal/scripts/patch-wasm.sh",
+        "format": "biome format --write .",
+        "format:check": "biome format .",
+        "build": "bun build --compile src/index.ts --outfile ./dist/dot",
+        "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/dot",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "test:e2e": "vitest run --config e2e/vitest.config.ts",
+        "test:e2e:smoke": "tools/e2e-local.sh smoke",
+        "test:e2e:pr": "tools/e2e-local.sh pr",
+        "test:e2e:nightly": "tools/e2e-local.sh nightly"
+    },
+    "dependencies": {
+        "@dotdm/contracts": "latest",
+        "@parity/dotns-cli": "0.5.6",
+        "@polkadot-api/sdk-ink": "^0.6.2",
+        "@polkadot-apps/address": "latest",
+        "@polkadot-apps/bulletin": "latest",
+        "@polkadot-apps/chain-client": "latest",
+        "@polkadot-apps/contracts": "latest",
+        "@polkadot-apps/descriptors": "latest",
+        "@polkadot-apps/keys": "latest",
+        "@polkadot-apps/storage": "^0.2.8",
+        "@polkadot-apps/terminal": "latest",
+        "@polkadot-apps/tx": "latest",
+        "@polkadot-apps/utils": "latest",
+        "@sentry/node": "^9.47.1",
+        "bulletin-deploy": "0.7.6",
+        "commander": "^12.0.0",
+        "ink": "^5.2.1",
+        "polkadot-api": "^1.23.3",
+        "react": "^18.3.1",
+        "react-devtools-core": "file:stubs/react-devtools-core",
+        "tar": "^7.5.13"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@changesets/cli": "^2.29.8",
+        "@types/node": "^22.15.3",
+        "@types/react": "^18.3.18",
+        "execa": "^9.6.1",
+        "@types/tar": "^7.0.87",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.1"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "@biomejs/biome"
+        ],
+        "overrides": {
+            "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub"
+        },
+        "packageExtensions": {
+            "bulletin-deploy@0.7.6": {
+                "dependencies": {
+                    "@polkadot/util": "13.5.9"
+                }
+            },
+            "@parity/dotns-cli@0.5.6": {
+                "dependencies": {
+                    "@polkadot/util": "14.0.3"
+                }
+            }
         }
-      },
-      "@parity/dotns-cli@0.5.6": {
-        "dependencies": {
-          "@polkadot/util": "14.0.3"
-        }
-      }
     }
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,12 +89,12 @@ importers:
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.28
-      execa:
-        specifier: ^9.6.1
-        version: 9.6.1
       '@types/tar':
         specifier: ^7.0.87
         version: 7.0.87
+      execa:
+        specifier: ^9.6.1
+        version: 9.6.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+/**
+ * Guard against removing the Bun SEA-binary stdin warm-up.
+ *
+ * Per CLAUDE.md: Ink's `useInput` silently drops every keystroke in the
+ * `bun build --compile` binary unless `process.stdin.on("readable", …)`
+ * is touched before Ink's `render()`. We install a no-op `readable`
+ * listener at the top of `src/index.ts` as a warm-up.
+ *
+ * This is a SOURCE-LEVEL assertion (not behavioural). We deliberately
+ * don't import `./index.js` because that triggers `installSignalHandlers`,
+ * `startMemoryWatchdog`, Sentry SDK init, and other side effects that
+ * make a runtime listener-count check unreliable — and a real PTY-based
+ * behavioural test would require `node-pty`, which we ruled out.
+ *
+ * The test catches the documented regression — "someone deleted the
+ * warm-up line" — and nothing finer. A change that *renames* the call
+ * pattern (e.g. uses `addListener` instead of `.on`) would also fail
+ * here; that's a deliberate trip-wire, not a flake.
+ *
+ * Caveat: the lookbehind only excludes `//` line comments. A block comment
+ * (slash-star … star-slash) containing the same pattern would defeat the
+ * trip-wire. No such comment exists in src/index.ts today; if one is added
+ * later, tighten this regex.
+ */
+test("src/index.ts contains the stdin warm-up listener", () => {
+  const source = readFileSync("src/index.ts", "utf-8");
+  // Use a negative lookbehind to reject occurrences that appear inside a
+  // single-line comment (// …). A commented-out warm-up is the same as no
+  // warm-up from Bun's runtime perspective.
+  expect(source).toMatch(/(?<!\/\/.*)process\.stdin\.on\(\s*["']readable["']/m);
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,9 +26,9 @@ import { readFileSync } from "node:fs";
  * later, tighten this regex.
  */
 test("src/index.ts contains the stdin warm-up listener", () => {
-  const source = readFileSync("src/index.ts", "utf-8");
-  // Use a negative lookbehind to reject occurrences that appear inside a
-  // single-line comment (// …). A commented-out warm-up is the same as no
-  // warm-up from Bun's runtime perspective.
-  expect(source).toMatch(/(?<!\/\/.*)process\.stdin\.on\(\s*["']readable["']/m);
+    const source = readFileSync("src/index.ts", "utf-8");
+    // Use a negative lookbehind to reject occurrences that appear inside a
+    // single-line comment (// …). A commented-out warm-up is the same as no
+    // warm-up from Bun's runtime perspective.
+    expect(source).toMatch(/(?<!\/\/.*)process\.stdin\.on\(\s*["']readable["']/m);
 });

--- a/tools/e2e-local.sh
+++ b/tools/e2e-local.sh
@@ -9,7 +9,10 @@
 #     leak into tests (matches the runner's clean home).
 #
 # Usage:
-#   tools/e2e-local.sh                          # full suite
+#   tools/e2e-local.sh                          # full suite (smoke mode)
+#   tools/e2e-local.sh smoke                    # smoke mode (explicit)
+#   tools/e2e-local.sh pr                       # pr mode
+#   tools/e2e-local.sh nightly                  # nightly mode
 #   tools/e2e-local.sh e2e/cli/mod.test.ts      # filter (forwarded to vitest)
 #   tools/e2e-local.sh -t "registry-miss"       # name filter
 #
@@ -26,6 +29,20 @@ if ! command -v ipfs >/dev/null 2>&1; then
     echo "         install with: brew install ipfs   (macOS), or follow https://docs.ipfs.tech/install/" >&2
     echo "" >&2
 fi
+
+# Derive DOT_TAG from an optional leading mode keyword (smoke|pr|nightly).
+# e2e/cli/helpers/dot.ts defaults DOT_TAG to "e2e-local"; we override that
+# here so local runs are tagged by mode and stay distinct in Sentry dashboards.
+_MODE="${1:-smoke}"
+case "$_MODE" in
+	smoke|pr|nightly)
+		export DOT_TAG="${DOT_TAG:-e2e-local-${_MODE}}"
+		shift
+		;;
+	*)
+		export DOT_TAG="${DOT_TAG:-e2e-local-smoke}"
+		;;
+esac
 
 export TEST_TEMPLATE_DOMAIN="${TEST_TEMPLATE_DOMAIN:-dot-cli-mod-fixture.dot}"
 export TEST_TEMPLATE_REPO="${TEST_TEMPLATE_REPO:-https://github.com/paritytech/Rock-Paper-Scissors}"
@@ -44,6 +61,7 @@ if command -v ipfs >/dev/null 2>&1; then
     ipfs init --profile=test >/dev/null 2>&1 || true
 fi
 
+echo "→ DOT_TAG               $DOT_TAG"
 echo "→ TEST_TEMPLATE_DOMAIN  $TEST_TEMPLATE_DOMAIN"
 echo "→ TEST_TEMPLATE_REPO    $TEST_TEMPLATE_REPO"
 echo "→ DOT_DEPLOY_VERBOSE    $DOT_DEPLOY_VERBOSE"


### PR DESCRIPTION
## Summary

Phase 1 of the E2E suite redesign. Today's 27 E2E tests are unchanged — better-instrumented around. Spec: `docs-internal/2026-05-02-e2e-test-suite-design.md`.

## What changed

- **`E2E Report` job** posts a sticky PR comment with a per-cell summary table, failures detail block, and a Sentry traces link. Marker `<!-- e2e-pr-report -->` ensures the comment updates in place across pushes (verified during PR development — count stays at 1).
- **`nick-fields/retry@v3`** wraps the test invocation (max 2 attempts, 30s wait, 25-min per-attempt budget). Job timeout raised to 55 min so the retry budget can actually fit. Catches Paseo testnet flakes.
- **`DOT_TAG=e2e-ci-{pr|nightly|dispatch}`** propagated to the test run; CLI's existing `cli.tag` root-span attribute (`src/telemetry-config.ts:191`) picks it up automatically.
- **JUnit XML** (`e2e-reports/junit.xml`) + **forensic `dot-runs.log`** uploaded as workflow artefacts (7-day retention).
- **`src/index.test.ts`** — source-level guard against the documented Bun SEA stdin warm-up regression. Negative-lookbehind regex distinguishes the live call at `src/index.ts:87` from a `//` line comment that mentions it.
- **Auto-issue** on schedule/release failure (no de-dup by design — cadence of new issues is the signal).
- **Sticky-PR-comment + auto-issue verified end-to-end** before merge: a temporary `simulate_failure` workflow_dispatch input was added, fired once to produce real issue #83 (closed), then removed in a separate commit so the verification path doesn't ship.

## Out of scope (future phases)

- Per-cell SIGNER derivation, per-cell domain registrations (Phase 3)
- Matrix split into per-cell jobs with `max-parallel: 1` on publish cells (Phase 4)
- Hardhat/multi-contract/modable/chaos cells (Phase 5–6)
- Published-artefact surface + `release: prereleased` trigger (Phase 7)
- Branch protection / required status checks — currently `main` has no protection rule at all; flipping to gating is a separate post-Phase-4 decision (see spec §7f for the one-shot `gh api` snippet)
- Sentry dashboard creation for E2E health (manual one-time bootstrap, spec §9a)

## Phase 1 + 2 fold note

The spec listed `DOT_TAG` propagation + Sentry traces link as Phase 2; this PR folds them into Phase 1 because the Sentry link is useless until tags are set, and both touch the same workflow file in tightly-coupled ways.

## Test plan

- [x] Local: `pnpm test` — all unit tests pass (439, including new `src/index.test.ts`)
- [x] Local: `pnpm exec vitest run e2e/cli/install.test.ts` — JUnit XML produced, `dot-runs.log` populated
- [x] CI: sticky PR comment posts on first push, updates in place on subsequent pushes (count stayed at 1 across 4+ pushes during PR dev)
- [x] CI: deliberate test failure renders correctly in the failures detail block (verified by injecting a regex-based failure during PR dev, then reverting)
- [x] CI: `simulate_failure` dispatch path opened real issue #83 (closed); scaffolding removed in `b106f66`
- [x] CI: `if: always()` on report job correctly renders even when `test` cancels (verified — see runs 25260814880 and 25260866303 where test was cancelled by concurrency but report succeeded)
- [ ] **First post-merge nightly** (cron 06:00 UTC) — will produce the first real auto-issue if testnet flakes; auto-issue path verified pre-merge but real-cron path is exercised first time then

## Related
- Spec: `docs-internal/2026-05-02-e2e-test-suite-design.md` (Phase 1 of 8)
- Plan: `docs-internal/2026-05-02-e2e-phase-1-plan.md`
- Reference patterns: `docs-internal/e2e-testing-spec.md` §M1–M9