### PR TITLE
ci(e2e): Phase 7 — release-prerelease published-binary smoke

### DIFF
--- a/.changeset/e2e-phase-7-published-binary.md
+++ b/.changeset/e2e-phase-7-published-binary.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+CI now validates published RC binaries: a new `e2e-release.yml` workflow fires on `release: prereleased`, downloads the `dot-linux-x64` SEA asset, and runs `e2e/cli/published.test.ts` smoke tests (`--version`, `--help`). Catches packaging regressions before stable release.

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -1,0 +1,88 @@
+name: E2E (Published Binary)
+
+on:
+    release:
+        types: [prereleased]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to test (e.g. v0.16.0-rc.1)"
+                required: true
+
+permissions:
+    contents: read
+
+jobs:
+    smoke:
+        name: "E2E · release-smoke"
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - run: pnpm install
+
+            - name: Resolve release tag
+              id: tag
+              shell: bash
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                      TAG="${{ inputs.tag }}"
+                  else
+                      TAG="${{ github.event.release.tag_name }}"
+                  fi
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+            - name: Wait for SEA asset to be uploaded
+              shell: /usr/bin/bash -euo pipefail {0}
+              run: |
+                  TAG="${{ steps.tag.outputs.tag }}"
+                  for i in $(seq 1 30); do
+                      if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -q "^dot-linux-x64$"; then
+                          echo "Found dot-linux-x64 asset on attempt $i"
+                          exit 0
+                      fi
+                      echo "  attempt $i/30: waiting for asset..."
+                      sleep 10
+                  done
+                  echo "::error::Timed out waiting for dot-linux-x64 asset on $TAG"
+                  exit 1
+
+            - name: Download SEA asset
+              shell: bash
+              run: |
+                  TAG="${{ steps.tag.outputs.tag }}"
+                  mkdir -p ./bin
+                  gh release download "$TAG" --pattern "dot-linux-x64" --dir ./bin
+                  chmod +x ./bin/dot-linux-x64
+                  ls -la ./bin/dot-linux-x64
+
+            - name: Smoke test the published binary
+              uses: nick-fields/retry@v3
+              with:
+                  timeout_minutes: 5
+                  max_attempts: 2
+                  retry_wait_seconds: 15
+                  command: pnpm exec vitest run --config e2e/vitest.config.ts e2e/cli/published.test.ts
+              env:
+                  DOT_E2E_BINARY: ${{ github.workspace }}/bin/dot-linux-x64
+                  DOT_TAG: e2e-ci-release
+                  DOT_TELEMETRY: "1"
+
+            - name: Upload forensic artefacts
+              if: always()
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: e2e-reports-release-smoke
+                  path: e2e-reports/
+                  retention-days: 7
+                  if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ These are things that aren't self-evident from reading the code and have bitten 
 - **Local launcher:** `tools/e2e-local.sh [smoke|pr|nightly]` — also callable via `pnpm test:e2e:smoke`, `pnpm test:e2e:pr`, `pnpm test:e2e:nightly`.
 - **CI workflow:** `.github/workflows/e2e.yml` — runs on PR / push:main / cron 06:00 UTC / workflow_dispatch.
 - **CI matrix:** 12 cells across four matrices — `test-no-publish` (parallel: pr-install, pr-preflight, pr-mod, pr-init-session) + `test-publish` (max-parallel: 1: pr-deploy-frontend, pr-deploy-foundry) + `test-nightly-no-publish` (parallel, schedule/dispatch only: nightly-mod-miss, nightly-diagnostic, nightly-rejections, nightly-chaos-sigint) + `test-nightly-publish` (max-parallel: 1, schedule/dispatch only: nightly-deploy-hardhat, nightly-deploy-multi). Each cell runs a subset via `vitest -t "<pattern>"`.
+- **Release smoke:** `.github/workflows/e2e-release.yml` fires on `release: prereleased`, downloads the `dot-linux-x64` SEA asset, and runs `e2e/cli/published.test.ts` against it. Validates the published binary before stable release.
 - **Test files:** `e2e/cli/*.test.ts` (vitest, spawned via `bun run src/index.ts`).
 - **Reports directory:** `e2e-reports/junit.xml` + `e2e-reports/dot-runs.log` (gitignored).
 - **Tag prefix:** `DOT_TAG=e2e-{ci|local}-{trigger}` so Sentry dashboards filter test traffic. The CLI plumbs `DOT_TAG` into the `cli.tag` root-span attribute via `src/telemetry-config.ts`.

--- a/e2e/cli/helpers/published-binary.ts
+++ b/e2e/cli/helpers/published-binary.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolves the path to the `dot` binary for E2E tests against a published
+ * artefact. When `DOT_E2E_BINARY` is set, return that path (tests run against
+ * the SEA binary). Otherwise return null and the caller should use the
+ * source-build path via dot.ts.
+ */
+export function getPublishedBinaryPath(): string | null {
+	return process.env.DOT_E2E_BINARY ?? null;
+}

--- a/e2e/cli/published.test.ts
+++ b/e2e/cli/published.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Smoke tests for the published SEA binary. Skipped when DOT_E2E_BINARY is
+ * unset (i.e. on PR / dev runs). Exercised by the e2e-release.yml workflow
+ * after downloading the SEA asset from a prerelease tag.
+ *
+ * Coverage scope (per spec design §11, S20a):
+ *   - Binary launches and reports a sane version
+ *   - Binary exits 0 on --help with the expected sections
+ *
+ * The keystroke-handling regression (S20-unit / Bun stdin warm-up) is
+ * covered by src/index.test.ts at the source level. We deliberately do NOT
+ * use a PTY here — node-pty is rejected per spec.
+ */
+
+import { describe, test, expect } from "vitest";
+import { execa } from "execa";
+import { getPublishedBinaryPath } from "./helpers/published-binary.js";
+
+const binary = getPublishedBinaryPath();
+
+describe.skipIf(!binary)("dot — published SEA binary smoke", () => {
+	test("--version exits 0 with semver output", async () => {
+		const result = await execa(binary!, ["--version"], { reject: false });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+	});
+
+	test("--help exits 0 with usage section", async () => {
+		const result = await execa(binary!, ["--help"], { reject: false });
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout + result.stderr).toMatch(/Usage:/i);
+	});
+});


### PR DESCRIPTION
Phase 7 of the E2E redesign — validates the SEA binary before it goes stable.

## Summary
- New workflow `.github/workflows/e2e-release.yml` fires on `release: prereleased` (also workflow_dispatch with explicit tag).
- Polls for the `dot-linux-x64` SEA asset (10s × 30 = 5min budget) since the release event can fire before the binary is fully uploaded.
- Downloads + chmods the binary, sets `DOT_E2E_BINARY`, runs `e2e/cli/published.test.ts`.
- Test asserts `--version` exits 0 with semver output and `--help` exits 0 with usage section. Skipped via `describe.skipIf` when `DOT_E2E_BINARY` is unset (i.e. on PR / dev runs).
- The Bun stdin warm-up regression is covered by the existing source-level test in `src/index.test.ts` (no PTY here per spec).

## Stacked on
- PR #92 (Phase 6 SIGINT). Will rebase once #92 merges. No conflicts expected (Phase 7 is purely additive — new files only).

## Test plan
- [x] PR push: published.test.ts is correctly skipped (DOT_E2E_BINARY unset)
- [ ] First prereleased tag: workflow downloads SEA + runs smoke
- [ ] Manual: `gh workflow run e2e-release.yml --ref main -f tag=<existing-tag>` against any existing tag

## Out of scope
- Phase 5e (modable), 5f (cdm fixture)
- Phase 6 S18 (RPC failover — needs source change for env-var override)
- Post-release `@latest` smoke (e2e-post-release.yml — secondary follow-up)
