### PR TITLE
ci(e2e): surface failure detail inline in GH Actions UI

### DIFF
--- a/.changeset/ci-inline-failure-details.md
+++ b/.changeset/ci-inline-failure-details.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Failed E2E cells now surface forensic detail (CLI subprocess stdout/stderr from `dot-runs.log`, junit.xml failure messages, and `::error::` annotations at the top of the run page) directly in the GH Actions UI. Previously a triager had to download the artefact and untar it locally to see the real root cause. Closes #98.

--- a/.github/actions/surface-e2e-failure/action.yml
+++ b/.github/actions/surface-e2e-failure/action.yml
@@ -1,0 +1,37 @@
+name: Surface E2E failure detail
+description: |
+    Print dot-runs.log + failed-testcase summary to the job log and emit
+    ::error:: annotations so triagers see the real root cause without
+    downloading artefacts. Intended to run with `if: failure()` after a
+    cell's test step.
+
+runs:
+    using: composite
+    steps:
+        - name: Dump dot-runs.log + failed testcases
+          shell: bash
+          run: |
+              echo "::group::dot-runs.log (CLI subprocess stdout/stderr)"
+              if [ -f e2e-reports/dot-runs.log ]; then
+                  cat e2e-reports/dot-runs.log
+              else
+                  echo "(no dot-runs.log written — test failed before any dot subprocess ran, or the e2e-reports dir wasn't created)"
+              fi
+              echo "::endgroup::"
+
+              if [ -f e2e-reports/junit.xml ]; then
+                  if ! command -v xmlstarlet >/dev/null 2>&1; then
+                      sudo apt-get update -q
+                      sudo apt-get install -y -q xmlstarlet
+                  fi
+                  echo "::group::Failed testcases (from junit.xml)"
+                  xmlstarlet sel -t -m "//testcase[failure or error]" \
+                      -v "concat(@classname, ' › ', @name)" -o $'\n  ' \
+                      -v "failure/@message | error/@message" -n e2e-reports/junit.xml || true
+                  echo "::endgroup::"
+
+                  xmlstarlet sel -t -m "//testcase[failure or error]" \
+                      -v "concat('::error file=', @classname, '::', @name, ' — ')" \
+                      -v "failure/@message | error/@message" -n e2e-reports/junit.xml \
+                      | head -c 3000 || true
+              fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,10 @@ jobs:
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
 
+            - name: Surface failure detail
+              if: failure()
+              uses: ./.github/actions/surface-e2e-failure
+
             - name: Upload forensic artefacts
               if: always()
               continue-on-error: true
@@ -115,6 +119,10 @@ jobs:
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
 
+            - name: Surface failure detail
+              if: failure()
+              uses: ./.github/actions/surface-e2e-failure
+
             - name: Upload forensic artefacts
               if: always()
               continue-on-error: true
@@ -160,6 +168,10 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+
+            - name: Surface failure detail
+              if: failure()
+              uses: ./.github/actions/surface-e2e-failure
 
             - name: Upload forensic artefacts
               if: always()
@@ -216,6 +228,10 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+
+            - name: Surface failure detail
+              if: failure()
+              uses: ./.github/actions/surface-e2e-failure
 
             - name: Upload forensic artefacts
               if: always()


### PR DESCRIPTION
Closes #98.

## Summary
- New composite action `.github/actions/surface-e2e-failure` runs on `if: failure()` and dumps:
  - `e2e-reports/dot-runs.log` (CLI subprocess stdout/stderr) inside a collapsible group
  - Failed-testcase summary from `junit.xml` inside a collapsible group
  - `::error::` annotations at the top of the run page (one per failed testcase)
- Wired into all 4 matrix jobs (test-no-publish, test-publish, test-nightly-no-publish, test-nightly-publish).
- Triagers now see the real root cause without downloading artefacts.
- xmlstarlet is installed on-demand only on failure paths — zero overhead on green runs.

## Verification
- [ ] Trigger a deliberate failure on this branch and confirm the inline group + annotations appear.
- [ ] Confirm green runs are unaffected (the new step has `if: failure()`, so it never runs on success).