### PR TITLE
fix(init): expose freshly-installed rustup to the same dot init run

### DIFF
--- a/.changeset/init-rustup-path.md
+++ b/.changeset/init-rustup-path.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix `dot init` failing on a clean macOS/Linux machine where `rustup` isn't yet installed. The rustup installer writes its binaries to `~/.cargo/bin` and adds that directory to PATH only via shell rc files, which doesn't reach the running `dot` process. The next two steps (`Rust nightly`, `rust-src`) then fail with `bash: rustup: command not found`. After installing rustup we now prepend `$CARGO_HOME/bin` (default `~/.cargo/bin`) to `process.env.PATH` so the rest of `dot init` can resolve `rustup` immediately.

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { prependPath } from "./toolchain.js";
+
+describe("prependPath", () => {
+    let originalPath: string | undefined;
+
+    beforeEach(() => {
+        originalPath = process.env.PATH;
+    });
+
+    afterEach(() => {
+        if (originalPath === undefined) delete process.env.PATH;
+        else process.env.PATH = originalPath;
+    });
+
+    it("prepends the directory when not already present", () => {
+        process.env.PATH = "/usr/bin:/bin";
+        prependPath("/Users/me/.cargo/bin");
+        expect(process.env.PATH).toBe("/Users/me/.cargo/bin:/usr/bin:/bin");
+    });
+
+    it("is a no-op when the directory is already on PATH", () => {
+        process.env.PATH = "/Users/me/.cargo/bin:/usr/bin";
+        prependPath("/Users/me/.cargo/bin");
+        expect(process.env.PATH).toBe("/Users/me/.cargo/bin:/usr/bin");
+    });
+
+    it("handles an empty PATH", () => {
+        process.env.PATH = "";
+        prependPath("/Users/me/.cargo/bin");
+        expect(process.env.PATH).toBe("/Users/me/.cargo/bin");
+    });
+
+    it("handles an unset PATH", () => {
+        delete process.env.PATH;
+        prependPath("/Users/me/.cargo/bin");
+        expect(process.env.PATH).toBe("/Users/me/.cargo/bin");
+    });
+});

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -14,6 +14,17 @@ function run(cmd: string, opts?: { shell?: string }): Promise<string> {
     });
 }
 
+/**
+ * Prepend `dir` to `process.env.PATH` if not already present. Lets a step that
+ * just installed a binary expose it to the rest of `dot init` without waiting
+ * for a shell restart.
+ */
+export function prependPath(dir: string): void {
+    const segments = (process.env.PATH ?? "").split(":").filter(Boolean);
+    if (segments.includes(dir)) return;
+    process.env.PATH = process.env.PATH ? `${dir}:${process.env.PATH}` : dir;
+}
+
 export async function commandExists(cmd: string): Promise<boolean> {
     if (!/^[a-zA-Z0-9_-]+$/.test(cmd)) {
         throw new Error(`Invalid command name: ${cmd}`);
@@ -80,11 +91,17 @@ export const TOOL_STEPS: ToolStep[] = [
     {
         name: "rustup",
         check: () => commandExists("rustup"),
-        install: (onData) =>
-            runPiped(
+        install: async (onData) => {
+            await runPiped(
                 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y',
                 onData,
-            ),
+            );
+            // rustup-init writes binaries to $CARGO_HOME/bin (default ~/.cargo/bin)
+            // and updates shell rc files, but those edits don't reach the running
+            // dot process. Prepend the bin dir so the very next step in this same
+            // `dot init` can resolve `rustup`.
+            prependPath(resolve(process.env.CARGO_HOME ?? `${homedir()}/.cargo`, "bin"));
+        },
         manualHint: "https://rustup.rs",
     },
     {


### PR DESCRIPTION
## Summary

- On a clean macOS/Linux machine `dot init` shows `rustup` ✓ followed immediately by `Rust nightly` ✕ and `rust-src` ✕ with `bash: rustup: command not found`. The rustup installer drops `rustup` in `$CARGO_HOME/bin` (default `~/.cargo/bin`) and only updates PATH via `~/.zshrc` / `~/.bashrc` / `~/.profile`. Those edits never reach the running `dot` process — `runShell` spawns `bash -c …` which is non-interactive non-login, so it doesn't source the rc files, and inherits the parent's untouched PATH.
- Fix: after the rustup install step succeeds, prepend `$CARGO_HOME/bin` to `process.env.PATH` so the very next steps in the same `dot init` run can resolve `rustup`. Logic lives in a new exported `prependPath()` helper in `src/utils/toolchain.ts`.
- Adds `src/utils/toolchain.test.ts` covering `prependPath` (idempotent on duplicates, handles empty/unset PATH, prepends when missing). Includes a patch changeset.

## Test plan

- [x] `pnpm test` — 454/454 pass, including 4 new `prependPath` cases
- [x] `pnpm format:check` clean
- [x] `tsc --noEmit` clean
- [x] On a clean macOS box: `curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/<this-branch>/install.sh | bash` and confirm `Rust nightly` and `rust-src` come up ✓ on first run