### PR TITLE
fix(deploy): remove unreachable null-signer guard in resolveSignerSetup

### DIFF
--- a/.changeset/fix-dead-signer-guard.md
+++ b/.changeset/fix-dead-signer-guard.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Remove unreachable null-signer guard in `resolveSignerSetup` (`signerMode.ts`). The dead `throw` could never fire because `shouldResolveUserSigner()` guarantees a signer is resolved before `resolveSignerSetup` is called when `--playground` is set. No user-visible behaviour change.

--- a/src/utils/deploy/signerMode.test.ts
+++ b/src/utils/deploy/signerMode.test.ts
@@ -23,16 +23,6 @@ describe("resolveSignerSetup — dev mode", () => {
         expect(result.publishSigner).toBeNull();
     });
 
-    it("publishToPlayground without a userSigner throws a helpful message", () => {
-        expect(() =>
-            resolveSignerSetup({
-                mode: "dev",
-                userSigner: null,
-                publishToPlayground: true,
-            }),
-        ).toThrow(/dot init|--playground/);
-    });
-
     it("publishToPlayground with session userSigner adds one playground approval and leaves auth empty", () => {
         const user = fakeSigner("session");
         const result = resolveSignerSetup({

--- a/src/utils/deploy/signerMode.ts
+++ b/src/utils/deploy/signerMode.ts
@@ -138,14 +138,14 @@ export function resolveSignerSetup(opts: ResolveOptions): DeploySignerSetup {
     // Playground publish always uses the user's signer so ownership ties to
     // their address — otherwise the registry would record a shared dev key
     // and the myApps view would be useless.
+    //
+    // userSigner is guaranteed non-null here: shouldResolveUserSigner() returns
+    // true whenever publishToPlayground is true, so resolveSigner() in the
+    // preflight has already either resolved a signer or thrown before we reach
+    // this point. The null guard that previously lived here was unreachable.
     let publishSigner: ResolvedSigner | null = null;
     if (opts.publishToPlayground) {
-        if (!opts.userSigner) {
-            throw new Error(
-                'Publishing to Playground requires a logged-in account. Run "dot init" first, or drop --playground.',
-            );
-        }
-        publishSigner = opts.userSigner;
+        publishSigner = opts.userSigner!;
         approvals.push({ phase: "playground", label: "Publish to Playground registry" });
     }
 


### PR DESCRIPTION
## Context

Closes #104 (Bug 2).

Bug 1 from that issue (error message not mentioning `--suri`) was already fixed on `main` — `SignerNotAvailableError` now reads `'No signer available. Run "dot init" to log in, or pass --suri //Alice for dev.'`

This PR addresses Bug 2 only.

## Problem

`resolveSignerSetup` in `src/utils/deploy/signerMode.ts` contained a dead error branch:

```ts
if (opts.publishToPlayground) {
    if (!opts.userSigner) {
        throw new Error(
            'Publishing to Playground requires a logged-in account. Run "dot init" first, or drop --playground.',
        );
    }
    ...
}
```

The `!opts.userSigner` guard can never be true when `publishToPlayground` is true. The invariant is enforced one level up:

- `shouldResolveUserSigner()` returns `true` whenever `opts.publishToPlayground === true` (`signerMode.ts:256`)
- When that returns `true`, `resolveSigner()` is called in the preflight (`deploy/index.ts:203`)
- `resolveSigner()` either produces a `ResolvedSigner` or throws `SignerNotAvailableError` — it never returns `null`
- The preflight rethrows any `SignerNotAvailableError` when `publishToPlayground` is set (`deploy/index.ts:208-209`)

So by the time `resolveSignerSetup` is called, `userSigner` is guaranteed non-null. The throw was dead code.

## Fix

- Delete the `if (!opts.userSigner) throw` branch
- Replace with `opts.userSigner!` (non-null assertion) to keep TypeScript happy
- Add a comment explaining the invariant so a future refactor doesn't silently reintroduce the same guard thinking it's needed

## Testing

- `pnpm exec tsc --noEmit` — passes clean
- No behaviour change on any reachable path