### PR TITLE
chore: add changeset for telemetry fixes

### DIFF
--- a/.changeset/fix-deploy-telemetry.md
+++ b/.changeset/fix-deploy-telemetry.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix two telemetry correctness issues in the deploy pipeline: E2E runs now tag bulletin-deploy spans with an `e2e-cli-*` label so test traffic is filterable in dashboards, and `deploy.source` no longer gets incorrectly overwritten with `"playground-cli"` (it correctly reports `"ci"` or `"local"` as intended).


### PR DESCRIPTION
Adds the changeset for #128 and #129 so the release workflow produces a patch version bump on merge.