### PR TITLE
ci(e2e): Phase 5d — nightly-rejections cell

### DIFF
--- a/.changeset/e2e-phase-5d-rejections.md
+++ b/.changeset/e2e-phase-5d-rejections.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Nightly E2E now exercises the `--no-contract-build` error path: a new `nightly-rejections` cell asserts the integration-level error message when a Foundry project requests skip-build but ships no pre-built artefacts under `out/`.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -189,6 +189,9 @@ jobs:
                       # testFile scoping skips globalSetup chain-RPC calls (no chain access needed for diagnostic flag tests).
                       pattern: "diagnostic mode"
                       testFile: e2e/cli/diagnostic.test.ts
+                    - cell: nightly-rejections
+                      # source: e2e/cli/deploy.test.ts → describe("dot deploy — rejects --no-contract-build with no artefacts")
+                      pattern: "rejects --no-contract-build"
         steps:
             # checkout must run before the local composite action can be loaded.
             - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ These are things that aren't self-evident from reading the code and have bitten 
 
 - **Local launcher:** `tools/e2e-local.sh [smoke|pr|nightly]` — also callable via `pnpm test:e2e:smoke`, `pnpm test:e2e:pr`, `pnpm test:e2e:nightly`.
 - **CI workflow:** `.github/workflows/e2e.yml` — runs on PR / push:main / cron 06:00 UTC / workflow_dispatch.
-- **CI matrix:** 10 cells across four matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry) + `test-nightly-no-publish` (parallel, schedule/dispatch only: nightly-mod-miss, nightly-diagnostic) + `test-nightly-publish` (max-parallel: 1, schedule/dispatch only: nightly-deploy-hardhat, nightly-deploy-multi). Each cell runs a subset via `vitest -t "<pattern>"`.
+- **CI matrix:** 11 cells across four matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry) + `test-nightly-no-publish` (parallel, schedule/dispatch only: nightly-mod-miss, nightly-diagnostic, nightly-rejections) + `test-nightly-publish` (max-parallel: 1, schedule/dispatch only: nightly-deploy-hardhat, nightly-deploy-multi). Each cell runs a subset via `vitest -t "<pattern>"`.
 - **Test files:** `e2e/cli/*.test.ts` (vitest, spawned via `bun run src/index.ts`).
 - **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
 - **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -287,6 +287,28 @@ runContractDeployTest({ name: "hardhat", domain: E2E_DOMAINS.hardhat, fixture: h
 // (TokenA.sol + TokenB.sol deployed in a single --contracts run).
 runContractDeployTest({ name: "multi", domain: E2E_DOMAINS.multi, fixture: multiContract });
 
+// Rejection test — does NOT require Paseo or IPFS; exits before any chain mutation.
+describe("dot deploy — rejects --no-contract-build with no artefacts", () => {
+	test("foundry project with --no-contract-build but no out/ → clear error", { timeout: 120_000 }, async () => {
+		const constructorArgs = fixturePath("constructor-args");
+		const result = await dot([
+			"deploy",
+			"--signer", "dev",
+			"--domain", E2E_DOMAINS.preflight,
+			"--buildDir", absBuildDir(constructorArgs),
+			"--contracts",
+			"--no-contract-build",
+			"--playground",
+			"--suri", SIGNER.suri,
+			"--dir", constructorArgs,
+		]);
+		const output = result.stdout + result.stderr;
+		expect(result.exitCode).not.toBe(0);
+		expect(output).toMatch(/no pre-built contract artifacts found/i);
+		expect(output).toMatch(/--no-contract-build/);
+	});
+});
+
 // SKIPPED: the rust-cdm fixture's `target/flipper.contract` is a stub
 // (`{"source":{"hash":"0xabc"}}`) and there is no `target/<crate>.release.polkavm`
 // for the skip-build path to read. A working fixture needs:


### PR DESCRIPTION
Phase 5d of the E2E redesign — pivoted from constructor-args rejection to `--no-contract-build` error path (the original scenario lacks a CLI-layer specific error message; this variant tests an integration path that's already unit-tested in src/utils/deploy/contracts.test.ts).

## Summary
- New `nightly-rejections` cell asserts the integration-level error when --no-contract-build is set on a project missing pre-built artefacts.
- Reuses the existing constructor-args fixture (foundry.toml without out/) as the empty-artefacts vehicle.

## Out of scope
- Phase 5e: nightly-deploy-modable
- Phase 5f: rust-cdm fixture upgrade
- Phase 6: chaos cells (S18, S19)
- Phase 7: published-binary surface