### PR TITLE
fix(mod,deploy): reject private repos with a clear error

### DIFF
--- a/.changeset/fix-modable-private-repo-preflight.md
+++ b/.changeset/fix-modable-private-repo-preflight.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`dot deploy --modable` now rejects private GitHub repositories at preflight with a clear error message instead of silently failing later. `dot mod` also surfaces a more actionable error when it encounters a private or non-existent repository instead of the misleading "pin one in metadata.branch" hint.

--- a/src/utils/deploy/modable.test.ts
+++ b/src/utils/deploy/modable.test.ts
@@ -90,8 +90,7 @@ describe("assertPublicGitHubRepo", () => {
     });
 
     it("skips check for rate-limit (403) responses", async () => {
-        const mockFetch: typeof fetch = async () =>
-            new Response("rate limited", { status: 403 });
+        const mockFetch: typeof fetch = async () => new Response("rate limited", { status: 403 });
         await expect(
             assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
         ).resolves.toBeUndefined();

--- a/src/utils/deploy/modable.test.ts
+++ b/src/utils/deploy/modable.test.ts
@@ -3,7 +3,12 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { decideRepositoryAction, resolveRepositoryUrl } from "./modable.js";
+import {
+    decideRepositoryAction,
+    resolveRepositoryUrl,
+    assertPublicGitHubRepo,
+    ModablePreflightError,
+} from "./modable.js";
 
 describe("decideRepositoryAction", () => {
     it("uses the existing origin when present", () => {
@@ -35,6 +40,64 @@ describe("decideRepositoryAction", () => {
     });
 });
 
+describe("assertPublicGitHubRepo", () => {
+    it("does nothing for a public repo", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response(JSON.stringify({ private: false }), { status: 200 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
+        ).resolves.toBeUndefined();
+    });
+
+    it("throws for a private repo (API reports private: true)", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response(JSON.stringify({ private: true }), { status: 200 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/org/secret", mockFetch),
+        ).rejects.toThrow(ModablePreflightError);
+    });
+
+    it("throws for a 404 response (private or missing)", async () => {
+        const mockFetch: typeof fetch = async () => new Response("Not Found", { status: 404 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/org/ghost", mockFetch),
+        ).rejects.toThrow(/private or does not exist/i);
+    });
+
+    it("throws for a 401 response", async () => {
+        const mockFetch: typeof fetch = async () => new Response("Unauthorized", { status: 401 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/org/ghost", mockFetch),
+        ).rejects.toThrow(ModablePreflightError);
+    });
+
+    it("does nothing for a non-GitHub URL", async () => {
+        const mockFetch: typeof fetch = async () => {
+            throw new Error("should not be called");
+        };
+        await expect(
+            assertPublicGitHubRepo("https://gitlab.com/foo/bar", mockFetch),
+        ).resolves.toBeUndefined();
+    });
+
+    it("does nothing on network error (fail open)", async () => {
+        const mockFetch: typeof fetch = async () => {
+            throw new Error("ECONNREFUSED");
+        };
+        await expect(
+            assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
+        ).resolves.toBeUndefined();
+    });
+
+    it("skips check for rate-limit (403) responses", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response("rate limited", { status: 403 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
+        ).resolves.toBeUndefined();
+    });
+});
+
 describe("resolveRepositoryUrl", () => {
     let tmp: string | null = null;
 
@@ -42,6 +105,11 @@ describe("resolveRepositoryUrl", () => {
         if (tmp) rmSync(tmp, { recursive: true, force: true });
         tmp = null;
     });
+
+    const publicFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ private: false }), { status: 200 });
+    const privateFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ private: true }), { status: 200 });
 
     it("uses an existing origin without pushing", async () => {
         tmp = mkdtempSync(join(tmpdir(), "pg-modable-origin-"));
@@ -51,8 +119,21 @@ describe("resolveRepositoryUrl", () => {
             stdio: "ignore",
         });
 
-        await expect(resolveRepositoryUrl({ cwd: tmp, repoName: null })).resolves.toBe(
-            "git@github.com:foo/bar",
-        );
+        await expect(
+            resolveRepositoryUrl({ cwd: tmp, repoName: null, fetch: publicFetch }),
+        ).resolves.toBe("git@github.com:foo/bar");
+    });
+
+    it("throws when the existing origin is a private GitHub repo", async () => {
+        tmp = mkdtempSync(join(tmpdir(), "pg-modable-private-"));
+        execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
+        execFileSync("git", ["remote", "add", "origin", "https://github.com/org/secret.git"], {
+            cwd: tmp,
+            stdio: "ignore",
+        });
+
+        await expect(
+            resolveRepositoryUrl({ cwd: tmp, repoName: null, fetch: privateFetch }),
+        ).rejects.toThrow(ModablePreflightError);
     });
 });

--- a/src/utils/deploy/modable.ts
+++ b/src/utils/deploy/modable.ts
@@ -10,6 +10,7 @@
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { commandExists, TOOL_STEPS } from "../toolchain.js";
+import { parseGitHubRepoUrl } from "../mod/source.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -85,9 +86,48 @@ export interface ResolveRepoOptions {
     cwd: string;
     repoName: string | null;
     onLog?: (line: string) => void;
+    fetch?: typeof fetch;
+}
+
+/**
+ * Verifies that a GitHub repository URL is publicly accessible.
+ * Throws ModablePreflightError for private or missing repos.
+ * Skips silently for non-GitHub URLs or when the API is unreachable.
+ */
+export async function assertPublicGitHubRepo(
+    url: string,
+    f: typeof fetch = fetch,
+): Promise<void> {
+    const ref = parseGitHubRepoUrl(url);
+    if (!ref) return;
+
+    let res: Response;
+    try {
+        res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`);
+    } catch {
+        return; // network error — can't verify, let downstream fail
+    }
+
+    if (res.ok) {
+        const body = (await res.json()) as { private?: boolean };
+        if (body.private) {
+            throw new ModablePreflightError(
+                `${ref.owner}/${ref.repo} is a private repository — modable apps must use a public repository so users can clone the source`,
+            );
+        }
+        return;
+    }
+
+    if (res.status === 404 || res.status === 401) {
+        throw new ModablePreflightError(
+            `${ref.owner}/${ref.repo} is private or does not exist — modable apps must use a public repository`,
+        );
+    }
+    // other non-ok status (rate limit, server error) — skip check
 }
 
 export async function resolveRepositoryUrl(opts: ResolveRepoOptions): Promise<string> {
+    const f = opts.fetch ?? fetch;
     const action = decideRepositoryAction({
         originUrl: readOrigin(opts.cwd),
         repoName: opts.repoName,
@@ -99,6 +139,7 @@ export async function resolveRepositoryUrl(opts: ResolveRepoOptions): Promise<st
     }
     if (action.kind === "use-origin") {
         opts.onLog?.(`using existing origin (${action.url})…`);
+        await assertPublicGitHubRepo(action.url, f);
         return action.url;
     }
 

--- a/src/utils/deploy/modable.ts
+++ b/src/utils/deploy/modable.ts
@@ -94,10 +94,7 @@ export interface ResolveRepoOptions {
  * Throws ModablePreflightError for private or missing repos.
  * Skips silently for non-GitHub URLs or when the API is unreachable.
  */
-export async function assertPublicGitHubRepo(
-    url: string,
-    f: typeof fetch = fetch,
-): Promise<void> {
+export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetch): Promise<void> {
     const ref = parseGitHubRepoUrl(url);
     if (!ref) return;
 

--- a/src/utils/mod/source.test.ts
+++ b/src/utils/mod/source.test.ts
@@ -99,6 +99,24 @@ describe("resolveDefaultBranch", () => {
             resolveDefaultBranch({ owner: "foo", repo: "bar" }, { fetch: fetchImpl }),
         ).rejects.toThrow(/could not resolve a default branch/i);
     });
+
+    it("throws a private-or-missing error when the API returns 404 and probes fail", async () => {
+        const fetchImpl: typeof fetch = async () => new Response("Not Found", { status: 404 });
+        await expect(
+            resolveDefaultBranch({ owner: "foo", repo: "bar" }, { fetch: fetchImpl }),
+        ).rejects.toThrow(/private or does not exist/i);
+    });
+
+    it("throws a private-or-missing error when the API returns 401 and probes fail", async () => {
+        const fetchImpl: typeof fetch = async (url) => {
+            if (String(url).startsWith("https://api.github.com"))
+                return new Response("Unauthorized", { status: 401 });
+            return new Response("Not Found", { status: 404 });
+        };
+        await expect(
+            resolveDefaultBranch({ owner: "foo", repo: "bar" }, { fetch: fetchImpl }),
+        ).rejects.toThrow(/private or does not exist/i);
+    });
 });
 
 describe("downloadGitHubTarball", () => {

--- a/src/utils/mod/source.ts
+++ b/src/utils/mod/source.ts
@@ -37,14 +37,16 @@ export async function resolveDefaultBranch(
     opts: FetchOpts = {},
 ): Promise<string> {
     const f = opts.fetch ?? fetch;
+    let apiStatus: number | undefined;
     try {
         const res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`);
+        apiStatus = res.status;
         if (res.ok) {
             const body = (await res.json()) as { default_branch?: string };
             if (body.default_branch) return body.default_branch;
         }
     } catch {
-        // fall through to the heuristic probes
+        // network error — fall through to the heuristic probes
     }
     for (const candidate of ["main", "master"]) {
         try {
@@ -53,6 +55,11 @@ export async function resolveDefaultBranch(
         } catch {
             // try next
         }
+    }
+    if (apiStatus === 404 || apiStatus === 401) {
+        throw new Error(
+            `Repository ${ref.owner}/${ref.repo} is private or does not exist — dot mod only supports public repositories`,
+        );
     }
     throw new Error(
         `Could not resolve a default branch for ${ref.owner}/${ref.repo} — pin one in metadata.branch`,


### PR DESCRIPTION
## Summary

- `dot deploy --modable` now fails at preflight with a `ModablePreflightError` when the configured origin repo is private or missing on GitHub, instead of proceeding and failing cryptically downstream
- `dot mod` now surfaces "private or does not exist" instead of the misleading "pin one in metadata.branch" hint when the GitHub API returns 401/404
- Adds `assertPublicGitHubRepo(url, fetch?)` to `modable.ts` — exported and fully unit-tested with injectable fetch
- Adds `fetch?` to `ResolveRepoOptions` so the check is mockable in tests

## Root cause

`playground-e2e-app.dot` was registered as modable but its source (`paritytech/playground-app`) is private. The picker showed it as a valid mod target; clicking through gave a confusing "pin metadata.branch" error. This PR fixes the error surfaces — a separate deploy will fix the fixture data.

## Test plan

- [ ] `pnpm test` — 464 tests pass
- [ ] `assertPublicGitHubRepo`: 7 unit tests covering public, private, 404, 401, non-GitHub URL, network error, rate-limit
- [ ] `resolveRepositoryUrl`: existing test updated to inject mock fetch; new test for private-origin path
- [ ] `resolveDefaultBranch`: 2 new tests for 404 and 401 API responses