### PR TITLE
ci: use parity-default runners in paritytech org

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -22,7 +22,7 @@ runs:
         - name: Install Kubo (IPFS)
           shell: bash
           run: |
-              wget -q https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz
+              curl -fsSL -o kubo_v0.32.1_linux-amd64.tar.gz https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz
               tar xf kubo_v0.32.1_linux-amd64.tar.gz
               sudo mv kubo/ipfs /usr/local/bin/
               ipfs init --profile=test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     format:
         name: Format
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4
@@ -21,7 +21,7 @@ jobs:
 
     unit-tests:
         name: Unit Tests
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     release:
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -32,6 +32,9 @@ jobs:
                   bun build --compile --target=bun-darwin-x64 src/index.ts --outfile dot-darwin-x64
                   bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dot-darwin-arm64
 
+            - name: Ensure gh CLI
+              run: type gh >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y gh)
+
             - name: Delete previous dev release
               run: gh release delete "dev/${{ github.head_ref }}" --cleanup-tag -y 2>/dev/null || true
               env:

--- a/.github/workflows/e2e-cleanup.yml
+++ b/.github/workflows/e2e-cleanup.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
     sweep:
         name: Sweep rotating E2E state
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/e2e-post-release.yml
+++ b/.github/workflows/e2e-post-release.yml
@@ -16,7 +16,7 @@ jobs:
     smoke:
         name: "E2E · post-release-smoke"
         if: github.event.release.prerelease != true || github.event_name == 'workflow_dispatch'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 15
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-post-release.yml
+++ b/.github/workflows/e2e-post-release.yml
@@ -42,6 +42,9 @@ jobs:
                   fi
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+            - name: Ensure gh CLI
+              run: type gh >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y gh)
+
             - name: Wait for SEA asset on the release
               shell: /usr/bin/bash -euo pipefail {0}
               run: |

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
     smoke:
         name: "E2E · release-smoke"
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 15
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -41,6 +41,9 @@ jobs:
                   fi
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+            - name: Ensure gh CLI
+              run: type gh >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y gh)
+
             - name: Wait for SEA asset to be uploaded
               shell: /usr/bin/bash -euo pipefail {0}
               run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
     test-no-publish:
         name: "E2E · ${{ matrix.cell }}"
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 25
         strategy:
             fail-fast: false
@@ -81,7 +81,7 @@ jobs:
 
     test-publish:
         name: "E2E · ${{ matrix.cell }}"
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 55
         strategy:
             fail-fast: false
@@ -136,7 +136,7 @@ jobs:
     test-nightly-publish:
         name: "E2E · ${{ matrix.cell }}"
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 55
         strategy:
             fail-fast: false
@@ -190,7 +190,7 @@ jobs:
     test-nightly-no-publish:
         name: "E2E · ${{ matrix.cell }}"
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 25
         strategy:
             fail-fast: false
@@ -251,7 +251,7 @@ jobs:
         name: E2E Report
         needs: [test-no-publish, test-publish, test-nightly-no-publish, test-nightly-publish]
         if: always()
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         timeout-minutes: 5
         steps:
             - name: Download JUnit + forensic artefacts

--- a/.github/workflows/funder-balance-check.yml
+++ b/.github/workflows/funder-balance-check.yml
@@ -42,6 +42,9 @@ jobs:
                   bun run scripts/check-funder-balance.ts | tee balance.txt
                   echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
+            - name: Ensure gh CLI
+              run: type gh >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y gh)
+
             - name: File or update issue when low
               if: steps.check.outputs.exitcode != '0'
               env:

--- a/.github/workflows/funder-balance-check.yml
+++ b/.github/workflows/funder-balance-check.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
     check:
         name: Check dedicated funder balance
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
     release:
         if: github.actor != 'github-actions[bot]'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
Closes #88

## Summary

- All 13 `runs-on: ubuntu-latest` entries across 8 workflow files replaced with the conditional expression `${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}`
- Forks and external contributors continue to use `ubuntu-latest` automatically
- Pattern matches what bulletin-deploy adopted

## Test plan

- [ ] CI passes on this PR (uses `parity-default` runner)
- [ ] Verify a fork of this repo triggers with `ubuntu-latest` (expression falls back correctly)