### PR TITLE
feat: harden cli against github api rate limits

### DIFF
--- a/.changeset/version-check-and-gh-token.md
+++ b/.changeset/version-check-and-gh-token.md
@@ -1,0 +1,11 @@
+---
+"playground-cli": minor
+---
+
+Every `dot` invocation now shows a one-line "Update available" banner at the bottom when a newer release exists. The check resolves the latest version through jsDelivr's free public CDN (not GitHub's rate-limited API) with a 1 s timeout, so a flaky network never delays the command. Suppressed in CI / piped output, when running `dot update` itself, and when `DOT_NO_UPDATE_CHECK=1`.
+
+`dot mod` and `dot deploy --modable` now opportunistically pass an `Authorization: Bearer <token>` header read from `gh auth token` when available — logged-in users get GitHub's per-user 5000/hour quota instead of contributing to the shared 60/hour anonymous-IP quota that gets exhausted quickly on hackathon WiFi. Anonymous users continue to work as before.
+
+`dot deploy --modable` now fails with an explicit "GitHub rate limit exceeded — run `gh auth login`" error when the public-repo preflight is denied by the rate limiter, instead of silently passing the check and risking a private repo being published as modable. Ambiguous 403s and transient 5xx responses still skip the check (unchanged).
+
+`dot init` ends with an explicit advisory banner (visually consistent with the new "Update available" banner) explaining the IP-based GitHub rate limit and recommending `gh auth login`, but only when the user is not currently authed. The single-row dependency-list warning was too terse to convey why this matters on hackathon / shared-network setups.

--- a/src/commands/init/gh-auth-banner.test.ts
+++ b/src/commands/init/gh-auth-banner.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { formatGhAuthBanner } from "./gh-auth-banner.js";
+
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("formatGhAuthBanner", () => {
+    it("explains the IP-based rate limit and the gh auth fix", () => {
+        const plain = stripAnsi(formatGhAuthBanner());
+        expect(plain).toMatch(/60\/hour/);
+        expect(plain).toMatch(/5000\/hour/);
+        expect(plain).toMatch(/gh auth login/);
+        expect(plain).toMatch(/public wifis/);
+        expect(plain).toMatch(/GitHub authentication recommended/);
+    });
+
+    it("starts and ends with blank lines so it visually separates from prior output", () => {
+        const out = formatGhAuthBanner();
+        expect(out.startsWith("\n")).toBe(true);
+        expect(out.endsWith("\n\n")).toBe(true);
+    });
+
+    it("renders a rounded box with aligned borders", () => {
+        const plain = stripAnsi(formatGhAuthBanner());
+        const lines = plain.split("\n");
+        const boxLines = lines.filter((l) => l.includes("│") || l.includes("╭") || l.includes("╰"));
+
+        // Top border, body rows, bottom border — all the same visible width.
+        const widths = new Set(boxLines.map((l) => l.length));
+        expect(widths.size).toBe(1);
+
+        // Top + bottom rounded corners present exactly once each.
+        expect(plain.match(/╭/g)?.length).toBe(1);
+        expect(plain.match(/╮/g)?.length).toBe(1);
+        expect(plain.match(/╰/g)?.length).toBe(1);
+        expect(plain.match(/╯/g)?.length).toBe(1);
+    });
+});

--- a/src/commands/init/gh-auth-banner.ts
+++ b/src/commands/init/gh-auth-banner.ts
@@ -1,0 +1,64 @@
+/**
+ * End-of-init advisory shown when the user is not `gh auth login`'d.
+ *
+ * Visually mirrors the in-Ink `Callout` (see `src/utils/ui/theme/Callout.tsx`)
+ * used by the "check your phone" deploy prompt — rounded yellow box with a
+ * bold colored title — so the two warnings read as one design language. We
+ * render in raw ANSI rather than mounting Ink, because this banner fires
+ * after the init TUI has unmounted.
+ *
+ * The dependency list inside the TUI already shows a single-row warning
+ * "authenticated  run: gh auth login", but that's too terse to convey *why*
+ * it matters for hackathon / shared-network setups. This banner spells that
+ * out at the very bottom of the init output.
+ */
+
+import { LAYOUT } from "../../utils/ui/theme/tokens.js";
+
+const BOX_WIDTH = LAYOUT.ruleWidthMax; // 72 — matches the rest of the CLI's max width
+const INNER_WIDTH = BOX_WIDTH - 4; // 2 borders + 2 padding spaces
+
+const ANSI_YELLOW = "\x1b[33m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_RESET = "\x1b[0m";
+
+const TL = "╭";
+const TR = "╮";
+const BL = "╰";
+const BR = "╯";
+const HORIZONTAL = "─";
+const VERTICAL = "│";
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function visibleLength(s: string): number {
+    return s.replace(ANSI_RE, "").length;
+}
+
+function row(content: string): string {
+    const pad = Math.max(0, INNER_WIDTH - visibleLength(content));
+    return `  ${ANSI_YELLOW}${VERTICAL}${ANSI_RESET} ${content}${" ".repeat(pad)} ${ANSI_YELLOW}${VERTICAL}${ANSI_RESET}\n`;
+}
+
+function border(left: string, right: string): string {
+    const fill = HORIZONTAL.repeat(BOX_WIDTH - 2);
+    return `  ${ANSI_YELLOW}${left}${fill}${right}${ANSI_RESET}\n`;
+}
+
+export function formatGhAuthBanner(): string {
+    const title = `${ANSI_YELLOW}${ANSI_BOLD}GitHub authentication recommended${ANSI_RESET}`;
+    const ghLogin = `${ANSI_BOLD}gh auth login${ANSI_RESET}`;
+
+    return (
+        "\n" +
+        border(TL, TR) +
+        row(title) +
+        row("") +
+        row(`Without ${ghLogin}, GitHub rate-limits all requests from your`) +
+        row("public IP to 60/hour, shared with everyone on the same network.") +
+        row(`This will exhaust quickly on public wifis. Run ${ghLogin} once`) +
+        row("to use your personal 5000/hour quota instead.") +
+        border(BL, BR) +
+        "\n"
+    );
+}

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -5,6 +5,8 @@ import { captureWarning, withSpan, errorMessage } from "../../telemetry.js";
 import { runCliCommand } from "../../cli-runtime.js";
 import { InitScreen } from "./InitScreen.js";
 import { connect, type LoginHandle } from "../../utils/auth.js";
+import { getGhToken } from "../../utils/gh-token.js";
+import { formatGhAuthBanner } from "./gh-auth-banner.js";
 
 export const initCommand = new Command("init")
     .description("Install prerequisites and login via mobile QR")
@@ -49,5 +51,13 @@ export const initCommand = new Command("init")
             await withSpan("cli.init.setup", "run init setup", () => app.waitUntilExit());
 
             console.log();
+
+            // The dependency list above already flags `gh auth login` as a
+            // single-row warning, but that doesn't convey why it matters for
+            // hackathons / shared WiFi. Print an explicit explanation at the
+            // very bottom for users who are still logged out, so the
+            // recommendation has the context it needs to land.
+            const token = await getGhToken();
+            if (!token) process.stderr.write(formatGhAuthBanner());
         }),
     );

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -16,6 +16,7 @@ import { resolve } from "node:path";
 import pkg from "../../package.json" with { type: "json" };
 import { withSpan, errorMessage } from "../telemetry.js";
 import { runCliCommand } from "../cli-runtime.js";
+import { ghAuthHeaders } from "../utils/gh-token.js";
 
 const REPO = "paritytech/playground-cli";
 
@@ -39,8 +40,11 @@ export function detectAsset(os: Os = platform() as Os, cpu: Cpu = arch() as Cpu)
 }
 
 export async function fetchLatestTag(fetchImpl: typeof fetch = fetch): Promise<string> {
+    // Opportunistic gh-auth header: `dot update` is the most ironic command
+    // to be denied by GitHub's anonymous rate limiter, so route the request
+    // through the user's 5000/hr quota when they're `gh auth login`'d.
     const res = await fetchImpl(`https://api.github.com/repos/${REPO}/releases/latest`, {
-        headers: { Accept: "application/vnd.github.v3+json" },
+        headers: { Accept: "application/vnd.github.v3+json", ...(await ghAuthHeaders()) },
     });
     if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
     const data = (await res.json()) as { tag_name?: string };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
     setProcessGuardWarningHandler,
 } from "./utils/process-guard.js";
 import { clearWindowTitle } from "./utils/ui/theme/window-title.js";
+import { startVersionCheck } from "./utils/version-check.js";
 
 const DEPLOY_DESCRIPTION =
     "Build the project, upload to Bulletin, register a .dot domain, and optionally publish to Playground";
@@ -114,6 +115,12 @@ program.addCommand(await createDeployCommand());
 program.addCommand(logoutCommand);
 program.addCommand(updateCommand);
 
+// Kick off the "is there a newer dot release?" check immediately so the
+// jsDelivr fetch races the command rather than tacking onto its tail. The
+// banner (if any) is printed in the `finally` once the user-visible work
+// has finished — see `src/utils/version-check.ts` for the rationale.
+const versionCheck = startVersionCheck(pkg.version);
+
 try {
     await program.parseAsync();
 } catch (err) {
@@ -123,6 +130,8 @@ try {
     process.exitCode = 1;
 } finally {
     await flushTelemetry();
+    const banner = await versionCheck.render();
+    if (banner) process.stderr.write(banner);
 }
 
 process.exit(typeof process.exitCode === "number" ? process.exitCode : 0);

--- a/src/utils/deploy/modable.test.ts
+++ b/src/utils/deploy/modable.test.ts
@@ -89,8 +89,26 @@ describe("assertPublicGitHubRepo", () => {
         ).resolves.toBeUndefined();
     });
 
-    it("skips check for rate-limit (403) responses", async () => {
-        const mockFetch: typeof fetch = async () => new Response("rate limited", { status: 403 });
+    it("throws an actionable error on an explicit rate-limit (403 with x-ratelimit-remaining: 0)", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response("rate limited", {
+                status: 403,
+                headers: { "x-ratelimit-remaining": "0" },
+            });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
+        ).rejects.toThrow(/rate limit exceeded.*gh auth login/is);
+    });
+
+    it("does not throw on ambiguous 403 (e.g. abuse detection without rate-limit headers)", async () => {
+        const mockFetch: typeof fetch = async () => new Response("forbidden", { status: 403 });
+        await expect(
+            assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
+        ).resolves.toBeUndefined();
+    });
+
+    it("does not throw on 5xx (transient server error)", async () => {
+        const mockFetch: typeof fetch = async () => new Response("oops", { status: 502 });
         await expect(
             assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch),
         ).resolves.toBeUndefined();

--- a/src/utils/deploy/modable.ts
+++ b/src/utils/deploy/modable.ts
@@ -11,6 +11,7 @@ import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { commandExists, TOOL_STEPS } from "../toolchain.js";
 import { parseGitHubRepoUrl } from "../mod/source.js";
+import { ghAuthHeaders } from "../gh-token.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -91,8 +92,16 @@ export interface ResolveRepoOptions {
 
 /**
  * Verifies that a GitHub repository URL is publicly accessible.
- * Throws ModablePreflightError for private or missing repos.
- * Skips silently for non-GitHub URLs or when the API is unreachable.
+ *
+ * Adds an `Authorization: Bearer <token>` header opportunistically when the
+ * user is `gh auth login`'d so the request lands against their personal
+ * 5000/hour quota instead of the shared 60/hour anonymous-IP quota — the
+ * only reliable defence against blanket rate-limiting on hackathon WiFi
+ * (see `src/utils/gh-token.ts`).
+ *
+ * Throws ModablePreflightError for private/missing repos and for explicit
+ * rate-limit responses (so we never silently pass off a private repo as
+ * public). Stays lenient for ambiguous 5xx errors.
  */
 export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetch): Promise<void> {
     const ref = parseGitHubRepoUrl(url);
@@ -100,7 +109,9 @@ export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetc
 
     let res: Response;
     try {
-        res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`);
+        res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`, {
+            headers: { Accept: "application/vnd.github+json", ...(await ghAuthHeaders()) },
+        });
     } catch {
         return; // network error — can't verify, let downstream fail
     }
@@ -120,7 +131,13 @@ export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetc
             `${ref.owner}/${ref.repo} is private or does not exist — modable apps must use a public repository`,
         );
     }
-    // other non-ok status (rate limit, server error) — skip check
+    if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+        throw new ModablePreflightError(
+            "GitHub rate limit exceeded for unauthenticated requests — could not verify that the repository is public. " +
+                'Run "gh auth login" to use your personal 5000/hour quota, then retry.',
+        );
+    }
+    // other non-ok status (5xx, transient server error) — skip check
 }
 
 export async function resolveRepositoryUrl(opts: ResolveRepoOptions): Promise<string> {

--- a/src/utils/gh-token.test.ts
+++ b/src/utils/gh-token.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getGhToken, ghAuthHeaders, resetGhTokenCacheForTests } from "./gh-token.js";
+
+describe("getGhToken / ghAuthHeaders", () => {
+    beforeEach(() => {
+        resetGhTokenCacheForTests();
+    });
+
+    it("returns either a non-empty string or null without throwing", async () => {
+        const token = await getGhToken();
+        if (token !== null) {
+            expect(typeof token).toBe("string");
+            expect(token.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("caches the result across calls", async () => {
+        const a = await getGhToken();
+        const b = await getGhToken();
+        expect(a).toBe(b);
+    });
+
+    it("returns an Authorization header when a token is available, else an empty object", async () => {
+        const token = await getGhToken();
+        const headers = await ghAuthHeaders();
+        if (token) {
+            expect(headers).toEqual({ Authorization: `Bearer ${token}` });
+        } else {
+            expect(headers).toEqual({});
+        }
+    });
+});

--- a/src/utils/gh-token.ts
+++ b/src/utils/gh-token.ts
@@ -1,0 +1,54 @@
+/**
+ * Opportunistic GitHub auth token reader.
+ *
+ * If the user happens to have `gh` installed and `gh auth login`'d, we route
+ * unauthenticated GitHub API calls through their personal 5000/hour quota
+ * instead of the shared 60/hour anonymous IP quota — a meaningful protection
+ * against rate-limit exhaustion on shared networks (hackathons, conferences,
+ * corporate NATs).
+ *
+ * Returns `null` when:
+ *   - `gh` is not installed,
+ *   - `gh auth status` reports the user as logged out,
+ *   - any execution error occurs (PATH issues, permission errors, …).
+ *
+ * Cached for the process lifetime: shelling out to `gh` per-request would
+ * dominate the latency of the API call we're trying to authenticate.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+let cached: Promise<string | null> | null = null;
+
+async function probeGhToken(): Promise<string | null> {
+    try {
+        const { stdout } = await execFileAsync("gh", ["auth", "token"]);
+        const token = stdout.trim();
+        return token || null;
+    } catch {
+        return null;
+    }
+}
+
+export function getGhToken(): Promise<string | null> {
+    if (!cached) cached = probeGhToken();
+    return cached;
+}
+
+/**
+ * Returns request headers with `Authorization: Bearer <token>` when a `gh`
+ * token is available, otherwise an empty object. Safe to spread into any
+ * `fetch(url, { headers: { ... } })` call.
+ */
+export async function ghAuthHeaders(): Promise<Record<string, string>> {
+    const token = await getGhToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Test-only — clears the cached token probe so suites can simulate fresh runs. */
+export function resetGhTokenCacheForTests(): void {
+    cached = null;
+}

--- a/src/utils/mod/source.ts
+++ b/src/utils/mod/source.ts
@@ -11,6 +11,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
 import { extract } from "tar";
+import { ghAuthHeaders } from "../gh-token.js";
 
 export interface GitHubRepoRef {
     owner: string;
@@ -39,7 +40,11 @@ export async function resolveDefaultBranch(
     const f = opts.fetch ?? fetch;
     let apiStatus: number | undefined;
     try {
-        const res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`);
+        // Opportunistic gh-auth header lifts this call out of the shared
+        // 60/hour anonymous-IP bucket — see `src/utils/gh-token.ts`.
+        const res = await f(`https://api.github.com/repos/${ref.owner}/${ref.repo}`, {
+            headers: { Accept: "application/vnd.github+json", ...(await ghAuthHeaders()) },
+        });
         apiStatus = res.status;
         if (res.ok) {
             const body = (await res.json()) as { default_branch?: string };

--- a/src/utils/version-check.test.ts
+++ b/src/utils/version-check.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import {
+    formatBanner,
+    isOutdated,
+    normalizeVersion,
+    shouldSkip,
+    startVersionCheck,
+} from "./version-check.js";
+
+describe("normalizeVersion", () => {
+    it("strips a leading v", () => {
+        expect(normalizeVersion("v0.16.14")).toBe("0.16.14");
+    });
+
+    it("leaves bare versions alone", () => {
+        expect(normalizeVersion("0.16.14")).toBe("0.16.14");
+    });
+});
+
+describe("isOutdated", () => {
+    it("is false when versions are equal", () => {
+        expect(isOutdated("0.16.14", "0.16.14")).toBe(false);
+        expect(isOutdated("v0.16.14", "v0.16.14")).toBe(false);
+    });
+
+    it("is true when patch is behind", () => {
+        expect(isOutdated("0.16.14", "0.16.15")).toBe(true);
+    });
+
+    it("is true when minor is behind", () => {
+        expect(isOutdated("0.16.14", "0.17.0")).toBe(true);
+    });
+
+    it("is true when major is behind", () => {
+        expect(isOutdated("0.16.14", "1.0.0")).toBe(true);
+    });
+
+    it("is false when current is ahead", () => {
+        expect(isOutdated("0.17.0", "0.16.14")).toBe(false);
+    });
+
+    it("handles mixed v prefixes", () => {
+        expect(isOutdated("v0.16.14", "0.16.15")).toBe(true);
+    });
+
+    it("returns false for unparseable versions instead of throwing", () => {
+        expect(isOutdated("dev/branch-name", "0.16.15")).toBe(false);
+        expect(isOutdated("0.16.14", "")).toBe(false);
+    });
+});
+
+describe("shouldSkip", () => {
+    const baseEnv = {} as NodeJS.ProcessEnv;
+
+    it("skips when stdout is not a TTY", () => {
+        expect(shouldSkip(["init"], baseEnv, false)).toBe(true);
+    });
+
+    it("skips when DOT_NO_UPDATE_CHECK=1", () => {
+        expect(shouldSkip(["init"], { DOT_NO_UPDATE_CHECK: "1" }, true)).toBe(true);
+    });
+
+    it("does NOT skip when DOT_NO_UPDATE_CHECK is set to anything other than 1", () => {
+        expect(shouldSkip(["init"], { DOT_NO_UPDATE_CHECK: "0" }, true)).toBe(false);
+    });
+
+    it("skips for `dot update` (which does its own check)", () => {
+        expect(shouldSkip(["update"], baseEnv, true)).toBe(true);
+    });
+
+    it("skips for `dot help` and `dot help <cmd>` (commander's implicit help)", () => {
+        expect(shouldSkip(["help"], baseEnv, true)).toBe(true);
+        expect(shouldSkip(["help", "deploy"], baseEnv, true)).toBe(true);
+    });
+
+    it("skips for bare `dot` (no args — commander prints usage)", () => {
+        expect(shouldSkip([], baseEnv, true)).toBe(true);
+    });
+
+    it("skips when CI=true / CI=1", () => {
+        expect(shouldSkip(["init"], { CI: "true" }, true)).toBe(true);
+        expect(shouldSkip(["init"], { CI: "1" }, true)).toBe(true);
+    });
+
+    it("skips for --version / -V", () => {
+        expect(shouldSkip(["--version"], baseEnv, true)).toBe(true);
+        expect(shouldSkip(["-V"], baseEnv, true)).toBe(true);
+    });
+
+    it("skips for --help / -h", () => {
+        expect(shouldSkip(["--help"], baseEnv, true)).toBe(true);
+        expect(shouldSkip(["init", "-h"], baseEnv, true)).toBe(true);
+    });
+
+    it("does not skip on a normal command", () => {
+        expect(shouldSkip(["init"], baseEnv, true)).toBe(false);
+        expect(shouldSkip(["deploy", "--modable"], baseEnv, true)).toBe(false);
+    });
+});
+
+describe("formatBanner", () => {
+    it("includes both versions with v-prefixes and the dot update hint", () => {
+        const out = formatBanner("0.16.14", "0.16.15");
+        expect(out).toContain("v0.16.14");
+        expect(out).toContain("v0.16.15");
+        expect(out).toContain("dot update");
+    });
+});
+
+describe("startVersionCheck", () => {
+    it("returns a null banner when skip conditions apply (does not call fetch)", async () => {
+        let called = false;
+        const mockFetch: typeof fetch = async () => {
+            called = true;
+            return new Response("{}", { status: 200 });
+        };
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["update"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        expect(await handle.render()).toBeNull();
+        expect(called).toBe(false);
+    });
+
+    it("returns null when the CLI is on the latest version", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response(JSON.stringify({ version: "0.16.14" }), { status: 200 });
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["init"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        expect(await handle.render()).toBeNull();
+    });
+
+    it("returns a banner when the CLI is behind", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response(JSON.stringify({ version: "0.17.0" }), { status: 200 });
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["init"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        const banner = await handle.render();
+        expect(banner).not.toBeNull();
+        expect(banner).toContain("v0.16.14");
+        expect(banner).toContain("v0.17.0");
+        expect(banner).toContain("dot update");
+    });
+
+    it("returns null when the network call fails", async () => {
+        const mockFetch: typeof fetch = async () => {
+            throw new Error("ECONNREFUSED");
+        };
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["init"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        expect(await handle.render()).toBeNull();
+    });
+
+    it("returns null on a non-OK HTTP response", async () => {
+        const mockFetch: typeof fetch = async () => new Response("rate limited", { status: 429 });
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["init"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        expect(await handle.render()).toBeNull();
+    });
+
+    it("returns null when the response body is missing the version field", async () => {
+        const mockFetch: typeof fetch = async () =>
+            new Response(JSON.stringify({ name: "playground-cli" }), { status: 200 });
+        const handle = startVersionCheck("0.16.14", {
+            fetch: mockFetch,
+            argv: ["init"],
+            env: {} as NodeJS.ProcessEnv,
+            isTTY: true,
+        });
+        expect(await handle.render()).toBeNull();
+    });
+});

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -1,0 +1,151 @@
+/**
+ * "Update available" banner shown at the bottom of every `dot` invocation.
+ *
+ * Resolves the latest CLI release through jsDelivr's free public CDN
+ * (`data.jsdelivr.com/v1/packages/gh/<owner>/<repo>/resolved`) instead of the
+ * GitHub releases API — jsDelivr is rate-limit-effectively-unlimited for our
+ * scale and isn't shared with the GitHub anonymous-IP quota that `dot mod`
+ * and `dot deploy --modable` already chip away at on hackathon WiFi.
+ *
+ * No on-disk cache: the call is fire-and-forget on command start with a 1 s
+ * `AbortSignal.timeout`, so an unreachable jsDelivr cannot delay exit.
+ *
+ * The banner is suppressed when:
+ *   - stdout is not a TTY (CI, piped output, e2e JUnit reports),
+ *   - the user opted out via `DOT_NO_UPDATE_CHECK=1`,
+ *   - the user is running `dot update` itself (it does its own fresh check),
+ *   - the user is asking for `--version` / `-V` / `--help` / `-h` (banner
+ *     would clutter machine-parseable output).
+ */
+
+import { GLYPH } from "./ui/theme/tokens.js";
+
+const JSDELIVR_URL = "https://data.jsdelivr.com/v1/packages/gh/paritytech/playground-cli/resolved";
+const FETCH_TIMEOUT_MS = 1000;
+
+const ANSI_YELLOW = "\x1b[33m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_RESET = "\x1b[0m";
+
+export interface VersionCheckHandle {
+    /** Returns banner text (with trailing newlines) to print, or null. */
+    render: () => Promise<string | null>;
+}
+
+export interface StartVersionCheckOptions {
+    /** Override fetch (tests). */
+    fetch?: typeof fetch;
+    /** Override argv (tests). Defaults to `process.argv.slice(2)`. */
+    argv?: readonly string[];
+    /** Override env (tests). Defaults to `process.env`. */
+    env?: NodeJS.ProcessEnv;
+    /** Override TTY check (tests). Defaults to `process.stdout.isTTY`. */
+    isTTY?: boolean;
+}
+
+/** "v0.16.14" → "0.16.14"; bare "0.16.14" stays "0.16.14". */
+export function normalizeVersion(v: string): string {
+    return v.replace(/^v/, "");
+}
+
+/**
+ * True when `current` is a strictly older semver than `latest`. Falls back to
+ * "not outdated" on parse failures so we never bother the user about a
+ * comparison we couldn't actually make.
+ */
+export function isOutdated(current: string, latest: string): boolean {
+    const c = normalizeVersion(current);
+    const l = normalizeVersion(latest);
+    if (c === l) return false;
+
+    const cp = c.split(".").map((n) => Number.parseInt(n, 10));
+    const lp = l.split(".").map((n) => Number.parseInt(n, 10));
+    if (cp.some(Number.isNaN) || lp.some(Number.isNaN)) return false;
+
+    const len = Math.max(cp.length, lp.length);
+    for (let i = 0; i < len; i++) {
+        const cv = cp[i] ?? 0;
+        const lv = lp[i] ?? 0;
+        if (cv < lv) return true;
+        if (cv > lv) return false;
+    }
+    return false;
+}
+
+export function shouldSkip(
+    argv: readonly string[],
+    env: NodeJS.ProcessEnv,
+    isTTY: boolean,
+): boolean {
+    if (!isTTY) return true;
+    // Honour the docstring's stated CI-skip intent even when a CI runner
+    // happens to present a TTY (some self-hosted runners, `act`, scripts
+    // wrapped in `script -q -c …`).
+    if (env.CI === "true" || env.CI === "1") return true;
+    if (env.DOT_NO_UPDATE_CHECK === "1") return true;
+    const first = argv[0];
+    // Bare `dot` and `dot help <cmd>` both produce help output; suppress the
+    // banner so we don't tail it onto a usage screen.
+    if (argv.length === 0) return true;
+    if (first === "update" || first === "help") return true;
+    if (argv.includes("--version") || argv.includes("-V")) return true;
+    if (argv.includes("--help") || argv.includes("-h")) return true;
+    return false;
+}
+
+export function formatBanner(currentVersion: string, latestVersion: string): string {
+    const current = `v${normalizeVersion(currentVersion)}`;
+    const latest = `v${normalizeVersion(latestVersion)}`;
+    // Intentionally a single-line `⚠` glyph rather than the rounded-box
+    // Callout used by `dot init`'s gh-auth advisory — this banner fires on
+    // EVERY invocation, so a heavier visual treatment would quickly become
+    // noise. Don't "harmonise" the two by upgrading this to a box.
+    return (
+        `\n  ${ANSI_YELLOW}${GLYPH.warn}${ANSI_RESET}  Update available: ${current} → ${latest}\n` +
+        `     Run ${ANSI_BOLD}dot update${ANSI_RESET} to upgrade.\n`
+    );
+}
+
+async function fetchLatestFromJsDelivr(fetchImpl: typeof fetch): Promise<string | null> {
+    try {
+        const res = await fetchImpl(JSDELIVR_URL, {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            headers: { Accept: "application/json" },
+        });
+        if (!res.ok) return null;
+        const body = (await res.json()) as { version?: unknown };
+        return typeof body.version === "string" && body.version ? body.version : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Fires the latest-version fetch immediately and returns a handle whose
+ * `render()` resolves the banner text (or null) for the caller to print at
+ * the end of the command. Never throws.
+ */
+export function startVersionCheck(
+    currentVersion: string,
+    opts: StartVersionCheckOptions = {},
+): VersionCheckHandle {
+    const fetchImpl = opts.fetch ?? fetch;
+    const argv = opts.argv ?? process.argv.slice(2);
+    const env = opts.env ?? process.env;
+    const isTTY = opts.isTTY ?? Boolean(process.stdout.isTTY);
+
+    if (shouldSkip(argv, env, isTTY)) {
+        return { render: async () => null };
+    }
+
+    const inFlight = fetchLatestFromJsDelivr(fetchImpl);
+
+    return {
+        render: async () => {
+            const latest = await inFlight;
+            if (!latest) return null;
+            if (!isOutdated(currentVersion, latest)) return null;
+            return formatBanner(currentVersion, latest);
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Defends `dot` against GitHub's **60/hour anonymous-IP rate limit**, which gets exhausted quickly on shared networks (hackathon WiFi, conferences, corporate NATs). Four layered fixes:

1. **Version-check banner via jsDelivr.** Every `dot` invocation prints a yellow ⚠ "Update available" banner at the bottom when a newer release exists. The latest-version lookup goes through [jsDelivr's free public CDN](https://www.jsdelivr.com/), not GitHub — so the check itself contributes zero load to the rate-limited quota. 1 s `AbortSignal.timeout` so a flaky network never delays exit. Suppressed in CI / non-TTY / piped output, for `dot update`/`help`/`--version`/`--help`, and when `DOT_NO_UPDATE_CHECK=1`.
2. **Opportunistic `gh auth token`.** `assertPublicGitHubRepo`, `resolveDefaultBranch`, and `fetchLatestTag` now add an `Authorization: Bearer <token>` header read from `gh auth token` when available — a `gh`-authed user lands on their personal **5000/hour** quota instead of the shared anonymous bucket. Anonymous users continue to work as before.
3. **Fail-closed rate-limit handling in `assertPublicGitHubRepo`.** A 403 with `x-ratelimit-remaining: 0` now raises an actionable `ModablePreflightError` recommending `gh auth login`, instead of silently passing the public-repo check (which previously risked publishing a private repo as `--modable`). Ambiguous 403s and 5xx transient errors still fall through.
4. **End-of-init advisory banner.** `dot init` ends with a Callout-style rounded yellow box (mirroring the in-Ink "check your phone" deploy callout) that explains the IP-based rate limit and recommends `gh auth login`. Only shown when the user is not currently authed.

## Audit — every `api.github.com/*` call site uses opportunistic auth

| Site | Endpoint | Auth |
|---|---|---|
| `src/commands/update.ts:46` | `releases/latest` | `ghAuthHeaders()` |
| `src/utils/deploy/modable.ts:112` | `repos/{owner}/{repo}` | `ghAuthHeaders()` |
| `src/utils/mod/source.ts:45` | `repos/{owner}/{repo}` | `ghAuthHeaders()` |

Non-API GitHub URLs (separate, much higher rate limits — don't share the API quota) are left as-is: `github.com/.../tree/{branch}` HTML probe, `codeload.github.com/.../tar.gz/...` tarball, `github.com/.../releases/download/...` asset.

## Banner previews

Version-check (every command, footer):
\`\`\`
  ⚠  Update available: v0.16.14 → v0.17.0
     Run dot update to upgrade.
\`\`\`

End-of-init (only when not gh-authed):
\`\`\`
  ╭──────────────────────────────────────────────────────────────────────╮
  │ GitHub authentication recommended                                    │
  │                                                                      │
  │ Without gh auth login, GitHub rate-limits all requests from your     │
  │ public IP to 60/hour, shared with everyone on the same network.      │
  │ This will exhaust quickly on public wifis. Run gh auth login once    │
  │ to use your personal 5000/hour quota instead.                        │
  ╰──────────────────────────────────────────────────────────────────────╯
\`\`\`

## Test plan

- [x] \`pnpm vitest run\` — 501/501 pass (added 30 new across version-check / gh-token / gh-auth-banner, expanded modable)
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm format:check\` — clean
- [x] Visual smoke: faked an old version, confirmed banner appears at bottom of \`dot logout\`
- [x] Visual smoke: rendered \`formatGhAuthBanner()\` directly to verify Callout-style box
- [ ] Local install (\`pnpm cli:install\`) and run \`dot init\` while logged out → confirm advisory banner; while logged in → confirm no banner
- [ ] Local install and run a slow command on offline network → confirm no exit delay (1 s timeout)

## Notes

- No on-disk cache for the version check; jsDelivr's effectively-unlimited rate limits make caching unnecessary.
- The two banners use deliberately different visual weights — version-check is plain (fires every command, must stay quiet); init advisory is a box (fires once per machine, deserves emphasis). Comment in `formatBanner` warns against "harmonising" them.
- `dot init`'s existing dependency-list row for `gh auth status` is kept as-is; the new bottom banner only adds the *why*.