### PR TITLE
fix(update): mkdir install dir before writing binary (#97)

### DIFF
--- a/.changeset/fix-update-mkdir.md
+++ b/.changeset/fix-update-mkdir.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`dot update` now creates its install directory if missing instead of failing with ENOENT. Previously the directory was assumed to exist (created by `install.sh` during `dot init`), causing `dot update` to fail on environments that didn't run the installer (e.g. CI runners spawning the CLI directly). Fixes #97.

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -3,6 +3,7 @@ import {
     chmodSync,
     closeSync,
     fsyncSync,
+    mkdirSync,
     openSync,
     renameSync,
     unlinkSync,
@@ -154,6 +155,7 @@ export const updateCommand = new Command("update")
                     "install update",
                     { "cli.update.asset": asset },
                     async () => {
+                        mkdirSync(installDir, { recursive: true });
                         atomicInstall(dest, binary);
 
                         if (platform() === "darwin") {


### PR DESCRIPTION
Closes #97.

`dot update` previously failed with `ENOENT` when the install dir didn't exist (CI runners that spawn the CLI directly without running `install.sh`). The fix is one `mkdirSync(installDir, { recursive: true })` call before `atomicInstall`.

This unblocks the `pr-install > dot update succeeds` test in PRs #93, #95.

## Test plan
- [x] tsc clean, format clean, all unit tests pass (445/445)
- [ ] On main: `pr-install` cell goes green