### PR TITLE
fix: reclassify MetaRegistryFailure as unexpected error

### DIFF
--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -66,7 +66,7 @@ describe("getRegistryContract", () => {
         const rawClient = {} as any;
 
         await expect(getRegistryContract(rawClient, fakeSigner)).rejects.toThrow(
-            /BadRegistryLookup/,
+            /MetaRegistryFailure/,
         );
 
         expect(fromClientMock).not.toHaveBeenCalled();

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -30,7 +30,7 @@ export async function getRegistryContract(
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         throw new Error(
-            `BadRegistryLookup: Could not resolve the live Playground registry contract address from the CDM meta-registry. Refusing to use the cdm.json snapshot because it may be stale. ${msg}`,
+            `MetaRegistryFailure: Could not resolve the live Playground registry contract address from the CDM meta-registry. Refusing to use the cdm.json snapshot because it may be stale. ${msg}`,
             { cause: err instanceof Error ? err : undefined },
         );
     }


### PR DESCRIPTION
## Summary

- Renames the error thrown in `getRegistryContract` when the CDM meta-registry fails to return a live contract address from `BadRegistryLookup` → `MetaRegistryFailure`
- Removes it from the `isExpectedCliError` allowlist so it registers as `cli.expected=false` in Sentry — this is an infra failure, not a user mistake
- `BadRegistryLookup` remains in the allowlist for other registry errors that are legitimate user-facing conditions

## Test plan

- [x] `pnpm test` — 492 tests passing