### PR TITLE
ci(e2e): Phase 5c — nightly-deploy-multi + parametrize contract-deploy tests

### DIFF
--- a/.changeset/e2e-phase-5c-multi-contract.md
+++ b/.changeset/e2e-phase-5c-multi-contract.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Nightly E2E now exercises the multi-contract publish path: `nightly-deploy-multi` cell publishes both `TokenA.sol` and `TokenB.sol` from the multi-contract fixture to the `e2e-cli-multi.dot` domain, exercising the batch contract-instantiate path. Refactored the 3 near-identical contract-deploy tests (foundry, hardhat, multi) into a shared `runContractDeployTest` helper.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -138,6 +138,9 @@ jobs:
                     - cell: nightly-deploy-hardhat
                       # source: e2e/cli/deploy.test.ts → describe("dot deploy — hardhat …")
                       pattern: "deploy — hardhat"
+                    - cell: nightly-deploy-multi
+                      # source: e2e/cli/deploy.test.ts → describe("dot deploy — multi …")
+                      pattern: "deploy — multi"
         steps:
             - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ These are things that aren't self-evident from reading the code and have bitten 
 
 - **Local launcher:** `tools/e2e-local.sh [smoke|pr|nightly]` — also callable via `pnpm test:e2e:smoke`, `pnpm test:e2e:pr`, `pnpm test:e2e:nightly`.
 - **CI workflow:** `.github/workflows/e2e.yml` — runs on PR / push:main / cron 06:00 UTC / workflow_dispatch.
-- **CI matrix:** 9 cells across four matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry) + `test-nightly-no-publish` (parallel, schedule/dispatch only: nightly-mod-miss, nightly-diagnostic) + `test-nightly-publish` (max-parallel: 1, schedule/dispatch only: nightly-deploy-hardhat). Each cell runs a subset via `vitest -t "<pattern>"`.
+- **CI matrix:** 10 cells across four matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry) + `test-nightly-no-publish` (parallel, schedule/dispatch only: nightly-mod-miss, nightly-diagnostic) + `test-nightly-publish` (max-parallel: 1, schedule/dispatch only: nightly-deploy-hardhat, nightly-deploy-multi). Each cell runs a subset via `vitest -t "<pattern>"`.
 - **Test files:** `e2e/cli/*.test.ts` (vitest, spawned via `bun run src/index.ts`).
 - **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
 - **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -30,6 +30,48 @@ function absBuildDir(fixture: string, dir = "dist"): string {
 	return resolve(fixture, dir);
 }
 
+/**
+ * Shared helper for contract-deploy end-to-end tests.
+ *
+ * `--no-contract-build` skips the toolchain subprocess (forge / npx hardhat
+ * compile / cargo-contract) so the CI runner doesn't need the EVM/Rust
+ * toolchain installed. Each fixture ships pre-built bytecode in its out/ or
+ * artifacts/ directory.
+ */
+interface ContractDeployTestConfig {
+	/** describe-block discriminator: "foundry", "hardhat", "multi" */
+	name: string;
+	/** E2E_DOMAINS.<name> */
+	domain: string;
+	/** fixturePath() result */
+	fixture: string;
+}
+
+function runContractDeployTest(cfg: ContractDeployTestConfig): void {
+	describe(`dot deploy — ${cfg.name} (requires Paseo + IPFS)`, () => {
+		test(`${cfg.name} deploy completes end-to-end`, { timeout: 450_000 }, async () => {
+			const result = await dot([
+				"deploy",
+				"--signer", "dev",
+				"--domain", cfg.domain,
+				"--buildDir", absBuildDir(cfg.fixture),
+				"--contracts",
+				"--no-contract-build",
+				"--playground",
+				"--suri", SIGNER.suri,
+				"--dir", cfg.fixture,
+			], { timeout: 400_000 });
+
+			expect(
+				result.exitCode,
+				`${cfg.name} deploy failed: ${result.stdout}\n${result.stderr}`,
+			).toBe(0);
+			expect(result.stdout).toContain("Deploy complete");
+			expect(result.stdout).toContain(cfg.domain);
+		});
+	});
+}
+
 describe("dot deploy — preflight and validation", () => {
 	test("reports mainnet not yet supported", async () => {
 		const result = await dot([
@@ -238,61 +280,12 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 	});
 });
 
-describe("dot deploy — foundry (requires Paseo + IPFS)", () => {
-	test("foundry deploy completes end-to-end", { timeout: 450_000 }, async () => {
-		const domain = E2E_DOMAINS.foundry;
-		const result = await dot([
-			"deploy",
-			"--signer", "dev",
-			"--domain", domain,
-			"--buildDir", absBuildDir(foundry),
-			// --no-contract-build skips the forge subprocess so we don't
-			// need the EVM toolchain on the CI runner; the fixture ships
-			// pre-committed bytecode under out/Counter.sol/Counter.json.
-			// The frontend build is the trivial mkdir+echo in the fixture's
-			// package.json — let it run to produce dist/.
-			"--contracts",
-			"--no-contract-build",
-			"--playground",
-			"--suri", SIGNER.suri,
-			"--dir", foundry,
-		], { timeout: 400_000 });
-
-		expect(
-			result.exitCode,
-			`foundry deploy failed: ${result.stdout}\n${result.stderr}`,
-		).toBe(0);
-		expect(result.stdout).toContain("Deploy complete");
-		expect(result.stdout).toContain(domain);
-	});
-});
-
-describe("dot deploy — hardhat (requires Paseo + IPFS)", () => {
-	test("hardhat deploy completes end-to-end", { timeout: 450_000 }, async () => {
-		const domain = E2E_DOMAINS.hardhat;
-		const result = await dot([
-			"deploy",
-			"--signer", "dev",
-			"--domain", domain,
-			"--buildDir", absBuildDir(hardhat),
-			// --no-contract-build skips `npx hardhat compile` (the toolchain
-			// isn't installed on the CI runner). The fixture ships pre-built
-			// bytecode under artifacts/contracts/Lock.sol/Lock.json.
-			"--contracts",
-			"--no-contract-build",
-			"--playground",
-			"--suri", SIGNER.suri,
-			"--dir", hardhat,
-		], { timeout: 400_000 });
-
-		expect(
-			result.exitCode,
-			`hardhat deploy failed: ${result.stdout}\n${result.stderr}`,
-		).toBe(0);
-		expect(result.stdout).toContain("Deploy complete");
-		expect(result.stdout).toContain(domain);
-	});
-});
+// Contract-deploy tests — parametrized via runContractDeployTest
+runContractDeployTest({ name: "foundry", domain: E2E_DOMAINS.foundry, fixture: foundry });
+runContractDeployTest({ name: "hardhat", domain: E2E_DOMAINS.hardhat, fixture: hardhat });
+// Multi-contract foundry project — exercises the contracts-batch publish path
+// (TokenA.sol + TokenB.sol deployed in a single --contracts run).
+runContractDeployTest({ name: "multi", domain: E2E_DOMAINS.multi, fixture: multiContract });
 
 // SKIPPED: the rust-cdm fixture's `target/flipper.contract` is a stub
 // (`{"source":{"hash":"0xabc"}}`) and there is no `target/<crate>.release.polkavm`


### PR DESCRIPTION
Phase 5c of the E2E redesign — multi-contract publish path + test parametrization.

## Summary
- New `nightly-deploy-multi` cell exercises the multi-contract `--contracts` batch publish path (TokenA.sol + TokenB.sol → `e2e-cli-multi.dot`)
- Refactored the 3 near-identical contract-deploy tests (foundry, hardhat, multi) into a shared `runContractDeployTest` helper — net line reduction of ~40 LOC of repeated boilerplate
- The CDM `describe.skip` block stays as-is pending its fixture upgrade (Phase 5f)
- `note` and `manualToolchain` fields were considered and dropped per the simplify self-review: neither would be consumed inside the helper body

## Test plan
- [x] Pattern counts verified locally: foundry=1, hardhat=1, multi=1, full pipeline=3
- [x] YAML parses clean (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 445 unit tests pass

## Out of scope (subsequent sub-PRs)
- Phase 5d: nightly-rejections-full (constructor-args new test)
- Phase 5e: nightly-deploy-modable (--modable + GH repo)
- Phase 5f: rust-cdm fixture upgrade + re-add pr-deploy-cdm
- Phase 6: chaos cells
- Phase 7: published-binary surface