### PR TITLE
chore: add changeset for MetaRegistryFailure reclassification

### DIFF
--- a/.changeset/meta-registry-failure.md
+++ b/.changeset/meta-registry-failure.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Improve error reporting when the CDM meta-registry fails to return a live contract address.


### PR DESCRIPTION
Adds the changeset file so the release workflow can cut a new patch version.