### PR TITLE
fix(telemetry): stop overriding deploy.source with "playground-cli"

### DIFF
--- a/src/utils/deploy/storage.ts
+++ b/src/utils/deploy/storage.ts
@@ -43,10 +43,7 @@ export interface StorageDeployOptions {
     onLogEvent?: (event: DeployLogEvent) => void;
     /** Target environment — currently only `testnet` is supported. */
     env?: Env;
-    /**
-     * Extra telemetry attributes merged into bulletin-deploy's deploy span.
-     * Defaults to `{ "deploy.source": "playground-cli" }`.
-     */
+    /** Extra telemetry attributes merged into bulletin-deploy's deploy span. */
     attributes?: Record<string, string>;
 }
 
@@ -76,10 +73,7 @@ export async function runStorageDeploy(options: StorageDeployOptions): Promise<D
             // WebContainer-safe path for metadata upload.
             rpc: cfg.bulletinRpc,
             ...options.auth,
-            attributes: {
-                "deploy.source": "playground-cli",
-                ...options.attributes,
-            },
+            attributes: options.attributes,
         });
     } finally {
         restore();


### PR DESCRIPTION
## Summary

- `deploy.source` is bulletin-deploy's internal attribute with a fixed semantic: `"ci"` or `"local"`. playground-cli was passing `"deploy.source": "playground-cli"` as a custom attribute to `bulletinDeploy()`, which called `setDeployAttribute("deploy.source", "playground-cli")` → `span.setAttribute(...)`, overwriting the correct value on the running deploy span.
- In ambient mode (Sentry SDK v9), this manifested as `deploy.source = "playground-cli"` appearing in bulletin-deploy's telemetry instead of the expected `"ci"` / `"local"`.
- `deploy.host_app = "playground-cli"` is already set via `BULLETIN_DEPLOY_HOST_APP` wired in `bootstrap.ts`, so the host identity was always fully captured — the rogue `deploy.source` override was both wrong and redundant.

## Test plan

- [ ] Unit tests pass (`pnpm test` — 492 tests, no failures)
- [ ] Format clean (`pnpm format:check`)
- [ ] Verify next E2E deploy run shows `deploy.source = "ci"` (not `"playground-cli"`) in bulletin-deploy's Sentry spans