### PR TITLE
fix installer VERSION override tags

### DIFF
--- a/.changeset/tame-rockets-serve.md
+++ b/.changeset/tame-rockets-serve.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Preserve explicit installer VERSION overrides such as dev branch release tags.

--- a/install.sh
+++ b/install.sh
@@ -27,9 +27,9 @@ else
     TAG=$(curl -fsSL "https://data.jsdelivr.com/v1/packages/gh/$REPO/resolved" \
           | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -n1) || true
   fi
+  case "$TAG" in v*|'') ;; *) TAG="v$TAG" ;; esac
 fi
 [ -z "$TAG" ] && echo "Could not determine latest release" && exit 1
-case "$TAG" in v*) ;; *) TAG="v$TAG" ;; esac
 
 # 3) Install binary
 spin() { while true; do for c in '|' '/' '-' '\'; do printf "\r%s %s" "$1" "$c"; sleep 0.1; done; done; }


### PR DESCRIPTION
## Summary
- preserve explicit `VERSION` overrides verbatim so `dev/<branch>` release tags are not prefixed with `v`
- keep `v` normalization for implicit latest/jsDelivr stable release resolution
- add a patch changeset for the installer fix

## Verification
- `bash -n install.sh`
- `zsh -n install.sh`
- `git diff --check`
- simulated override resolution keeps `dev/rh/fix-pagination` unchanged
- simulated stable fallback resolution maps `0.19.0` to `v0.19.0`
- checked the real `dev/rh/fix-pagination` asset URL resolves while `vdev/rh/fix-pagination` 404s