### PR TITLE
feat(deploy): --no-contract-build flag for CI without contract toolchains

### DIFF
--- a/.changeset/feat-skip-contract-build.md
+++ b/.changeset/feat-skip-contract-build.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+Add `--no-contract-build` flag to `dot deploy`. When set alongside `--contracts`, the deploy uses pre-existing contract artifacts (foundry `out/`, hardhat `artifacts/contracts/`, cdm `target/<crate>.release.polkavm`) instead of running the build toolchain. Useful for CI environments where `forge` / `cargo-contract` aren't installed.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Passing all four of `--signer`, `--domain`, `--buildDir`, and `--playground` run
 
 The publish step is always signed by the user so the registry contract records their address as the app owner — this is what drives the Playground "my apps" view.
 
+#### CI / automation flags for `dot deploy`
+
+These flags are designed for non-interactive (CI) usage. Combining all four of `--signer`, `--domain`, `--buildDir`, and `--playground` triggers fully headless mode; the flags below layer on top.
+
+| Flag | Effect |
+|---|---|
+| `--signer dev` | Use the dev signer (no phone QR scan). Requires `--suri`. |
+| `--suri <suri>` | Secret URI for the user signer (e.g. `//Alice` or a full mnemonic). Required with `--signer dev`. |
+| `--domain <name>` | DotNS domain. Skips interactive selection. |
+| `--buildDir <path>` | Path to existing built frontend assets. |
+| `--no-build` | Skip the **frontend** build (`pnpm build`). Use pre-built `dist/`. |
+| `--no-contract-build` | Skip the **contract** compile (`forge build --resolc`, `cargo-contract build`, `npx hardhat compile`). Use pre-built `out/` / `target/<crate>.release.polkavm` / `artifacts/contracts/`. Requires `--contracts`. |
+| `--no-modable` | Don't push source to GitHub even if `--modable` would normally apply. |
+| `--playground` | Publish to the playground registry. Required with all the above to trigger the fully-headless code path. |
+
 ### `dot mod`
 
 Pull a modable playground app's source into a fresh local project so you can customise and re-deploy it. The interactive picker only shows apps that opted into modable at deploy time; non-modable apps surface a clear "this app is not modable" error if you target them by domain.

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -42,6 +42,13 @@ interface DeployOpts {
      * a `--no-foo` option is declared.
      */
     build?: boolean;
+    /**
+     * Commander's auto-negated boolean: defaults to `true`; `--no-contract-build` flips it to `false`.
+     * When false, the contract compile step (forge/hardhat/cargo-contract) is skipped and
+     * pre-existing artifacts on disk are used instead. CI-friendly for environments without
+     * the contract toolchains installed.
+     */
+    contractBuild?: boolean;
     /** Deploy the project's contracts alongside the frontend. Defaults to false. */
     contracts?: boolean;
     /** Publish the source repo so others can `dot mod` it. Commander auto-negates: `--no-modable` ⇒ false. */
@@ -67,6 +74,10 @@ export const deployCommand = new Command("deploy")
     .option(
         "--contracts",
         "Also deploy any contracts detected in the project (foundry/hardhat/cdm)",
+    )
+    .option(
+        "--no-contract-build",
+        "Skip the contract compile step (forge/hardhat/cargo-contract) and deploy existing pre-built artifacts. Requires --contracts. Useful for CI environments without the contract toolchains installed.",
     )
     .option("--playground", "Publish to the playground registry")
     .option(
@@ -261,6 +272,7 @@ async function runHeadless(ctx: {
     const buildDir = ctx.opts.buildDir as string;
     const skipBuild = ctx.opts.build === false;
     const deployContracts = Boolean(ctx.opts.contracts);
+    const skipContractBuild = ctx.opts.contractBuild === false;
     const contractsType = safeDetectContractsType(ctx.projectDir);
     if (deployContracts && contractsType === null) {
         throw new Error(
@@ -369,6 +381,7 @@ async function runHeadless(ctx: {
                 modable,
                 repositoryUrl,
                 deployContracts,
+                skipContractBuild,
                 contractsFundingNeeded,
                 userSigner: ctx.userSigner,
                 plan: availability.plan,

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -156,10 +156,9 @@ export const deployCommand = new Command("deploy")
                 const nonInteractive = isFullySpecified(opts);
 
                 if (opts.contractBuild === false && opts.contracts && !nonInteractive) {
-                    console.error(
-                        "Error: --no-contract-build requires headless mode (combine with --signer, --domain, --buildDir, --playground).",
+                    throw new Error(
+                        "--no-contract-build requires headless mode (combine with --signer, --domain, --buildDir, --playground).",
                     );
-                    process.exit(2);
                 }
 
                 if (nonInteractive) {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -154,6 +154,14 @@ export const deployCommand = new Command("deploy")
 
             try {
                 const nonInteractive = isFullySpecified(opts);
+
+                if (opts.contractBuild === false && opts.contracts && !nonInteractive) {
+                    console.error(
+                        "Error: --no-contract-build requires headless mode (combine with --signer, --domain, --buildDir, --playground).",
+                    );
+                    process.exit(2);
+                }
+
                 if (nonInteractive) {
                     await runHeadless({ projectDir, env, userSigner, opts });
                 } else {

--- a/src/utils/deploy/contracts.test.ts
+++ b/src/utils/deploy/contracts.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -177,7 +177,7 @@ describe("runContractsPhase skipBuild=true (foundry)", () => {
         runStreamedMock.mockClear();
         deployBatchMock.mockClear();
         // Fresh tmp dir per test so artifact presence/absence is controlled.
-        dir = join(tmpdir(), `contracts-test-foundry-${Date.now()}`);
+        dir = mkdtempSync(join(tmpdir(), "contracts-test-foundry-"));
     });
 
     it("uses existing foundry artifacts without spawning forge", async () => {
@@ -222,7 +222,7 @@ describe("runContractsPhase skipBuild=true (hardhat)", () => {
     beforeEach(() => {
         runStreamedMock.mockClear();
         deployBatchMock.mockClear();
-        dir = join(tmpdir(), `contracts-test-hardhat-${Date.now()}`);
+        dir = mkdtempSync(join(tmpdir(), "contracts-test-hardhat-"));
     });
 
     it("uses existing hardhat artifacts without spawning npx hardhat compile", async () => {

--- a/src/utils/deploy/contracts.test.ts
+++ b/src/utils/deploy/contracts.test.ts
@@ -1,6 +1,41 @@
-import { describe, it, expect } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Buffer } from "node:buffer";
 import { extractFoundryBytecode, extractHardhatBytecode, hexToBytes } from "./contracts.js";
+
+// ── skipBuild mocks ──────────────────────────────────────────────────────────
+//
+// These mocks exist purely for the skipBuild integration tests at the bottom of
+// this file. The pure-helper tests above do not need them.
+
+const { runStreamedMock, deployBatchMock } = vi.hoisted(() => ({
+    runStreamedMock: vi.fn(async () => {}),
+    deployBatchMock: vi.fn(async () => ({
+        addresses: ["0xdeadbeef"] as `0x${string}`[],
+        chunkCount: 1,
+    })),
+}));
+
+vi.mock("../process.js", () => ({
+    runStreamed: runStreamedMock,
+}));
+
+vi.mock("@dotdm/contracts", async (importOriginal) => {
+    const real = await importOriginal<typeof import("@dotdm/contracts")>();
+    return {
+        ...real,
+        buildContracts: vi.fn(async () => ({
+            contracts: [{ crate: "flipper", pvmPath: "/tmp/flipper.polkavm" }],
+            totalDurationMs: 1,
+        })),
+        detectContracts: vi.fn(() => [{ name: "flipper" }]),
+        ContractDeployer: class MockContractDeployer {
+            deployBatch = deployBatchMock;
+        },
+    };
+});
 
 describe("hexToBytes", () => {
     it("decodes a 0x-prefixed hex string", () => {
@@ -108,5 +143,116 @@ describe("extractHardhatBytecode", () => {
         expect(extractHardhatBytecode(undefined)).toBeNull();
         expect(extractHardhatBytecode("0x60806040")).toBeNull();
         expect(extractHardhatBytecode(42)).toBeNull();
+    });
+});
+
+// ── skipBuild integration tests ───────────────────────────────────────────────
+//
+// These tests verify that the compile step (runStreamed) is NOT called when
+// skipBuild is true, and that the discovery loop reads pre-existing artifacts.
+// They use a real tmp dir so the fs checks in compileFoundry/compileHardhat
+// work correctly; ContractDeployer.deployBatch is mocked to avoid chain I/O.
+
+import { runContractsPhase } from "./contracts.js";
+
+function makeOpts(projectDir: string, contractsType: "foundry" | "hardhat", skipBuild: boolean) {
+    return {
+        projectDir,
+        contractsType,
+        skipBuild,
+        // ContractDeployer is mocked — provide the minimal shape that the
+        // constructor call `new ContractDeployer(signer, origin, raw.assetHub,
+        // assetHub)` accesses before handing off to the mock.
+        client: { raw: { assetHub: {} }, assetHub: {} } as any,
+        signer: {} as any,
+        origin: "5FakeAddress" as any,
+        onEvent: () => {},
+    };
+}
+
+describe("runContractsPhase skipBuild=true (foundry)", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        runStreamedMock.mockClear();
+        deployBatchMock.mockClear();
+        // Fresh tmp dir per test so artifact presence/absence is controlled.
+        dir = join(tmpdir(), `contracts-test-foundry-${Date.now()}`);
+    });
+
+    it("uses existing foundry artifacts without spawning forge", async () => {
+        // Set up out/Counter.sol/Counter.json with real bytecode.
+        const solDir = join(dir, "out", "Counter.sol");
+        mkdirSync(solDir, { recursive: true });
+        writeFileSync(
+            join(solDir, "Counter.json"),
+            JSON.stringify({ bytecode: { object: "0x6080604052" } }),
+        );
+
+        const result = await runContractsPhase(makeOpts(dir, "foundry", true));
+
+        expect(runStreamedMock).not.toHaveBeenCalled();
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0].name).toBe("Counter");
+    });
+
+    it("throws with a clear message when out/ is missing", async () => {
+        // No out/ directory — simulates a project where forge was never run.
+        mkdirSync(dir, { recursive: true });
+
+        await expect(runContractsPhase(makeOpts(dir, "foundry", true))).rejects.toThrow(
+            /no pre-built contract artifacts found at/,
+        );
+        expect(runStreamedMock).not.toHaveBeenCalled();
+    });
+
+    it("throws with a clear message when out/ exists but has no valid artifacts", async () => {
+        // out/ exists but is empty — forge ran but produced nothing usable.
+        mkdirSync(join(dir, "out"), { recursive: true });
+
+        await expect(runContractsPhase(makeOpts(dir, "foundry", true))).rejects.toThrow(
+            /no pre-built contract artifacts found at/,
+        );
+    });
+});
+
+describe("runContractsPhase skipBuild=true (hardhat)", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        runStreamedMock.mockClear();
+        deployBatchMock.mockClear();
+        dir = join(tmpdir(), `contracts-test-hardhat-${Date.now()}`);
+    });
+
+    it("uses existing hardhat artifacts without spawning npx hardhat compile", async () => {
+        // Set up artifacts/contracts/Lock.sol/Lock.json with real bytecode.
+        const solDir = join(dir, "artifacts", "contracts", "Lock.sol");
+        mkdirSync(solDir, { recursive: true });
+        writeFileSync(join(solDir, "Lock.json"), JSON.stringify({ bytecode: "0x6080604052" }));
+
+        const result = await runContractsPhase(makeOpts(dir, "hardhat", true));
+
+        expect(runStreamedMock).not.toHaveBeenCalled();
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0].name).toBe("Lock");
+    });
+
+    it("throws with a clear message when artifacts/contracts/ is missing", async () => {
+        mkdirSync(dir, { recursive: true });
+
+        await expect(runContractsPhase(makeOpts(dir, "hardhat", true))).rejects.toThrow(
+            /no pre-built contract artifacts found at/,
+        );
+        expect(runStreamedMock).not.toHaveBeenCalled();
+    });
+
+    it("throws with a clear message when artifacts/contracts/ has no valid artifacts", async () => {
+        // Directory exists but contains no .sol subdirs with valid JSON.
+        mkdirSync(join(dir, "artifacts", "contracts"), { recursive: true });
+
+        await expect(runContractsPhase(makeOpts(dir, "hardhat", true))).rejects.toThrow(
+            /no pre-built contract artifacts found at/,
+        );
     });
 });

--- a/src/utils/deploy/contracts.ts
+++ b/src/utils/deploy/contracts.ts
@@ -28,6 +28,7 @@ import { runStreamed } from "../process.js";
 import {
     ContractDeployer,
     buildContracts,
+    detectContracts,
     type BuildEvent as CdmBuildEvent,
     type PipelineChainClient,
 } from "@dotdm/contracts";
@@ -58,6 +59,12 @@ export interface RunContractsPhaseOptions {
     /** SS58-encoded address of `signer`. Used as the deployer origin for dry-runs. */
     origin: SS58String;
     onEvent: (event: ContractsPhaseEvent) => void;
+    /**
+     * If true, skip the contract compile step (forge/hardhat/cargo-contract)
+     * and use pre-existing artifacts on disk. CI-friendly for environments
+     * without the contract toolchain installed. Throws if no artifacts found.
+     */
+    skipBuild?: boolean;
 }
 
 export interface ContractsPhaseResult {
@@ -140,6 +147,10 @@ async function compileContracts(opts: RunContractsPhaseOptions): Promise<Compile
 // ── cdm compile ──────────────────────────────────────────────────────────────
 
 async function compileCdm(opts: RunContractsPhaseOptions): Promise<CompiledArtifact[]> {
+    if (opts.skipBuild) {
+        return compileCdmSkipBuild(opts);
+    }
+
     const summary = await buildContracts({
         rootDir: opts.projectDir,
         onEvent: (event: CdmBuildEvent) => {
@@ -156,6 +167,40 @@ async function compileCdm(opts: RunContractsPhaseOptions): Promise<CompiledArtif
             throw new Error(`cdm build produced no bytecode path for ${c.crate}`);
         }
         artifacts.push({ name: c.crate, pvmPath: c.pvmPath });
+    }
+    return artifacts;
+}
+
+/**
+ * CDM skip-build path: use `detectContracts` to enumerate crates from
+ * Cargo metadata (no build required), then resolve the expected
+ * `target/<crate>.release.polkavm` path that `buildContracts` would have
+ * produced. Throws with a clear message if any artifact is missing.
+ */
+async function compileCdmSkipBuild(opts: RunContractsPhaseOptions): Promise<CompiledArtifact[]> {
+    const projectDir = resolve(opts.projectDir);
+    const contracts = detectContracts(projectDir);
+
+    if (contracts.length === 0) {
+        throw new Error(
+            `no pre-built contract artifacts found under ${projectDir}; remove --no-contract-build or run \`cargo-contract build\` manually first`,
+        );
+    }
+
+    opts.onEvent({
+        kind: "compile-detected",
+        contracts: contracts.map((c) => c.name),
+    });
+
+    const artifacts: CompiledArtifact[] = [];
+    for (const contract of contracts) {
+        const pvmPath = join(projectDir, `target/${contract.name}.release.polkavm`);
+        if (!existsSync(pvmPath)) {
+            throw new Error(
+                `no pre-built contract artifacts found at ${pvmPath}; remove --no-contract-build or run \`cargo-contract build\` manually first`,
+            );
+        }
+        artifacts.push({ name: contract.name, pvmPath });
     }
     return artifacts;
 }
@@ -178,19 +223,26 @@ function relayCdmBuildEvent(event: CdmBuildEvent, emit: (e: ContractsPhaseEvent)
 async function compileFoundry(opts: RunContractsPhaseOptions): Promise<CompiledArtifact[]> {
     const projectDir = resolve(opts.projectDir);
 
-    // `--resolc` forces PolkaVM codegen regardless of `foundry.toml`; plain
-    // `forge build` defaults to EVM even on the polkadot fork.
-    await runStreamed({
-        cmd: "forge",
-        args: ["build", "--resolc"],
-        cwd: projectDir,
-        description: "forge build --resolc",
-        failurePrefix: "forge build failed",
-        onData: (line) => opts.onEvent({ kind: "compile-log", line }),
-    });
+    if (!opts.skipBuild) {
+        // `--resolc` forces PolkaVM codegen regardless of `foundry.toml`; plain
+        // `forge build` defaults to EVM even on the polkadot fork.
+        await runStreamed({
+            cmd: "forge",
+            args: ["build", "--resolc"],
+            cwd: projectDir,
+            description: "forge build --resolc",
+            failurePrefix: "forge build failed",
+            onData: (line) => opts.onEvent({ kind: "compile-log", line }),
+        });
+    }
 
     const outDir = join(projectDir, "out");
     if (!existsSync(outDir)) {
+        if (opts.skipBuild) {
+            throw new Error(
+                `no pre-built contract artifacts found at ${outDir}; remove --no-contract-build or run \`forge build --resolc\` manually first`,
+            );
+        }
         throw new Error(`forge build did not produce an out/ directory at ${outDir}`);
     }
 
@@ -215,6 +267,12 @@ async function compileFoundry(opts: RunContractsPhaseOptions): Promise<CompiledA
         });
     }
 
+    if (opts.skipBuild && artifacts.length === 0) {
+        throw new Error(
+            `no pre-built contract artifacts found at ${outDir}; remove --no-contract-build or run \`forge build --resolc\` manually first`,
+        );
+    }
+
     return artifacts;
 }
 
@@ -223,17 +281,24 @@ async function compileFoundry(opts: RunContractsPhaseOptions): Promise<CompiledA
 async function compileHardhat(opts: RunContractsPhaseOptions): Promise<CompiledArtifact[]> {
     const projectDir = resolve(opts.projectDir);
 
-    await runStreamed({
-        cmd: "npx",
-        args: ["hardhat", "compile"],
-        cwd: projectDir,
-        description: "npx hardhat compile",
-        failurePrefix: "hardhat compile failed",
-        onData: (line) => opts.onEvent({ kind: "compile-log", line }),
-    });
+    if (!opts.skipBuild) {
+        await runStreamed({
+            cmd: "npx",
+            args: ["hardhat", "compile"],
+            cwd: projectDir,
+            description: "npx hardhat compile",
+            failurePrefix: "hardhat compile failed",
+            onData: (line) => opts.onEvent({ kind: "compile-log", line }),
+        });
+    }
 
     const artifactsRoot = join(projectDir, "artifacts", "contracts");
     if (!existsSync(artifactsRoot)) {
+        if (opts.skipBuild) {
+            throw new Error(
+                `no pre-built contract artifacts found at ${artifactsRoot}; remove --no-contract-build or run \`npx hardhat compile\` manually first`,
+            );
+        }
         throw new Error(
             `hardhat compile did not produce artifacts/contracts/ at ${artifactsRoot} — did you load "@parity/hardhat-polkadot" in your hardhat.config?`,
         );
@@ -259,6 +324,12 @@ async function compileHardhat(opts: RunContractsPhaseOptions): Promise<CompiledA
                 pvmPath: writeTmpBytecode(`hardhat-${contractName}`, bytes),
             });
         }
+    }
+
+    if (opts.skipBuild && artifacts.length === 0) {
+        throw new Error(
+            `no pre-built contract artifacts found at ${artifactsRoot}; remove --no-contract-build or run \`npx hardhat compile\` manually first`,
+        );
     }
 
     return artifacts;

--- a/src/utils/deploy/contracts.ts
+++ b/src/utils/deploy/contracts.ts
@@ -124,6 +124,14 @@ export async function runContractsPhase(
     return { deployed };
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function throwMissingArtifacts(dir: string, manualCmd: string): never {
+    throw new Error(
+        `no pre-built contract artifacts found at ${dir}; remove --no-contract-build or run \`${manualCmd}\` manually first`,
+    );
+}
+
 // ── Compile dispatch ─────────────────────────────────────────────────────────
 
 interface CompiledArtifact {
@@ -182,9 +190,7 @@ async function compileCdmSkipBuild(opts: RunContractsPhaseOptions): Promise<Comp
     const contracts = detectContracts(projectDir);
 
     if (contracts.length === 0) {
-        throw new Error(
-            `no pre-built contract artifacts found under ${projectDir}; remove --no-contract-build or run \`cargo-contract build\` manually first`,
-        );
+        throwMissingArtifacts(projectDir, "cargo-contract build");
     }
 
     opts.onEvent({
@@ -196,9 +202,7 @@ async function compileCdmSkipBuild(opts: RunContractsPhaseOptions): Promise<Comp
     for (const contract of contracts) {
         const pvmPath = join(projectDir, `target/${contract.name}.release.polkavm`);
         if (!existsSync(pvmPath)) {
-            throw new Error(
-                `no pre-built contract artifacts found at ${pvmPath}; remove --no-contract-build or run \`cargo-contract build\` manually first`,
-            );
+            throwMissingArtifacts(pvmPath, "cargo-contract build");
         }
         artifacts.push({ name: contract.name, pvmPath });
     }
@@ -237,17 +241,19 @@ async function compileFoundry(opts: RunContractsPhaseOptions): Promise<CompiledA
     }
 
     const outDir = join(projectDir, "out");
-    if (!existsSync(outDir)) {
-        if (opts.skipBuild) {
-            throw new Error(
-                `no pre-built contract artifacts found at ${outDir}; remove --no-contract-build or run \`forge build --resolc\` manually first`,
-            );
+    let foundryEntries: import("node:fs").Dirent[];
+    try {
+        foundryEntries = readdirSync(outDir, { withFileTypes: true });
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            if (opts.skipBuild) throwMissingArtifacts(outDir, "forge build --resolc");
+            throw new Error(`forge build did not produce an out/ directory at ${outDir}`);
         }
-        throw new Error(`forge build did not produce an out/ directory at ${outDir}`);
+        throw err;
     }
 
     const artifacts: CompiledArtifact[] = [];
-    for (const entry of readdirSync(outDir, { withFileTypes: true })) {
+    for (const entry of foundryEntries) {
         if (!entry.isDirectory()) continue;
         if (entry.name.endsWith(".t.sol") || entry.name.endsWith(".s.sol")) continue;
         if (!entry.name.endsWith(".sol")) continue;
@@ -268,9 +274,7 @@ async function compileFoundry(opts: RunContractsPhaseOptions): Promise<CompiledA
     }
 
     if (opts.skipBuild && artifacts.length === 0) {
-        throw new Error(
-            `no pre-built contract artifacts found at ${outDir}; remove --no-contract-build or run \`forge build --resolc\` manually first`,
-        );
+        throwMissingArtifacts(outDir, "forge build --resolc");
     }
 
     return artifacts;
@@ -293,19 +297,21 @@ async function compileHardhat(opts: RunContractsPhaseOptions): Promise<CompiledA
     }
 
     const artifactsRoot = join(projectDir, "artifacts", "contracts");
-    if (!existsSync(artifactsRoot)) {
-        if (opts.skipBuild) {
+    let hardhatEntries: import("node:fs").Dirent[];
+    try {
+        hardhatEntries = readdirSync(artifactsRoot, { withFileTypes: true });
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            if (opts.skipBuild) throwMissingArtifacts(artifactsRoot, "npx hardhat compile");
             throw new Error(
-                `no pre-built contract artifacts found at ${artifactsRoot}; remove --no-contract-build or run \`npx hardhat compile\` manually first`,
+                `hardhat compile did not produce artifacts/contracts/ at ${artifactsRoot} — did you load "@parity/hardhat-polkadot" in your hardhat.config?`,
             );
         }
-        throw new Error(
-            `hardhat compile did not produce artifacts/contracts/ at ${artifactsRoot} — did you load "@parity/hardhat-polkadot" in your hardhat.config?`,
-        );
+        throw err;
     }
 
     const artifacts: CompiledArtifact[] = [];
-    for (const entry of readdirSync(artifactsRoot, { withFileTypes: true })) {
+    for (const entry of hardhatEntries) {
         if (!entry.isDirectory()) continue;
         if (!entry.name.endsWith(".sol")) continue;
 
@@ -327,9 +333,7 @@ async function compileHardhat(opts: RunContractsPhaseOptions): Promise<CompiledA
     }
 
     if (opts.skipBuild && artifacts.length === 0) {
-        throw new Error(
-            `no pre-built contract artifacts found at ${artifactsRoot}; remove --no-contract-build or run \`npx hardhat compile\` manually first`,
-        );
+        throwMissingArtifacts(artifactsRoot, "npx hardhat compile");
     }
 
     return artifacts;

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -81,6 +81,12 @@ export interface RunDeployOptions {
     repositoryUrl?: string | null;
     /** Compile + deploy foundry/hardhat/cdm contracts alongside the frontend. */
     deployContracts?: boolean;
+    /**
+     * Skip the contract compile step (forge/hardhat/cargo-contract) and use
+     * pre-existing artifacts on disk. CI-friendly for environments without the
+     * contract toolchain installed. Throws if no artifacts are found.
+     */
+    skipContractBuild?: boolean;
     /** The logged-in phone signer. Required for `mode === "phone"` or `publishToPlayground`. */
     userSigner: ResolvedSigner | null;
     /** Event sink — consumed by the TUI / RevX. */
@@ -277,6 +283,7 @@ async function maybeRunContracts(
             const result = await runContractsPhase({
                 projectDir: options.projectDir,
                 contractsType,
+                skipBuild: options.skipContractBuild,
                 // cdm's PipelineChainClient is a structural subset of our
                 // ChainClient — cast keeps the extra `individuality` field out
                 // of the SDK-surface type without affecting runtime behaviour.


### PR DESCRIPTION
## Summary

- Adds \`--no-contract-build\` to \`dot deploy\`. When set alongside \`--contracts\`, the deploy skips the toolchain spawn (\`forge build --resolc\`, \`npx hardhat compile\`, \`cargo-contract build\` via \`@dotdm/contracts\`) and uses existing on-disk artifacts under the project's standard output dir.
- Throws with a clear error message (including the path and a hint to remove the flag or build manually) when no artifacts are found.
- Use case: CI environments without the contract compilers installed. The fixture projects under \`e2e/cli/fixtures/projects/{foundry,hardhat,rust-cdm}\` ship pre-built artefacts; the new flag lets E2E deploy tests use them directly.

## What changes

- \`src/commands/deploy/index.ts\` — declares \`--no-contract-build\`; \`contractBuild?: boolean\` added to \`DeployOpts\`; \`skipContractBuild\` plumbed to \`runDeploy\`
- \`src/utils/deploy/run.ts\` — \`skipContractBuild?: boolean\` added to \`RunDeployOptions\`; forwarded to \`runContractsPhase\` as \`skipBuild\`
- \`src/utils/deploy/contracts.ts\` — \`skipBuild?: boolean\` added to \`RunContractsPhaseOptions\`; \`compileFoundry\` / \`compileHardhat\` skip \`runStreamed\` when set; \`compileCdm\` branches to a new \`compileCdmSkipBuild\` helper that uses \`detectContracts\` + checks \`target/<crate>.release.polkavm\`
- \`src/utils/deploy/contracts.test.ts\` — 6 new integration tests for the skip path (3 foundry + 3 hardhat), covering the happy path and two error paths each
- \`README.md\` — CI/automation flags table added under \`dot deploy\`
- \`.changeset/feat-skip-contract-build.md\` — minor bump

## CDM skip-build implementation

\`@dotdm/contracts\` does not have a discover-only mode in \`buildContracts\`. Instead, \`compileCdmSkipBuild\` calls the exported \`detectContracts(rootDir)\` (reads \`cargo metadata\`, no build required), then checks \`target/<crate>.release.polkavm\` — the exact path \`buildContracts\` writes per the upstream source at \`dist/index.js:674\`. No \`.contract\` JSON parsing needed.

CDM skip-build is implemented but not unit-tested — \`detectContracts\` requires a real Cargo workspace or a heavy mock; correctness is exercised through e2e in the follow-up.

## Interactive path

\`--no-contract-build\` is headless-only by design. The flag is parsed but not forwarded to the interactive TUI path (\`runInteractive\`), consistent with how the flag is described as CI-only in the README.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm test\` — 445 passing (6 new integration tests added)
- [x] \`bun run src/index.ts deploy --help\` shows \`--no-contract-build\` with description
- [x] \`--no-contract-build\` without \`--contracts\` is a no-op (the \`deployContracts\` gate in \`maybeRunContracts\` already short-circuits before \`runContractsPhase\` is called)