### PR TITLE
feat: warn when CLI is out of date (closes #59)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
     setProcessGuardWarningHandler,
 } from "./utils/process-guard.js";
 import { clearWindowTitle } from "./utils/ui/theme/window-title.js";
+import { checkForUpdates, flushVersionCheck } from "./utils/version-check.js";
 
 const DEPLOY_DESCRIPTION =
     "Build the project, upload to Bulletin, register a .dot domain, and optionally publish to Playground";
@@ -115,6 +116,7 @@ program.addCommand(logoutCommand);
 program.addCommand(updateCommand);
 
 try {
+    checkForUpdates(pkg.version);
     await program.parseAsync();
 } catch (err) {
     if (process.exitCode === undefined || process.exitCode === 0) {
@@ -123,6 +125,7 @@ try {
     process.exitCode = 1;
 } finally {
     await flushTelemetry();
+    await flushVersionCheck();
 }
 
 process.exit(typeof process.exitCode === "number" ? process.exitCode : 0);

--- a/src/utils/version-check.test.ts
+++ b/src/utils/version-check.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+    isOutdated,
+    normalizeVersion,
+    readCachedVersion,
+    writeCachedVersion,
+    getCachePath,
+} from "./version-check.js";
+
+describe("normalizeVersion", () => {
+    it("strips leading v", () => {
+        expect(normalizeVersion("v0.16.14")).toBe("0.16.14");
+    });
+
+    it("leaves bare version unchanged", () => {
+        expect(normalizeVersion("0.16.14")).toBe("0.16.14");
+    });
+});
+
+describe("isOutdated", () => {
+    it("returns false when versions are equal", () => {
+        expect(isOutdated("0.16.14", "0.16.14")).toBe(false);
+    });
+
+    it("returns false when versions are equal with v prefix", () => {
+        expect(isOutdated("v0.16.14", "v0.16.14")).toBe(false);
+    });
+
+    it("returns true when patch is behind", () => {
+        expect(isOutdated("0.16.14", "0.16.15")).toBe(true);
+    });
+
+    it("returns true when minor is behind", () => {
+        expect(isOutdated("0.16.14", "0.17.0")).toBe(true);
+    });
+
+    it("returns true when major is behind", () => {
+        expect(isOutdated("0.16.14", "1.0.0")).toBe(true);
+    });
+
+    it("returns false when current is ahead", () => {
+        expect(isOutdated("0.17.0", "0.16.14")).toBe(false);
+    });
+
+    it("handles mixed v prefixes", () => {
+        expect(isOutdated("v0.16.14", "0.16.15")).toBe(true);
+    });
+});
+
+describe("readCachedVersion", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = resolve(tmpdir(), `version-check-test-${Date.now()}`);
+        mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null for missing file", () => {
+        expect(readCachedVersion(resolve(tmpDir, "nope.json"))).toBeNull();
+    });
+
+    it("returns null for corrupted JSON", () => {
+        const p = resolve(tmpDir, "bad.json");
+        writeFileSync(p, "not json");
+        expect(readCachedVersion(p)).toBeNull();
+    });
+
+    it("returns null for JSON without latest_version", () => {
+        const p = resolve(tmpDir, "empty.json");
+        writeFileSync(p, JSON.stringify({ foo: "bar" }));
+        expect(readCachedVersion(p)).toBeNull();
+    });
+
+    it("reads a valid cache file", () => {
+        const p = resolve(tmpDir, "good.json");
+        writeFileSync(p, JSON.stringify({ latest_version: "v0.17.0", last_checked: "2026-05-04" }));
+        const result = readCachedVersion(p);
+        expect(result).not.toBeNull();
+        expect(result!.latest_version).toBe("v0.17.0");
+    });
+});
+
+describe("writeCachedVersion", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = resolve(tmpdir(), `version-check-write-${Date.now()}`);
+        mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("writes a cache file that can be read back", () => {
+        const p = resolve(tmpDir, "cache.json");
+        writeCachedVersion(p, "v0.17.0");
+        const result = readCachedVersion(p);
+        expect(result).not.toBeNull();
+        expect(result!.latest_version).toBe("v0.17.0");
+        expect(result!.last_checked).toBeTruthy();
+    });
+
+    it("creates parent directories", () => {
+        const p = resolve(tmpDir, "nested", "deep", "cache.json");
+        writeCachedVersion(p, "v1.0.0");
+        const result = readCachedVersion(p);
+        expect(result).not.toBeNull();
+        expect(result!.latest_version).toBe("v1.0.0");
+    });
+});
+
+describe("getCachePath", () => {
+    it("returns empty string when HOME is not set", () => {
+        expect(getCachePath({ HOME: undefined } as NodeJS.ProcessEnv)).toBe("");
+    });
+
+    it("returns path under ~/.polkadot/", () => {
+        const result = getCachePath({ HOME: "/Users/test" } as NodeJS.ProcessEnv);
+        expect(result).toBe("/Users/test/.polkadot/playground-cli.json");
+    });
+});

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -1,0 +1,127 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { fetchLatestTag } from "../commands/update.js";
+
+interface VersionCache {
+    latest_version: string;
+    last_checked: string;
+}
+
+/**
+ * Returns the path to the version cache file.
+ * Lives alongside other playground state in ~/.polkadot/
+ */
+export function getCachePath(env: NodeJS.ProcessEnv = process.env): string {
+    const home = env.HOME;
+    if (!home) return "";
+    return resolve(home, ".polkadot", "playground-cli.json");
+}
+
+/**
+ * Reads the cached latest version from disk.
+ * Returns null if the file doesn't exist or is corrupted.
+ */
+export function readCachedVersion(cachePath: string): VersionCache | null {
+    try {
+        const raw = readFileSync(cachePath, "utf-8");
+        const parsed = JSON.parse(raw) as Partial<VersionCache>;
+        if (typeof parsed.latest_version === "string" && parsed.latest_version) {
+            return {
+                latest_version: parsed.latest_version,
+                last_checked: parsed.last_checked ?? "",
+            };
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Writes the latest version to the cache file.
+ */
+export function writeCachedVersion(cachePath: string, version: string): void {
+    try {
+        const dir = resolve(cachePath, "..");
+        mkdirSync(dir, { recursive: true });
+        const data: VersionCache = {
+            latest_version: version,
+            last_checked: new Date().toISOString(),
+        };
+        writeFileSync(cachePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch {
+        // Silent fail — cache is best-effort
+    }
+}
+
+/**
+ * Normalizes a version tag to a comparable string.
+ * "v0.16.14" → "0.16.14", "0.16.14" → "0.16.14"
+ */
+export function normalizeVersion(v: string): string {
+    return v.replace(/^v/, "");
+}
+
+/**
+ * Returns true if the current version is behind the latest.
+ */
+export function isOutdated(current: string, latest: string): boolean {
+    const c = normalizeVersion(current);
+    const l = normalizeVersion(latest);
+    if (c === l) return false;
+
+    const cp = c.split(".").map(Number);
+    const lp = l.split(".").map(Number);
+
+    for (let i = 0; i < Math.max(cp.length, lp.length); i++) {
+        const cv = cp[i] ?? 0;
+        const lv = lp[i] ?? 0;
+        if (cv < lv) return true;
+        if (cv > lv) return false;
+    }
+    return false;
+}
+
+/**
+ * Prints an update warning if the CLI is behind the cached latest version.
+ * Kicks off a background fetch to refresh the cache for next run.
+ * Returns immediately — never blocks the command.
+ */
+export function checkForUpdates(currentVersion: string): void {
+    const cachePath = getCachePath();
+    if (!cachePath) return;
+
+    // 1. Check cached version (sync, fast — local file read)
+    const cached = readCachedVersion(cachePath);
+    if (cached && isOutdated(currentVersion, cached.latest_version)) {
+        const latest = cached.latest_version.startsWith("v")
+            ? cached.latest_version
+            : `v${cached.latest_version}`;
+        process.stderr.write(
+            `\n  ⚠  Update available: v${normalizeVersion(currentVersion)} → ${latest}\n` +
+                `     Run \x1b[1mdot update\x1b[0m to upgrade.\n\n`,
+        );
+    }
+
+    // 2. Refresh cache in the background (async, non-blocking)
+    _pendingRefresh = fetchLatestTag()
+        .then((tag) => writeCachedVersion(cachePath, tag))
+        .catch(() => {
+            // Silent fail — no network is fine, we'll try next time
+        });
+}
+
+/** In-flight background refresh, if any. */
+let _pendingRefresh: Promise<void> | null = null;
+
+/**
+ * Waits briefly for the background version-cache refresh to land.
+ * Called once in the shutdown path so quick commands (--help, --version)
+ * still get a chance to persist the latest tag. A 2 s cap ensures we
+ * never visibly delay exit.
+ */
+export async function flushVersionCheck(timeoutMs = 2000): Promise<void> {
+    if (!_pendingRefresh) return;
+    await Promise.race([_pendingRefresh, new Promise((r) => setTimeout(r, timeoutMs))]);
+    _pendingRefresh = null;
+}


### PR DESCRIPTION
Closes #59

Adds a version check that runs before every command:

- Reads a cached latest version from `~/.polkadot/playground-cli.json` (instant, no network delay)
- Shows a warning if the installed version is behind
- Refreshes the cache in the background via GitHub API for the next run
- Includes 17 unit tests

Tested manually — warning appears when outdated, disappears when current.