### PR TITLE
fix(e2e,tools): use PAS instead of DOT for testnet token strings (#96)

### DIFF
--- a/.changeset/fix-pas-token-strings.md
+++ b/.changeset/fix-pas-token-strings.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+E2E test setup and bootstrap-tool log strings now correctly use PAS (Paseo's native token symbol) instead of DOT. The numeric values are unchanged (1 PAS = 10^10 plancks); only the displayed unit symbol changes. Closes #96.

--- a/e2e/cli/setup/fund.ts
+++ b/e2e/cli/setup/fund.ts
@@ -15,26 +15,26 @@ import { checkBalance, ensureFunded } from "../../../src/utils/account/funding.j
 import { getTestClient } from "../helpers/chain.js";
 import { SIGNER } from "../fixtures/accounts.js";
 
-const DOT = 10_000_000_000n;
+const PAS = 10_000_000_000n;
 
 /** Top up the deployer if it falls below this. */
-export const MIN_BALANCE = 500n * DOT;
+export const MIN_BALANCE = 500n * PAS;
 
 /** Amount to send when topping up. */
-export const TOP_UP_AMOUNT = 1000n * DOT;
+export const TOP_UP_AMOUNT = 1000n * PAS;
 
 export async function fundDeployerIfLow(): Promise<void> {
 	const client = await getTestClient();
 	const before = await checkBalance(client, SIGNER.address, MIN_BALANCE);
 	console.log(
-		`[e2e setup] SIGNER (${SIGNER.name}) balance: ${before.free / DOT} DOT (${SIGNER.address})`,
+		`[e2e setup] SIGNER (${SIGNER.name}) balance: ${before.free / PAS} PAS (${SIGNER.address})`,
 	);
 	if (before.sufficient) return;
 
 	console.log(
-		`[e2e setup] balance below ${MIN_BALANCE / DOT} DOT — topping up by ${TOP_UP_AMOUNT / DOT} DOT…`,
+		`[e2e setup] balance below ${MIN_BALANCE / PAS} PAS — topping up by ${TOP_UP_AMOUNT / PAS} PAS…`,
 	);
 	await ensureFunded(client, SIGNER.address, MIN_BALANCE, TOP_UP_AMOUNT);
 	const after = await checkBalance(client, SIGNER.address, MIN_BALANCE);
-	console.log(`[e2e setup] SIGNER topped up: ${after.free / DOT} DOT`);
+	console.log(`[e2e setup] SIGNER topped up: ${after.free / PAS} PAS`);
 }

--- a/tools/register-e2e-fixtures.ts
+++ b/tools/register-e2e-fixtures.ts
@@ -70,9 +70,9 @@ const FIXTURES: readonly Fixture[] = [
 ];
 
 const DEFAULT_SURI = `${DEDICATED_E2E_DEPLOYER_MNEMONIC}//e2e-deployer`;
-const DOT = 10_000_000_000n;
-const TOPUP_TARGET = 500n * DOT;
-const TOPUP_AMOUNT = 1000n * DOT;
+const PAS = 10_000_000_000n;
+const TOPUP_TARGET = 500n * PAS;
+const TOPUP_AMOUNT = 1000n * PAS;
 
 interface Args {
 	onlyDomain: string | null;
@@ -107,12 +107,12 @@ function parseArgs(argv: string[]): Args {
 
 async function topUpIfLow(client: Awaited<ReturnType<typeof getConnection>>, address: string): Promise<void> {
 	const balance = await checkBalance(client, address, TOPUP_TARGET);
-	console.log(`signer balance: ${balance.free / DOT} DOT`);
+	console.log(`signer balance: ${balance.free / PAS} PAS`);
 	if (!balance.sufficient) {
-		console.log(`balance below ${TOPUP_TARGET / DOT} DOT — topping up by ${TOPUP_AMOUNT / DOT} DOT…`);
+		console.log(`balance below ${TOPUP_TARGET / PAS} PAS — topping up by ${TOPUP_AMOUNT / PAS} PAS…`);
 		await ensureFunded(client, address, TOPUP_TARGET, TOPUP_AMOUNT);
 		const after = await checkBalance(client, address, MIN_BALANCE);
-		console.log(`topped up: ${after.free / DOT} DOT`);
+		console.log(`topped up: ${after.free / PAS} PAS`);
 	}
 	console.log();
 }
@@ -158,8 +158,8 @@ async function main(): Promise<number> {
 
 	try {
 		const client = await getConnection();
-		// Balance checked once; TOPUP_TARGET (500 DOT) gives ~1000× headroom
-		// for the ~0.1 DOT/publish cost across all 5 fixtures.
+		// Balance checked once; TOPUP_TARGET (500 PAS) gives ~1000× headroom
+		// for the ~0.1 PAS/publish cost across all 5 fixtures.
 		await topUpIfLow(client, signer.address);
 		for (const fixture of targets) {
 			await registerOne(fixture, signer);


### PR DESCRIPTION
Closes #96.

The Paseo testnet's native token is PAS, not DOT. Two files had outdated 'DOT' strings:
- `e2e/cli/setup/fund.ts`: constant rename DOT→PAS + log strings
- `tools/register-e2e-fixtures.ts`: same pattern

No behavioral change — values and code paths are identical, only the displayed unit changes from 'DOT' to 'PAS'.

Env vars (DOT_TAG, DOT_TELEMETRY, etc.) and DotNS labels (`*.dot` domain suffix, `dot` CLI name) are intentionally NOT touched — they're unrelated to the token symbol.