### PR TITLE
fix: wire deploys to paseo next v2

### DIFF
--- a/.changeset/fix-paseo-v2-deploy-env.md
+++ b/.changeset/fix-paseo-v2-deploy-env.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Pass the selected deploy environment through to `bulletin-deploy`, resolve live CDM contracts through the active `cdm.json` target registry, pass the Asset Hub descriptor to playground registry handles, use the paseo-next-v2 IPFS gateway path for playground metadata reads, use `--suri` signers for DotNS in dev-mode deploys, and treat bare mnemonic SURIs as the root account.
+Pass the selected deploy environment through to `bulletin-deploy`, pin the paseo-next-v2 capable `bulletin-deploy` prerelease, resolve live CDM contracts through the active `cdm.json` target registry, pass the Asset Hub descriptor to playground registry handles, use the paseo-next-v2 IPFS gateway path for playground metadata reads, use `--suri` signers for DotNS in dev-mode deploys, and treat bare mnemonic SURIs as the root account.

--- a/.changeset/fix-paseo-v2-deploy-env.md
+++ b/.changeset/fix-paseo-v2-deploy-env.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Pass the selected deploy environment through to `bulletin-deploy` and use `--suri` signers for DotNS in dev-mode deploys.
+Pass the selected deploy environment through to `bulletin-deploy`, use `--suri` signers for DotNS in dev-mode deploys, and treat bare mnemonic SURIs as the root account.

--- a/.changeset/fix-paseo-v2-deploy-env.md
+++ b/.changeset/fix-paseo-v2-deploy-env.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Pass the selected deploy environment through to `bulletin-deploy` and use `--suri` signers for DotNS in dev-mode deploys.

--- a/.changeset/fix-paseo-v2-deploy-env.md
+++ b/.changeset/fix-paseo-v2-deploy-env.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Pass the selected deploy environment through to `bulletin-deploy`, use `--suri` signers for DotNS in dev-mode deploys, and treat bare mnemonic SURIs as the root account.
+Pass the selected deploy environment through to `bulletin-deploy`, resolve live CDM contracts through the active `cdm.json` target registry, pass the Asset Hub descriptor to playground registry handles, use the paseo-next-v2 IPFS gateway path for playground metadata reads, use `--suri` signers for DotNS in dev-mode deploys, and treat bare mnemonic SURIs as the root account.

--- a/cdm.json
+++ b/cdm.json
@@ -1,10 +1,5 @@
 {
   "targets": {
-    "4963ba95e259237b": {
-      "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
-      "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io",
-      "registry": "0x5c7b23d386ff622c7f7a4e7a95d5c7a67b10a00d"
-    },
     "8e7e0cf0a51d8e5e": {
       "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
       "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs",
@@ -12,13 +7,11 @@
     }
   },
   "dependencies": {
-    "4963ba95e259237b": {},
     "8e7e0cf0a51d8e5e": {
       "@w3s/playground-registry": "latest"
     }
   },
   "contracts": {
-    "4963ba95e259237b": {},
     "8e7e0cf0a51d8e5e": {
       "@w3s/playground-registry": {
         "version": 0,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@parity/product-sdk-utils": "^0.1.1",
         "@polkadot-api/sdk-ink": "^0.7.0",
         "@sentry/node": "^9.47.1",
-        "bulletin-deploy": "0.7.19",
+        "bulletin-deploy": "0.7.20-rc.4",
         "commander": "^12.0.0",
         "ink": "^5.2.1",
         "polkadot-api": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^9.47.1
         version: 9.47.1
       bulletin-deploy:
-        specifier: 0.7.19
-        version: 0.7.19(@polkadot/util@14.0.3)(esbuild@0.27.7)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.8.4)
+        specifier: 0.7.20-rc.4
+        version: 0.7.20-rc.4(@polkadot/util@14.0.3)(esbuild@0.27.7)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.8.4)
       commander:
         specifier: ^12.0.0
         version: 12.1.0
@@ -2394,8 +2394,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  bulletin-deploy@0.7.19:
-    resolution: {integrity: sha512-E/92y6erCLx3jQPqADxFVbnXZWwTkU3moBe+P2Tw9cFjO7nn6StbY5afdwR6zCbtQwRb4GQROGRbFojL8392fw==}
+  bulletin-deploy@0.7.20-rc.4:
+    resolution: {integrity: sha512-YOSiNAMJvyYfWWvCal8uhsInExbSXztWTFlxmhOX/iMDS01DdLeQWf/kPdgRkQsV2Em8mI6UkzJM+mbP58BYdw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -8487,7 +8487,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bulletin-deploy@0.7.19(@polkadot/util@14.0.3)(esbuild@0.27.7)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.8.4):
+  bulletin-deploy@0.7.20-rc.4(@polkadot/util@14.0.3)(esbuild@0.27.7)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.8.4):
     dependencies:
       '@ipld/car': 5.4.3
       '@ipld/dag-pb': 4.1.5

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -292,12 +292,13 @@ export function DeployScreen({
             {stage.kind === "validate-domain" && (
                 <ValidateDomainStage
                     domain={stage.domain}
-                    // Only gate on the user's address in phone mode — see
-                    // `ownerSs58Address` docs in availability.ts. In dev mode
-                    // bulletin-deploy signs DotNS with its own DEFAULT_MNEMONIC,
-                    // so the user's H160 does not match the registrar's H160
-                    // and the preflight would mis-report re-deploys as "taken".
-                    ownerSs58Address={mode === "phone" ? userSigner?.address : undefined}
+                    ownerSs58Address={
+                        mode === "phone"
+                            ? userSigner?.address
+                            : userSigner?.source === "dev"
+                              ? userSigner.address
+                              : undefined
+                    }
                     onAvailable={(result) => {
                         setDomain(result.fullDomain);
                         setPlan(result.plan);

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -308,13 +308,16 @@ async function runHeadless(ctx: {
     //
     // `ownerSs58Address` MUST match whoever will actually sign the DotNS
     // `register()` extrinsic — otherwise the preflight reports "taken" on a
-    // re-deploy. In phone mode bulletin-deploy uses the user's signer, so
-    // passing the user's address is correct. In dev mode bulletin-deploy
-    // falls back to its built-in DEFAULT_MNEMONIC, so the user's H160 does
-    // NOT match the on-chain owner — we omit the address and let
-    // bulletin-deploy's own preflight (run with the right signer during
-    // `deploy()`) do the comparison.
+    // re-deploy. Phone mode signs with the session account; dev-with-SURI signs
+    // with that local account. Pure dev mode still falls back to bulletin-deploy's
+    // built-in DEFAULT_MNEMONIC, so we omit the address there.
     process.stdout.write(`\nChecking availability of ${domain.replace(/\.dot$/, "") + ".dot"}…\n`);
+    const dotnsOwnerSs58Address =
+        mode === "phone"
+            ? ctx.userSigner?.address
+            : ctx.userSigner?.source === "dev"
+              ? ctx.userSigner.address
+              : undefined;
     const availability = await withSpan(
         "cli.deploy.availability",
         "check domain availability",
@@ -322,7 +325,7 @@ async function runHeadless(ctx: {
         () =>
             checkDomainAvailability(domain, {
                 env: ctx.env,
-                ownerSs58Address: mode === "phone" ? ctx.userSigner?.address : undefined,
+                ownerSs58Address: dotnsOwnerSs58Address,
             }),
     );
     if (availability.status !== "available") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,23 +36,6 @@ export type Env =
 export const ACTIVE_TESTNET_ENV: Env = "paseo-next-v2";
 export const DEFAULT_ENV: Env = ACTIVE_TESTNET_ENV;
 
-/**
- * DotNS contract addresses for an env. Resolved by bulletin-deploy when
- * `skipDotnsCli: true`; included here so other callers (mod, registry
- * lookups) can read the live set without re-parsing bulletin-deploy's bundled
- * environments.json.
- */
-export interface DotnsContracts {
-    REGISTRAR: string;
-    REGISTRAR_CONTROLLER: string;
-    REGISTRY: string;
-    RESOLVER: string;
-    CONTENT_RESOLVER: string;
-    REVERSE_RESOLVER: string;
-    POP_RULES: string;
-    STORE_FACTORY: string;
-}
-
 export interface ChainConfig {
     /** Env identifier — passes straight through to bulletin-deploy's `deploy({ env })`. */
     env: Env;
@@ -83,14 +66,12 @@ export interface ChainConfig {
     autoAccountMapping: boolean;
     /** True when `authorize_account` takes the v2 `{who, transactions, bytes}` signature. */
     bulletinAuthorizeV2: boolean;
-    /** DotNS contract addresses. null when bulletin-deploy/dotns-cli has hardcoded defaults. */
-    dotnsContracts: DotnsContracts | null;
     /** Public faucet URL, or null when allowances replace the funder flow. */
     faucetUrl: string | null;
 }
 
-// Paseo Next v2 — the active env. Source for endpoints + DotNS addresses:
-// bulletin-deploy/assets/environments.json (v2 entry).
+// Paseo Next v2 — the active env. DotNS contracts are owned by
+// bulletin-deploy's environment catalog and keyed by `env`.
 const PASEO_NEXT_V2: ChainConfig = {
     env: "paseo-next-v2",
     network: "testnet",
@@ -104,16 +85,6 @@ const PASEO_NEXT_V2: ChainConfig = {
     appViewerOrigin: "https://dot.li",
     autoAccountMapping: true,
     bulletinAuthorizeV2: true,
-    dotnsContracts: {
-        REGISTRAR: "0xE67B22B285912FFfaE23BdfAc8C80c779d99B3e0",
-        REGISTRAR_CONTROLLER: "0x8403e49Ec12F4EA5788f7bc0C0c2F649205774cC",
-        REGISTRY: "0xDeFE1AAE21eC2455bd04b213a51C16d4b426c7ef",
-        RESOLVER: "0xB436A271Beff1DBa6abDf2dbCc7E6d723d505EE6",
-        CONTENT_RESOLVER: "0xBcFa907Ff85dFc62a21b41d48F23D7A73aC42914",
-        REVERSE_RESOLVER: "0x4Ca32Dd0233D8c1B1709e20D9E4edBF2a77D21c3",
-        POP_RULES: "0xd3F059FA65dA566B294b5d755a06054d4bE7ce7C",
-        STORE_FACTORY: "0x4f1885fB6e0b154dCf9C2A8661e578B94aD50775",
-    },
     faucetUrl: null,
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,8 +23,6 @@
  * today; others throw from `getChainConfig` until they're populated.
  */
 
-import { REGISTRY_ADDRESS } from "@dotdm/contracts";
-
 export type Env =
     | "preview"
     | "paseo-next"
@@ -80,7 +78,7 @@ const PASEO_NEXT_V2: ChainConfig = {
     bulletinRpc: "wss://paseo-bulletin-next-rpc.polkadot.io",
     bulletinRpcFallbacks: [],
     peopleEndpoints: ["wss://paseo-people-next-system-rpc.polkadot.io"],
-    bulletinGateway: "https://paseo-bulletin-next-ipfs.polkadot.io/",
+    bulletinGateway: "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs/",
     identityBackendUrl: "https://identity-backend-next.parity-testnet.parity.io",
     appViewerOrigin: "https://dot.li",
     autoAccountMapping: true,
@@ -149,9 +147,6 @@ export function getNetworkLabel(env: Env = DEFAULT_ENV): string {
             return "kusama";
     }
 }
-
-/** CDM meta-registry contract address, sourced from `@dotdm/contracts`. */
-export const CDM_REGISTRY_ADDRESS = REGISTRY_ADDRESS;
 
 /** Identifier the terminal adapter reports during SSO. Kept stable so mobile pairings persist across releases. */
 export const DAPP_ID = "dot-cli";

--- a/src/utils/bulletinGateway.test.ts
+++ b/src/utils/bulletinGateway.test.ts
@@ -40,12 +40,12 @@ describe("bulletinGatewayUrl", () => {
 describe("getBulletinGateway", () => {
     it("returns the paseo-next-v2 gateway by default", () => {
         // Defaults to DEFAULT_ENV (paseo-next-v2); no env arg required.
-        expect(getBulletinGateway()).toBe("https://paseo-bulletin-next-ipfs.polkadot.io/");
+        expect(getBulletinGateway()).toBe("https://paseo-bulletin-next-ipfs.polkadot.io/ipfs/");
     });
 
     it("returns the same URL when explicitly asked for paseo-next-v2", () => {
         expect(getBulletinGateway("paseo-next-v2")).toBe(
-            "https://paseo-bulletin-next-ipfs.polkadot.io/",
+            "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs/",
         );
     });
 });

--- a/src/utils/contractManifest.test.ts
+++ b/src/utils/contractManifest.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import type { CdmJson } from "@parity/product-sdk-contracts";
-import { CDM_REGISTRY_ADDRESS } from "../config.js";
+import { REGISTRY_ADDRESS } from "@dotdm/contracts";
 
 const { createContractFromClientMock, getAddressQueryMock } = vi.hoisted(() => ({
     createContractFromClientMock: vi.fn(),
@@ -39,6 +39,7 @@ import {
 
 const snapshotAddress = "0x1111111111111111111111111111111111111111";
 const liveAddress = "0x2222222222222222222222222222222222222222";
+const targetRegistryAddress = "0x5555555555555555555555555555555555555555";
 
 /**
  * Mock `Weight` for `QueryResult.gasRequired` — required (non-optional) on
@@ -54,6 +55,7 @@ function manifest(): CdmJson {
             target1: {
                 "asset-hub": "wss://asset-hub.example",
                 bulletin: "https://bulletin.example/ipfs",
+                registry: targetRegistryAddress,
             },
         },
         dependencies: {
@@ -77,7 +79,7 @@ function manifest(): CdmJson {
                 },
             },
         },
-    };
+    } as CdmJson;
 }
 
 beforeEach(() => {
@@ -89,7 +91,7 @@ beforeEach(() => {
 });
 
 describe("resolveLiveContractAddresses", () => {
-    it("queries the fixed CDM registry for requested libraries", async () => {
+    it("queries the configured CDM registry for requested libraries", async () => {
         getAddressQueryMock.mockResolvedValue({
             success: true,
             value: { isSome: true, value: liveAddress },
@@ -97,15 +99,17 @@ describe("resolveLiveContractAddresses", () => {
         });
 
         const assetHub = {} as any;
-        const addresses = await resolveLiveContractAddresses(assetHub, [
-            PLAYGROUND_REGISTRY_CONTRACT,
-        ]);
+        const addresses = await resolveLiveContractAddresses(
+            assetHub,
+            [PLAYGROUND_REGISTRY_CONTRACT],
+            { registryAddress: targetRegistryAddress },
+        );
 
         expect(addresses).toEqual({ [PLAYGROUND_REGISTRY_CONTRACT]: liveAddress });
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
             { genesis: "0xasset" },
-            CDM_REGISTRY_ADDRESS,
+            targetRegistryAddress,
             expect.arrayContaining([
                 expect.objectContaining({ name: "getAddress", type: "function" }),
             ]),
@@ -125,12 +129,13 @@ describe("resolveLiveContractAddresses", () => {
         const origin = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
         await resolveLiveContractAddresses(assetHub, [PLAYGROUND_REGISTRY_CONTRACT], {
             defaultOrigin: origin,
+            registryAddress: targetRegistryAddress,
         });
 
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
             { genesis: "0xasset" },
-            CDM_REGISTRY_ADDRESS,
+            targetRegistryAddress,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),
         );
@@ -144,8 +149,28 @@ describe("resolveLiveContractAddresses", () => {
         });
 
         await expect(
-            resolveLiveContractAddresses({} as any, [PLAYGROUND_REGISTRY_CONTRACT]),
+            resolveLiveContractAddresses({} as any, [PLAYGROUND_REGISTRY_CONTRACT], {
+                registryAddress: targetRegistryAddress,
+            }),
         ).resolves.toEqual({});
+    });
+
+    it("falls back to CDM's package registry address when no registry is supplied", async () => {
+        getAddressQueryMock.mockResolvedValue({
+            success: true,
+            value: { isSome: true, value: liveAddress },
+            gasRequired: OK_WEIGHT,
+        });
+
+        await resolveLiveContractAddresses({} as any, [PLAYGROUND_REGISTRY_CONTRACT]);
+
+        expect(createContractFromClientMock).toHaveBeenCalledWith(
+            {},
+            { genesis: "0xasset" },
+            REGISTRY_ADDRESS,
+            expect.any(Array),
+            expect.any(Object),
+        );
     });
 });
 
@@ -207,7 +232,7 @@ describe("withLiveContractAddresses", () => {
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
             { genesis: "0xasset" },
-            CDM_REGISTRY_ADDRESS,
+            targetRegistryAddress,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),
         );
@@ -232,7 +257,7 @@ describe("withLiveContractAddresses", () => {
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
             { genesis: "0xasset" },
-            CDM_REGISTRY_ADDRESS,
+            targetRegistryAddress,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),
         );

--- a/src/utils/contractManifest.test.ts
+++ b/src/utils/contractManifest.test.ts
@@ -26,6 +26,10 @@ vi.mock("@parity/product-sdk-contracts", () => ({
     createContractFromClient: (...args: unknown[]) => createContractFromClientMock(...args),
 }));
 
+vi.mock("@parity/product-sdk-descriptors/paseo-asset-hub", () => ({
+    paseo_asset_hub: { genesis: "0xasset" },
+}));
+
 import {
     PLAYGROUND_REGISTRY_CONTRACT,
     resolveLiveContractAddresses,
@@ -100,6 +104,7 @@ describe("resolveLiveContractAddresses", () => {
         expect(addresses).toEqual({ [PLAYGROUND_REGISTRY_CONTRACT]: liveAddress });
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
+            { genesis: "0xasset" },
             CDM_REGISTRY_ADDRESS,
             expect.arrayContaining([
                 expect.objectContaining({ name: "getAddress", type: "function" }),
@@ -124,6 +129,7 @@ describe("resolveLiveContractAddresses", () => {
 
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
+            { genesis: "0xasset" },
             CDM_REGISTRY_ADDRESS,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),
@@ -200,6 +206,7 @@ describe("withLiveContractAddresses", () => {
 
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
+            { genesis: "0xasset" },
             CDM_REGISTRY_ADDRESS,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),
@@ -224,6 +231,7 @@ describe("withLiveContractAddresses", () => {
 
         expect(createContractFromClientMock).toHaveBeenCalledWith(
             assetHub,
+            { genesis: "0xasset" },
             CDM_REGISTRY_ADDRESS,
             expect.any(Array),
             expect.objectContaining({ defaultOrigin: origin }),

--- a/src/utils/contractManifest.ts
+++ b/src/utils/contractManifest.ts
@@ -19,8 +19,8 @@ import {
     type CdmJson,
 } from "@parity/product-sdk-contracts";
 import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
+import { REGISTRY_ADDRESS, resolveTargetRegistryAddress } from "@dotdm/contracts";
 import type { HexString, PolkadotClient } from "polkadot-api";
-import { CDM_REGISTRY_ADDRESS } from "../config.js";
 
 export const PLAYGROUND_REGISTRY_CONTRACT = "@w3s/playground-registry";
 
@@ -104,6 +104,16 @@ function defaultTargetHash(manifest: CdmJson): string {
     return targetHash;
 }
 
+function defaultTarget(manifest: CdmJson): CdmJson["targets"][string] & { registry?: string } {
+    const target = manifest.targets[defaultTargetHash(manifest)];
+    if (!target) throw new Error("No targets found in cdm.json");
+    return target;
+}
+
+function defaultRegistryAddress(manifest: CdmJson): HexString {
+    return resolveTargetRegistryAddress(defaultTarget(manifest)) as HexString;
+}
+
 function patchContractAddresses(
     manifest: CdmJson,
     liveAddresses: Record<string, HexString>,
@@ -131,6 +141,7 @@ function patchContractAddresses(
  */
 export interface LiveContractLookupOptions {
     defaultOrigin?: string;
+    registryAddress?: HexString;
 }
 
 export async function resolveLiveContractAddresses(
@@ -138,10 +149,11 @@ export async function resolveLiveContractAddresses(
     libraries: readonly string[] = LIVE_CONTRACTS,
     options: LiveContractLookupOptions = {},
 ): Promise<Record<string, HexString>> {
+    const registryAddress = options.registryAddress ?? (REGISTRY_ADDRESS as HexString);
     const registry = await createContractFromClient(
         assetHub,
         paseo_asset_hub,
-        CDM_REGISTRY_ADDRESS,
+        registryAddress,
         CDM_REGISTRY_ABI,
         { defaultOrigin: options.defaultOrigin },
     );
@@ -169,7 +181,10 @@ export async function withLiveContractAddresses(
     libraries: readonly string[] = LIVE_CONTRACTS,
     options: LiveContractLookupOptions = {},
 ): Promise<CdmJson> {
-    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries, options);
+    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries, {
+        ...options,
+        registryAddress: options.registryAddress ?? defaultRegistryAddress(manifest),
+    });
     return patchContractAddresses(manifest, liveAddresses);
 }
 
@@ -179,7 +194,10 @@ export async function withRequiredLiveContractAddresses(
     libraries: readonly string[] = LIVE_CONTRACTS,
     options: LiveContractLookupOptions = {},
 ): Promise<CdmJson> {
-    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries, options);
+    const liveAddresses = await resolveLiveContractAddresses(assetHub, libraries, {
+        ...options,
+        registryAddress: options.registryAddress ?? defaultRegistryAddress(manifest),
+    });
     const missing = libraries.filter((library) => !liveAddresses[library]);
     if (missing.length > 0) {
         throw new Error(`CDM meta-registry did not return live address for ${missing.join(", ")}`);

--- a/src/utils/contractManifest.ts
+++ b/src/utils/contractManifest.ts
@@ -18,6 +18,7 @@ import {
     type AbiEntry,
     type CdmJson,
 } from "@parity/product-sdk-contracts";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 import type { HexString, PolkadotClient } from "polkadot-api";
 import { CDM_REGISTRY_ADDRESS } from "../config.js";
 
@@ -139,6 +140,7 @@ export async function resolveLiveContractAddresses(
 ): Promise<Record<string, HexString>> {
     const registry = await createContractFromClient(
         assetHub,
+        paseo_asset_hub,
         CDM_REGISTRY_ADDRESS,
         CDM_REGISTRY_ABI,
         { defaultOrigin: options.defaultOrigin },

--- a/src/utils/deploy/signerMode.test.ts
+++ b/src/utils/deploy/signerMode.test.ts
@@ -52,6 +52,22 @@ describe("resolveSignerSetup — dev mode", () => {
         // Dev mode keeps bulletin-deploy on its built-in default mnemonic.
         expect(result.bulletinDeployAuthOptions).toEqual({});
     });
+
+    it("dev SURI signer is forwarded to DotNS auth for CI deploys", () => {
+        const user = fakeSigner("dev", "5DevSuri");
+        const result = resolveSignerSetup({
+            mode: "dev",
+            userSigner: user,
+            publishToPlayground: true,
+        });
+
+        expect(result.approvals).toEqual([
+            { phase: "playground", label: "Publish to Playground registry" },
+        ]);
+        expect(result.publishSigner).toBe(user);
+        expect(result.bulletinDeployAuthOptions.signer).toBe(user.signer);
+        expect(result.bulletinDeployAuthOptions.signerAddress).toBe("5DevSuri");
+    });
 });
 
 describe("resolveSignerSetup — phone mode", () => {

--- a/src/utils/deploy/signerMode.ts
+++ b/src/utils/deploy/signerMode.ts
@@ -20,9 +20,11 @@
  * rewriting callers.
  *
  * Today (testnet):
- *   - Dev mode: bulletin-deploy uses its built-in default mnemonic for
- *     storage AND DotNS. Playground publish (if enabled) still uses the
- *     user's phone signer so myApps ownership lands on the correct address.
+ *   - Dev mode: without a resolved local signer, bulletin-deploy uses its
+ *     built-in default mnemonic for storage AND DotNS. With `--suri`, DotNS
+ *     uses that local signer so CI can register/update names without mobile.
+ *     Playground publish uses the resolved signer so myApps ownership lands
+ *     on the account that ran the deploy.
  *   - Phone mode: bulletin-deploy uses the user's phone signer for DotNS
  *     (3 taps). Storage always uses the bulletin-deploy pool mnemonic.
  *     Playground publish uses the user's phone signer (1 more tap).
@@ -150,9 +152,16 @@ export function resolveSignerSetup(opts: ResolveOptions): DeploySignerSetup {
         approvals.push(...dotnsApprovals(opts.plan));
     }
 
+    if (opts.mode === "dev" && opts.userSigner?.source === "dev") {
+        bulletinDeployAuthOptions = {
+            signer: opts.userSigner.signer,
+            signerAddress: opts.userSigner.address,
+        };
+    }
+
     // Playground publish always uses the user's signer so ownership ties to
-    // their address — otherwise the registry would record a shared dev key
-    // and the myApps view would be useless.
+    // their address. In `--signer dev --suri ...` that user is the local SURI
+    // account; in phone mode it is the mobile session account.
     //
     // userSigner is guaranteed non-null here: shouldResolveUserSigner() returns
     // true whenever publishToPlayground is true, so resolveSigner() in the

--- a/src/utils/deploy/storage.test.ts
+++ b/src/utils/deploy/storage.test.ts
@@ -1,0 +1,50 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it, vi } from "vitest";
+import { runStorageDeploy } from "./storage.js";
+
+const bulletinDeployMock = vi.hoisted(() =>
+    vi.fn(async () => ({
+        cid: "bafyapp",
+        ipfsCid: "bafyapp",
+        carBytes: new Uint8Array(),
+    })),
+);
+
+vi.mock("bulletin-deploy", () => ({
+    deploy: bulletinDeployMock,
+}));
+
+describe("runStorageDeploy", () => {
+    it("passes the selected env and endpoints to bulletin-deploy", async () => {
+        await runStorageDeploy({
+            content: "/tmp/project/dist",
+            domainName: "my-app",
+            auth: {},
+            env: "paseo-next-v2",
+        });
+
+        expect(bulletinDeployMock).toHaveBeenCalledWith(
+            "/tmp/project/dist",
+            "my-app",
+            expect.objectContaining({
+                env: "paseo-next-v2",
+                rpc: "wss://paseo-bulletin-next-rpc.polkadot.io",
+                assetHubEndpoints: ["wss://paseo-asset-hub-next-rpc.polkadot.io"],
+            }),
+        );
+    });
+});

--- a/src/utils/deploy/storage.ts
+++ b/src/utils/deploy/storage.ts
@@ -62,13 +62,18 @@ export interface StorageDeployOptions {
     attributes?: Record<string, string>;
 }
 
+type EnvironmentAwareDeployOptions = DeployOptions & {
+    env?: Env;
+    assetHubEndpoints?: string[];
+};
+
 export async function runStorageDeploy(options: StorageDeployOptions): Promise<DeployResult> {
     const cfg = getChainConfig(options.env);
     const parser = new DeployLogParser();
     const restore = interceptConsoleLog(options.onLogEvent, parser);
 
     try {
-        return await bulletinDeploy(options.content, options.domainName, {
+        const deployOptions: EnvironmentAwareDeployOptions = {
             // Intentionally NOT setting `jsMerkle: true` — bulletin-deploy's
             // pure-JS merkleizer (`merkleizeJS`) produces CARs that are
             // missing their DAG-PB structural blocks (directory + file nodes)
@@ -86,10 +91,13 @@ export async function runStorageDeploy(options: StorageDeployOptions): Promise<D
             // — then flip `jsMerkle: true` back on for the WebContainer (RevX)
             // story. See `src/utils/deploy/playground.ts` for an ongoing
             // WebContainer-safe path for metadata upload.
+            env: cfg.env,
             rpc: cfg.bulletinRpc,
+            assetHubEndpoints: [cfg.assetHubRpc],
             ...options.auth,
             attributes: options.attributes,
-        });
+        };
+        return await bulletinDeploy(options.content, options.domainName, deployOptions);
     } finally {
         restore();
     }

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -31,6 +31,10 @@ vi.mock("@parity/product-sdk-contracts", () => ({
     },
 }));
 
+vi.mock("@parity/product-sdk-descriptors/paseo-asset-hub", () => ({
+    paseo_asset_hub: { genesis: "0xasset" },
+}));
+
 vi.mock("./contractManifest.js", () => ({
     PLAYGROUND_REGISTRY_CONTRACT: "@w3s/playground-registry",
     suppressReviveTraceNoise: (contract: unknown) => contract,
@@ -69,10 +73,15 @@ describe("getRegistryContract", () => {
             ["@w3s/playground-registry"],
             { defaultOrigin: fakeSigner.address },
         );
-        expect(fromClientMock).toHaveBeenCalledWith(patchedManifest, rawClient, {
-            defaultSigner: fakeSigner.signer,
-            defaultOrigin: fakeSigner.address,
-        });
+        expect(fromClientMock).toHaveBeenCalledWith(
+            patchedManifest,
+            rawClient,
+            { genesis: "0xasset" },
+            {
+                defaultSigner: fakeSigner.signer,
+                defaultOrigin: fakeSigner.address,
+            },
+        );
         expect(getContractMock).toHaveBeenCalledWith("@w3s/playground-registry");
     });
 

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -19,6 +19,7 @@
 
 import { ContractManager, type CdmJson } from "@parity/product-sdk-contracts";
 import { ss58Encode } from "@parity/product-sdk-address";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 import { getDevPublicKey } from "@parity/product-sdk-tx";
 import type { ResolvedSigner } from "./signer.js";
 import {
@@ -67,7 +68,7 @@ export async function getRegistryContract(
     signer: ResolvedSigner,
 ) {
     const manifest = await loadManifest(rawClient, signer.address);
-    const manager = await ContractManager.fromClient(manifest, rawClient, {
+    const manager = await ContractManager.fromClient(manifest, rawClient, paseo_asset_hub, {
         defaultSigner: signer.signer,
         defaultOrigin: signer.address,
     });
@@ -88,7 +89,7 @@ export async function getReadOnlyRegistryContract(
     rawClient: Parameters<typeof ContractManager.fromClient>[1],
 ) {
     const manifest = await loadManifest(rawClient, READ_ONLY_QUERY_ORIGIN);
-    const manager = await ContractManager.fromClient(manifest, rawClient, {
+    const manager = await ContractManager.fromClient(manifest, rawClient, paseo_asset_hub, {
         defaultOrigin: READ_ONLY_QUERY_ORIGIN,
     });
     return suppressReviveTraceNoise(manager.getContract(PLAYGROUND_REGISTRY_CONTRACT));

--- a/src/utils/sessionSigner.ts
+++ b/src/utils/sessionSigner.ts
@@ -130,10 +130,13 @@ export function createPlaygroundSessionSigner(
         };
     };
 
-    const signRaw = async (payload: { address: string; data: `0x${string}`; type: "bytes" }) => {
+    const signRaw = async (payload: { address: string; data: string; type: "bytes" }) => {
+        if (!payload.data.startsWith("0x")) {
+            throw new Error("Raw signing payload must be 0x-prefixed hex");
+        }
         const result = await session.signRaw({
             productAccountId,
-            data: { tag: "Bytes", value: fromHex(payload.data) },
+            data: { tag: "Bytes", value: fromHex(payload.data as `0x${string}`) },
         });
         if (result.isErr()) {
             throw new Error(`Mobile signing rejected: ${result.error.message}`);

--- a/src/utils/signer.test.ts
+++ b/src/utils/signer.test.ts
@@ -31,6 +31,8 @@ const mockCreateDevSigner = vi.fn().mockReturnValue({ __signer: "dev" });
 const mockGetDevPublicKey = vi.fn().mockReturnValue(new Uint8Array(32));
 const mockSs58Encode = vi.fn().mockReturnValue("5GrwvaEF...");
 const mockGetSessionSigner = vi.fn<() => Promise<unknown>>();
+const mockSeedToAccount = vi.fn();
+const TEST_MNEMONIC = "test test test test test test test test test test test junk";
 
 vi.mock("@parity/product-sdk-tx", () => ({
     createDevSigner: (...args: unknown[]) => mockCreateDevSigner(...args),
@@ -41,6 +43,10 @@ vi.mock("@parity/product-sdk-address", () => ({
     ss58Encode: (...args: unknown[]) => mockSs58Encode(...args),
 }));
 
+vi.mock("@parity/product-sdk-keys", () => ({
+    seedToAccount: (...args: unknown[]) => mockSeedToAccount(...args),
+}));
+
 vi.mock("./auth.js", () => ({
     getSessionSigner: () => mockGetSessionSigner(),
 }));
@@ -49,6 +55,13 @@ const { resolveSigner, parseDevAccountName, SignerNotAvailableError } = await im
 
 beforeEach(() => {
     vi.clearAllMocks();
+    mockSeedToAccount.mockImplementation((mnemonic: string) => {
+        if (mnemonic !== TEST_MNEMONIC) throw new Error("Invalid mnemonic phrase");
+        return {
+            signer: { __signer: "seed" },
+            publicKey: new Uint8Array(32).fill(7),
+        };
+    });
 });
 
 // ── parseDevAccountName ─────────────────────────────────────────────────────
@@ -107,6 +120,18 @@ describe("resolveSigner", () => {
 
     it("lists supported names in error message", async () => {
         await expect(resolveSigner({ suri: "//Bad" })).rejects.toThrow(/Alice.*Ferdie/);
+    });
+
+    it("uses the root account for a bare mnemonic", async () => {
+        await resolveSigner({ suri: TEST_MNEMONIC });
+
+        expect(mockSeedToAccount).toHaveBeenCalledWith(TEST_MNEMONIC, "");
+    });
+
+    it("uses an explicit derivation suffix when the mnemonic includes one", async () => {
+        await resolveSigner({ suri: `${TEST_MNEMONIC}//0` });
+
+        expect(mockSeedToAccount).toHaveBeenCalledWith(TEST_MNEMONIC, "//0");
     });
 
     it("falls back to session signer when no SURI", async () => {

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -86,7 +86,7 @@ export async function resolveSigner(options?: SignerOptions): Promise<ResolvedSi
         // to expose a separate `--derivation` flag.
         const sepIdx = options.suri.indexOf("//");
         const mnemonic = (sepIdx === -1 ? options.suri : options.suri.slice(0, sepIdx)).trim();
-        const path = sepIdx === -1 ? undefined : options.suri.slice(sepIdx);
+        const path = sepIdx === -1 ? "" : options.suri.slice(sepIdx);
         try {
             const account = seedToAccount(mnemonic, path);
             return {


### PR DESCRIPTION
## Summary
- wires the CLI testnet path to paseo-next-v2 through the central chain config
- passes the selected env and Asset Hub endpoint through to `bulletin-deploy`, and pins `bulletin-deploy@0.7.20-rc.4` for the embedded paseo-next-v2 environment catalog
- lets dev-mode deploys with `--suri` use that local signer for DotNS and playground publish, including bare mnemonic SURIs as the root account
- removes duplicated DotNS contract addresses from CLI config; `bulletin-deploy` owns that catalog
- resolves the live Playground registry through the active `cdm.json` target registry and passes the paseo Asset Hub descriptor to product-sdk contract handles
- fixes paseo-next-v2 metadata reads by using the `/ipfs/` gateway path

## Runtime state
- `dot deploy --env testnet --playground --moddable --suri ...` now completes upload + DotNS and publish-to-playground on paseo-next-v2.
- Registry reads for `dot mod` now use the live CDM registry address and the same Asset Hub descriptor path as writes.
- The mobile/iOS allowance timeout during `dot init` is separate from this deploy/moddable path and still needs product-sdk/mobile follow-up.

## Dependency note
- This intentionally uses an explicit prerelease pin, not `latest`, while waiting for the corresponding `bulletin-deploy` stable release.
- Once the release containing paritytech/bulletin-deploy#357 is promoted, replace `0.7.20-rc.4` with that explicit stable version.

## Verification
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm test`
- `pnpm build`
- `pnpm cli:install`
