### PR TITLE
ci: cache external binary downloads (Kubo, Rust nightly)

### DIFF
--- a/.github/actions/setup-e2e/action.yml
+++ b/.github/actions/setup-e2e/action.yml
@@ -19,12 +19,23 @@ runs:
           with:
               bun-version: latest
 
+        - name: Restore Kubo from cache
+          uses: actions/cache@v4
+          with:
+              path: ~/.cache/kubo
+              key: kubo-v0.32.1-linux-amd64
+
         - name: Install Kubo (IPFS)
           shell: bash
           run: |
-              curl -fsSL -o kubo_v0.32.1_linux-amd64.tar.gz https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz
-              tar xf kubo_v0.32.1_linux-amd64.tar.gz
-              sudo mv kubo/ipfs /usr/local/bin/
+              if [ ! -f ~/.cache/kubo/ipfs ]; then
+                mkdir -p ~/.cache/kubo
+                curl -fsSL -o /tmp/kubo.tar.gz https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_linux-amd64.tar.gz
+                tar -xf /tmp/kubo.tar.gz -C /tmp
+                cp /tmp/kubo/ipfs ~/.cache/kubo/ipfs
+                rm -rf /tmp/kubo /tmp/kubo.tar.gz
+              fi
+              sudo cp ~/.cache/kubo/ipfs /usr/local/bin/ipfs
               ipfs init --profile=test
               ipfs version
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,6 +110,22 @@ jobs:
             - id: setup
               uses: ./.github/actions/setup-e2e
 
+            - name: Compute Rust cache key
+              id: rust-key
+              if: matrix.cell == 'pr-deploy-cdm'
+              shell: bash
+              run: echo "key=rust-nightly-x86_64-$(date +%Y-%V)" >> "$GITHUB_OUTPUT"
+
+            - name: Restore Rust toolchain from cache
+              if: matrix.cell == 'pr-deploy-cdm'
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.rustup/toolchains
+                      ~/.cargo/bin
+                  key: ${{ steps.rust-key.outputs.key }}
+                  restore-keys: rust-nightly-x86_64-
+
             - name: Install Rust/CDM toolchain
               if: matrix.cell == 'pr-deploy-cdm'
               shell: bash
@@ -118,9 +134,9 @@ jobs:
                   sudo apt-get install -y -q --no-install-recommends build-essential pkg-config
                   if ! command -v rustup >/dev/null 2>&1; then
                     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-                    echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-                    source "$HOME/.cargo/env"
                   fi
+                  echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+                  source "$HOME/.cargo/env"
                   rustup toolchain install nightly --profile minimal --component rust-src
                   rustup default nightly
                   curl -fsSL https://raw.githubusercontent.com/paritytech/contract-dependency-manager/main/install.sh | bash


### PR DESCRIPTION
Wraps Kubo v0.32.1 and Rust nightly toolchain downloads in actions/cache@v4. On cache hit the binary is served from GitHub's infrastructure instead of dist.ipfs.tech / sh.rustup.rs. Fixes intermittent SSL timeout failures on ephemeral Parity runners.