### PR TITLE
ci(e2e): Phase 4 — 7-cell matrix split + foundry/CDM full-deploy tests

### DIFF
--- a/.changeset/e2e-phase-4-matrix-split.md
+++ b/.changeset/e2e-phase-4-matrix-split.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+E2E suite now runs as a 7-cell matrix on CI: 4 no-publish cells in parallel + 3 publish cells serial (sharing the registry signer to avoid nonce races). Adds full-deploy tests for the Foundry and CDM backends. Per-cell pass/fail is visible in the sticky PR comment with cell-specific JUnit + forensic logs.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,8 +112,10 @@ jobs:
                       pattern: "full pipeline"
                     - cell: pr-deploy-foundry
                       pattern: "deploy — foundry"
-                    - cell: pr-deploy-cdm
-                      pattern: "deploy — CDM"
+                    # pr-deploy-cdm dropped pending fixture upgrade — see the
+                    # describe.skip block in e2e/cli/deploy.test.ts. Phase 5
+                    # follow-up will land a real flipper fixture and re-add
+                    # this cell.
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,10 +19,23 @@ concurrency:
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-    test:
-        name: "E2E · current"
+    test-no-publish:
+        name: "E2E · ${{ matrix.cell }}"
         runs-on: ubuntu-latest
-        timeout-minutes: 55
+        timeout-minutes: 25
+        strategy:
+            fail-fast: false
+            max-parallel: 5
+            matrix:
+                include:
+                    - cell: pr-install
+                      pattern: "dot install"
+                    - cell: pr-preflight
+                      pattern: "dot build|preflight and validation"
+                    - cell: pr-mod
+                      pattern: "dot mod — clone"
+                    - cell: pr-init-session
+                      pattern: "dot init|session management"
         outputs:
             tag: ${{ steps.tag.outputs.tag }}
         steps:
@@ -62,13 +75,13 @@ jobs:
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                   echo "Resolved DOT_TAG=$TAG (event=${{ github.event_name }})"
 
-            - name: Run E2E tests (one retry on transient testnet failures)
+            - name: Run E2E cell (one retry on transient testnet failures)
               uses: nick-fields/retry@v3
               with:
-                  timeout_minutes: 25
+                  timeout_minutes: 20
                   max_attempts: 2
                   retry_wait_seconds: 30
-                  command: pnpm test:e2e
+                  command: pnpm exec vitest run --config e2e/vitest.config.ts -t "${{ matrix.pattern }}"
               env:
                   TEST_TEMPLATE_DOMAIN: dot-cli-mod-fixture.dot
                   TEST_TEMPLATE_REPO: https://github.com/paritytech/Rock-Paper-Scissors
@@ -81,22 +94,95 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: e2e-reports-current
+                  name: e2e-reports-${{ matrix.cell }}
+                  path: e2e-reports/
+                  retention-days: 7
+                  if-no-files-found: ignore
+
+    test-publish:
+        name: "E2E · ${{ matrix.cell }}"
+        runs-on: ubuntu-latest
+        timeout-minutes: 55
+        strategy:
+            fail-fast: false
+            max-parallel: 1                  # serial — share SIGNER + registry domains
+            matrix:
+                include:
+                    - cell: pr-deploy-frontend
+                      pattern: "full pipeline"
+                    - cell: pr-deploy-foundry
+                      pattern: "deploy — foundry"
+                    - cell: pr-deploy-cdm
+                      pattern: "deploy — CDM"
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install Kubo (IPFS)
+              run: |
+                  wget -q https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz
+                  tar xf kubo_v0.32.1_linux-amd64.tar.gz
+                  sudo mv kubo/ipfs /usr/local/bin/
+                  ipfs init --profile=test
+                  ipfs version
+
+            - run: pnpm install
+
+            - name: Resolve DOT_TAG from trigger
+              id: tag
+              shell: bash
+              run: |
+                  # Phase 1 triggers: pull_request / push:main / schedule / workflow_dispatch.
+                  # Phase 7 will add `release` (with TAG=e2e-ci-release).
+                  case "${{ github.event_name }}" in
+                      schedule)            TAG=e2e-ci-nightly  ;;
+                      workflow_dispatch)   TAG=e2e-ci-dispatch ;;
+                      *)                   TAG=e2e-ci-pr       ;;
+                  esac
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                  echo "Resolved DOT_TAG=$TAG (event=${{ github.event_name }})"
+
+            - name: Run E2E cell (one retry on transient testnet failures)
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 25
+                  max_attempts: 2
+                  retry_wait_seconds: 30
+                  command: pnpm exec vitest run --config e2e/vitest.config.ts -t "${{ matrix.pattern }}"
+              env:
+                  TEST_TEMPLATE_DOMAIN: dot-cli-mod-fixture.dot
+                  TEST_TEMPLATE_REPO: https://github.com/paritytech/Rock-Paper-Scissors
+                  DOT_DEPLOY_VERBOSE: "1"
+                  DOT_TAG: ${{ steps.tag.outputs.tag }}
+                  DOT_TELEMETRY: "1"
+
+            - name: Upload forensic artefacts
+              if: always()
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-reports-${{ matrix.cell }}
                   path: e2e-reports/
                   retention-days: 7
                   if-no-files-found: ignore
 
     report:
         name: E2E Report
-        needs: [test]
+        needs: [test-no-publish, test-publish]
         if: always()
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
             - name: Download JUnit + forensic artefacts
-              # Phase 1 has one upload (e2e-reports-current). When Phase 4 adds
-              # the matrix, drop `merge-multiple: true` and parse per-cell sub-dirs
-              # so per-leg junit.xml don't collide on the same flat path.
               uses: actions/download-artifact@v4
               with:
                   pattern: e2e-reports-*
@@ -127,11 +213,20 @@ jobs:
 
             - name: Parse JUnit and render report body
               env:
-                  AGGREGATE: ${{ needs.test.result }}
+                  AGGREGATE_PUBLISH: ${{ needs.test-publish.result }}
+                  AGGREGATE_NO_PUBLISH: ${{ needs.test-no-publish.result }}
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                  TAG: ${{ needs.test.outputs.tag }}
+                  TAG: ${{ needs.test-no-publish.outputs.tag }}
               shell: /usr/bin/bash -euo pipefail {0}
               run: |
+                  if [ "$AGGREGATE_PUBLISH" = "success" ] && [ "$AGGREGATE_NO_PUBLISH" = "success" ]; then
+                      AGGREGATE=success
+                  elif [ "$AGGREGATE_PUBLISH" = "cancelled" ] || [ "$AGGREGATE_NO_PUBLISH" = "cancelled" ]; then
+                      AGGREGATE=cancelled
+                  else
+                      AGGREGATE=failure
+                  fi
+
                   emoji() { case "$1" in
                       success)   echo "✅ PASS";;
                       failure)   echo "❌ FAIL";;
@@ -261,10 +356,10 @@ jobs:
             - name: Open failure issue
               if: >
                   (github.event_name == 'schedule' || github.event_name == 'release') &&
-                  needs.test.result != 'success'
+                  (needs.test-no-publish.result != 'success' || needs.test-publish.result != 'success')
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  TAG: ${{ needs.test.outputs.tag }}
+                  TAG: ${{ needs.test-no-publish.outputs.tag }}
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                   API_URL: ${{ github.api_url }}
                   REPO: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,5 +61,5 @@ These are things that aren't self-evident from reading the code and have bitten 
 - **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
 - **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.
 - **CI report job name:** `E2E Report` — aggregates per-leg conclusions, posts a sticky PR comment with marker `<!-- e2e-pr-report -->`, opens an auto-issue on schedule/release fail.
-- **Bootstrap:** see `tools/register-mod-fixture.ts` for the mod-test fixture; full bootstrap doc TBD in a later phase.
+- **Bootstrap:** see `tools/register-e2e-fixtures.ts` for the mod-test fixture; full bootstrap doc TBD in a later phase.
 - **Design spec:** `docs-internal/2026-05-02-e2e-test-suite-design.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ These are things that aren't self-evident from reading the code and have bitten 
 
 - **Local launcher:** `tools/e2e-local.sh [smoke|pr|nightly]` — also callable via `pnpm test:e2e:smoke`, `pnpm test:e2e:pr`, `pnpm test:e2e:nightly`.
 - **CI workflow:** `.github/workflows/e2e.yml` — runs on PR / push:main / cron 06:00 UTC / workflow_dispatch.
+- **CI matrix:** 7 cells in two matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry, pr-deploy-cdm). Each cell runs a subset via `vitest -t "<pattern>"`.
 - **Test files:** `e2e/cli/*.test.ts` (vitest, spawned via `bun run src/index.ts`).
 - **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
 - **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -237,3 +237,49 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 		expect(output.toLowerCase()).toMatch(/revert|taken|registered|owned|unavailable|already/);
 	});
 });
+
+describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
+	test("foundry deploy completes end-to-end", { timeout: 450_000 }, async () => {
+		const domain = E2E_DOMAINS.foundry;
+		const result = await dot([
+			"deploy",
+			"--signer", "dev",
+			"--domain", domain,
+			"--buildDir", absBuildDir(foundry),
+			"--contracts",
+			"--playground",
+			"--suri", SIGNER.suri,
+			"--dir", foundry,
+		], { timeout: 400_000 });
+
+		expect(
+			result.exitCode,
+			`foundry deploy failed: ${result.stdout}\n${result.stderr}`,
+		).toBe(0);
+		expect(result.stdout).toContain("Deploy complete");
+		expect(result.stdout).toContain(domain);
+	});
+});
+
+describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
+	test("CDM deploy completes end-to-end", { timeout: 450_000 }, async () => {
+		const domain = E2E_DOMAINS.cdm;
+		const result = await dot([
+			"deploy",
+			"--signer", "dev",
+			"--domain", domain,
+			"--buildDir", absBuildDir(rustCdm),
+			"--contracts",
+			"--playground",
+			"--suri", SIGNER.suri,
+			"--dir", rustCdm,
+		], { timeout: 400_000 });
+
+		expect(
+			result.exitCode,
+			`CDM deploy failed: ${result.stdout}\n${result.stderr}`,
+		).toBe(0);
+		expect(result.stdout).toContain("Deploy complete");
+		expect(result.stdout).toContain(domain);
+	});
+});

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -246,12 +246,13 @@ describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(foundry),
-			// --no-build skips both frontend AND contract build; the fixture
-			// ships pre-committed artefacts under out/ so the deploy uses
-			// them directly without spawning forge (not available on the
-			// CI runner).
+			// --no-build skips the frontend build; --no-contract-build skips
+			// the forge subprocess. The fixture ships pre-committed bytecode
+			// under out/Counter.sol/Counter.json so the deploy reads it
+			// directly without needing forge on the CI runner.
 			"--no-build",
 			"--contracts",
+			"--no-contract-build",
 			"--playground",
 			"--suri", SIGNER.suri,
 			"--dir", foundry,
@@ -274,11 +275,15 @@ describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(rustCdm),
-			// --no-build: the fixture ships a pre-committed .contract under
-			// target/ so the deploy uses it directly without spawning
-			// cargo-contract (not available on the CI runner).
+			// --no-build skips the frontend build; --no-contract-build skips
+			// the cargo-contract spawn so we don't need the rust toolchain
+			// on the CI runner. Note: the cdm skip-build path still calls
+			// detectContracts which spawns `cargo metadata` — tracked as a
+			// follow-up; for this fixture a small Cargo.toml that's quick
+			// to parse keeps it tolerable.
 			"--no-build",
 			"--contracts",
+			"--no-contract-build",
 			"--playground",
 			"--suri", SIGNER.suri,
 			"--dir", rustCdm,

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -246,11 +246,11 @@ describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(foundry),
-			// --no-build skips the frontend build; --no-contract-build skips
-			// the forge subprocess. The fixture ships pre-committed bytecode
-			// under out/Counter.sol/Counter.json so the deploy reads it
-			// directly without needing forge on the CI runner.
-			"--no-build",
+			// --no-contract-build skips the forge subprocess so we don't
+			// need the EVM toolchain on the CI runner; the fixture ships
+			// pre-committed bytecode under out/Counter.sol/Counter.json.
+			// The frontend build is the trivial mkdir+echo in the fixture's
+			// package.json — let it run to produce dist/.
 			"--contracts",
 			"--no-contract-build",
 			"--playground",
@@ -275,13 +275,11 @@ describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(rustCdm),
-			// --no-build skips the frontend build; --no-contract-build skips
-			// the cargo-contract spawn so we don't need the rust toolchain
-			// on the CI runner. Note: the cdm skip-build path still calls
-			// detectContracts which spawns `cargo metadata` — tracked as a
-			// follow-up; for this fixture a small Cargo.toml that's quick
-			// to parse keeps it tolerable.
-			"--no-build",
+			// --no-contract-build skips the cargo-contract spawn so we
+			// don't need the rust toolchain on the CI runner. Note: the
+			// cdm skip-build path still calls detectContracts which spawns
+			// `cargo metadata` — tracked as a follow-up. The frontend build
+			// is the trivial mkdir+echo in the fixture; let it run.
 			"--contracts",
 			"--no-contract-build",
 			"--playground",

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -246,6 +246,11 @@ describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(foundry),
+			// --no-build skips both frontend AND contract build; the fixture
+			// ships pre-committed artefacts under out/ so the deploy uses
+			// them directly without spawning forge (not available on the
+			// CI runner).
+			"--no-build",
 			"--contracts",
 			"--playground",
 			"--suri", SIGNER.suri,
@@ -269,6 +274,10 @@ describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(rustCdm),
+			// --no-build: the fixture ships a pre-committed .contract under
+			// target/ so the deploy uses it directly without spawning
+			// cargo-contract (not available on the CI runner).
+			"--no-build",
 			"--contracts",
 			"--playground",
 			"--suri", SIGNER.suri,

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -267,7 +267,17 @@ describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
 	});
 });
 
-describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
+// SKIPPED: the rust-cdm fixture's `target/flipper.contract` is a stub
+// (`{"source":{"hash":"0xabc"}}`) and there is no `target/<crate>.release.polkavm`
+// for the skip-build path to read. A working fixture needs:
+//   1. a real `src/lib.rs` so `cargo metadata` parses the manifest
+//      (currently fails: "no targets specified in the manifest")
+//   2. a committed `target/<crate>.release.polkavm` produced by an
+//      actual `cargo-contract build` of a minimal flipper contract
+// Tracked as Phase 5 follow-up. Until then, CDM detection is covered by
+// the preflight test in `dot deploy — preflight and validation` and the
+// skip-build path itself is unit-tested in `src/utils/deploy/contracts.test.ts`.
+describe.skip("dot deploy — CDM (requires Paseo + IPFS)", () => {
 	test("CDM deploy completes end-to-end", { timeout: 450_000 }, async () => {
 		const domain = E2E_DOMAINS.cdm;
 		const result = await dot([
@@ -275,11 +285,6 @@ describe("dot deploy — CDM (requires Paseo + IPFS)", () => {
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(rustCdm),
-			// --no-contract-build skips the cargo-contract spawn so we
-			// don't need the rust toolchain on the CI runner. Note: the
-			// cdm skip-build path still calls detectContracts which spawns
-			// `cargo metadata` — tracked as a follow-up. The frontend build
-			// is the trivial mkdir+echo in the fixture; let it run.
 			"--contracts",
 			"--no-contract-build",
 			"--playground",

--- a/e2e/cli/mod.test.ts
+++ b/e2e/cli/mod.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 	tempDirs.length = 0;
 });
 
-describe("dot mod", () => {
+describe("dot mod — clone", () => {
 	test.skipIf(!TEST_DOMAIN)(
 		"clones the registered template into a fresh directory",
 		{ timeout: 180_000 },
@@ -59,6 +59,17 @@ describe("dot mod", () => {
 		},
 	);
 
+	test("exits non-zero with signer suggestion when no signer available", async () => {
+		const tempHome = makeTempDir("dot-e2e-mod-home-");
+		const cwd = makeTempDir("dot-e2e-mod-cwd-");
+		const result = await dot(["mod", "some-app.dot"], { home: tempHome, cwd });
+		expect(result.exitCode).not.toBe(0);
+		const output = result.stdout + result.stderr;
+		expect(output).toMatch(/signer|init|log.?in/i);
+	});
+});
+
+describe("dot mod — registry miss", () => {
 	test("reports a registry-miss for an unknown domain", async () => {
 		const cwd = makeTempDir("dot-e2e-mod-unknown-");
 		const result = await dot(
@@ -68,14 +79,5 @@ describe("dot mod", () => {
 		const output = result.stdout + result.stderr;
 		expect(result.exitCode).not.toBe(0);
 		expect(output).toMatch(/not found/i);
-	});
-
-	test("exits non-zero with signer suggestion when no signer available", async () => {
-		const tempHome = makeTempDir("dot-e2e-mod-home-");
-		const cwd = makeTempDir("dot-e2e-mod-cwd-");
-		const result = await dot(["mod", "some-app.dot"], { home: tempHome, cwd });
-		expect(result.exitCode).not.toBe(0);
-		const output = result.stdout + result.stderr;
-		expect(output).toMatch(/signer|init|log.?in/i);
 	});
 });


### PR DESCRIPTION
## Summary

Phase 4 of the E2E redesign per `docs-internal/2026-05-02-e2e-test-suite-design.md`. Splits the single E2E job into a 6-cell matrix and adds a foundry full-deploy test.

## What changed

- **Matrix split**: `test-no-publish` (4 parallel cells) + `test-publish` (2 serial cells, `max-parallel: 1`)
- **`pr-deploy-foundry`** — NEW full-deploy test for the EVM/Foundry backend, uses pre-committed bytecode + `--no-contract-build` (no `forge` needed in CI)
- **`mod.test.ts` describe restructure** — `dot mod — clone` (PR cell) vs `dot mod — registry miss` (future nightly cell)

## Out of scope (deferred)

- **`pr-deploy-cdm`**: dropped pending a real rust-cdm fixture. The current fixture's `target/flipper.contract` is a stub; making CDM full-deploy work requires (a) a complete `Cargo.toml` so `detectContracts` can run, and (b) a committed `target/<crate>.release.polkavm` from a real `cargo-contract build`. Tracked as Phase 5 follow-up. Until then, CDM detection is covered by `pr-preflight`'s `detects CDM/Rust contracts type` test, and the skip-build path is covered by unit tests.
- Phase 5 cells (hardhat full-deploy, multi-contract, modable, registry-miss as nightly, etc.)
- Phase 6 chaos cells (RPC failover, SIGINT)
- Phase 7 published-binary surface

## Stacked on

- PR #82 (Phase 1, merged) — reporting + tagging
- PR #84 (Phase 3, merged) — register-e2e-fixtures
- PR #86 (merged) — `--no-contract-build` flag

## Test plan

- [x] All 6 PR cells green: `pr-install`, `pr-preflight`, `pr-deploy-frontend`, `pr-deploy-foundry`, `pr-mod`, `pr-init-session`
- [x] Critical path: ~14 min (publish chain serial); no-publish chain parallel
- [x] Sticky comment shows per-cell rows correctly (verified across multiple pushes)
- [x] Forensic uploads land per-cell (`e2e-reports-<cell>` artefact pattern)