### PR TITLE
test(e2e): register fixtures with visibility=0 (private)

### DIFF
--- a/tools/register-e2e-fixtures.ts
+++ b/tools/register-e2e-fixtures.ts
@@ -11,6 +11,11 @@
  * alongside the new per-cell deploy domains added in Phase 3 (foundry, cdm,
  * hardhat, multi).
  *
+ * All fixtures are registered with `visibility = 0` (private) so they don't
+ * clutter the public playground.dot grid. The CLI tests that hit these
+ * domains use direct `getMetadataUri` queries (`dot mod <domain>`,
+ * registry-readback assertions), which are unaffected by visibility.
+ *
  * Usage:
  *   bun tools/register-e2e-fixtures.ts                        # register all 5
  *   bun tools/register-e2e-fixtures.ts --domain e2efnd00      # one only
@@ -125,6 +130,7 @@ async function registerOne(fixture: Fixture, signer: Awaited<ReturnType<typeof r
 		domain: fixture.domain,
 		publishSigner: signer,
 		repositoryUrl: fixture.repositoryUrl,
+		isPrivate: true,
 		onLogEvent: (event) => {
 			if (event.kind === "info") console.log(`    • ${event.message}`);
 		},


### PR DESCRIPTION
## Summary
- Pass `isPrivate: true` to `publishToPlayground` in `tools/register-e2e-fixtures.ts` so bootstrapped E2E fixtures land at `visibility=0` on the registry contract.
- Mirrors the test-side `--private` flag added in #114; without this, re-running the bootstrap tool re-publishes fixtures as PUBLIC and undoes the visibility flip.
- Doc-string update explaining the rationale for future maintainers.

## Why
PR #114 hid new test traffic but called out a residual cleanup: *"the existing 9 visible entries need a one-off setVisibility flip."* The bootstrap tool itself was the gap — every re-run re-publishes the 5 fixtures (`dot-cli-mod-fixture.dot`, `e2e-cli-foundry/cdm/hardhat/multi`) at the default `visibility=1`. With this patch, a single re-run flips them to private and any future bootstrap keeps them private.

CLI tests that hit these domains use direct `getMetadataUri` queries (`dot mod <domain>`, registry-readback assertions) which are unaffected by visibility — so no test changes are needed.

## Test plan
- [ ] After merge, run `bun tools/register-e2e-fixtures.ts` once with the SIGNER seed to flip the existing 5 fixtures to private.
- [ ] Verify with `bun tools/list-registry-apps.ts` (queries as a non-owner): `dot-cli-mod-fixture.dot` no longer appears.
- [ ] Sanity-check that the next E2E CI run still passes — `dot mod dot-cli-mod-fixture.dot` works regardless of visibility.

No changeset required (tools/test-only change, no user-facing CLI behavior change).