### PR TITLE
chore: modernize e2e fixture registration

### DIFF
--- a/e2e/cli/fixtures/registry.ts
+++ b/e2e/cli/fixtures/registry.ts
@@ -19,20 +19,11 @@
  * Queries the on-chain playground registry to verify deploy outcomes.
  */
 
-import { ContractManager } from "@parity/product-sdk-contracts";
-import { createDevSigner, getDevPublicKey } from "@parity/product-sdk-tx";
-import { ss58Encode } from "@parity/product-sdk-address";
 import { getTestClient } from "../helpers/chain.js";
-import {
-	PLAYGROUND_REGISTRY_CONTRACT,
-	suppressReviveTraceNoise,
-	withRequiredLiveContractAddresses,
-} from "../../../src/utils/contractManifest.js";
+import { getReadOnlyRegistryContract } from "../../../src/utils/registry.js";
 import { resolveSigner } from "../../../src/utils/signer.js";
 import { publishToPlayground } from "../../../src/utils/deploy/playground.js";
 import { SIGNER } from "./accounts.js";
-
-import cdmJson from "../../../cdm.json";
 
 export interface AppEntry {
 	domain: string;
@@ -40,7 +31,7 @@ export interface AppEntry {
 	metadataUri: string;
 }
 
-type Registry = Awaited<ReturnType<Awaited<ReturnType<typeof ContractManager.fromClient>>["getContract"]>>;
+type Registry = Awaited<ReturnType<typeof getReadOnlyRegistryContract>>;
 
 let registryPromise: Promise<Registry> | null = null;
 
@@ -48,21 +39,7 @@ async function getRegistry(): Promise<Registry> {
 	if (!registryPromise) {
 		registryPromise = (async () => {
 			const client = await getTestClient();
-			const aliceSigner = createDevSigner("Alice");
-			const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
-			// Mirror src/utils/registry.ts — query the CDM meta-registry for the
-			// live address before binding, so the helper reads from the same
-			// contract `dot mod` and `dot deploy` actually use. Without this,
-			// reads land on the cdm.json snapshot and silently diverge from the
-			// command paths after a registry redeploy. See issue #74.
-			const manifest = await withRequiredLiveContractAddresses(cdmJson, client.raw.assetHub, [
-				PLAYGROUND_REGISTRY_CONTRACT,
-			]);
-			const manager = await ContractManager.fromClient(manifest, client.raw.assetHub, {
-				defaultSigner: aliceSigner,
-				defaultOrigin: aliceAddress,
-			});
-			return suppressReviveTraceNoise(manager.getContract(PLAYGROUND_REGISTRY_CONTRACT));
+			return getReadOnlyRegistryContract(client.raw.assetHub);
 		})().catch((err) => {
 			// Reset so the next call can retry instead of replaying the error
 			registryPromise = null;

--- a/e2e/cli/setup/fund.ts
+++ b/e2e/cli/setup/fund.ts
@@ -30,6 +30,11 @@ import { checkBalance, ensureFunded } from "../../../src/utils/account/funding.j
 import { getTestClient } from "../helpers/chain.js";
 import { SIGNER } from "../fixtures/accounts.js";
 
+interface FundedAccount {
+	name: string;
+	address: string;
+}
+
 const PAS = 10_000_000_000n;
 
 /** Top up the deployer if it falls below this. */
@@ -38,18 +43,22 @@ export const MIN_BALANCE = 500n * PAS;
 /** Amount to send when topping up. */
 export const TOP_UP_AMOUNT = 1000n * PAS;
 
-export async function fundDeployerIfLow(): Promise<void> {
+export async function fundAccountIfLow(account: FundedAccount): Promise<void> {
 	const client = await getTestClient();
-	const before = await checkBalance(client, SIGNER.address, MIN_BALANCE);
+	const before = await checkBalance(client, account.address, MIN_BALANCE);
 	console.log(
-		`[e2e setup] SIGNER (${SIGNER.name}) balance: ${before.free / PAS} PAS (${SIGNER.address})`,
+		`[e2e setup] ${account.name} balance: ${before.free / PAS} PAS (${account.address})`,
 	);
 	if (before.sufficient) return;
 
 	console.log(
 		`[e2e setup] balance below ${MIN_BALANCE / PAS} PAS — topping up by ${TOP_UP_AMOUNT / PAS} PAS…`,
 	);
-	await ensureFunded(client, SIGNER.address, MIN_BALANCE, TOP_UP_AMOUNT);
-	const after = await checkBalance(client, SIGNER.address, MIN_BALANCE);
-	console.log(`[e2e setup] SIGNER topped up: ${after.free / PAS} PAS`);
+	await ensureFunded(client, account.address, MIN_BALANCE, TOP_UP_AMOUNT);
+	const after = await checkBalance(client, account.address, MIN_BALANCE);
+	console.log(`[e2e setup] ${account.name} topped up: ${after.free / PAS} PAS`);
+}
+
+export async function fundDeployerIfLow(): Promise<void> {
+	await fundAccountIfLow(SIGNER);
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "bulletin-deploy": "0.7.20-rc.4",
         "commander": "^12.0.0",
         "ink": "^5.2.1",
-        "polkadot-api": "^2.1.2",
+        "polkadot-api": "^2.1.3",
         "react": "^18.3.1",
         "react-devtools-core": "file:stubs/react-devtools-core",
         "tar": "^7.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 0.1.1
       '@polkadot-api/sdk-ink':
         specifier: ^0.7.0
-        version: 0.7.0(@polkadot-api/ink-contracts@0.6.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
+        version: 0.7.0(@polkadot-api/ink-contracts@0.6.2)(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
       '@sentry/node':
         specifier: ^9.47.1
         version: 9.47.1
@@ -76,8 +76,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1(@types/react@18.3.28)(react-devtools-core@file:stubs/react-devtools-core)(react@18.3.1)
       polkadot-api:
-        specifier: ^2.1.2
-        version: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+        specifier: ^2.1.3
+        version: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1296,10 +1296,6 @@ packages:
     resolution: {integrity: sha512-jPa8WSNPZWdy372sBAUnm0nU1XX5mLbmgkOOU39+zpYPSE12mYXyM3r7JuT5IHdAccEJr6qK2DplPFTeNSyq9A==}
     hasBin: true
 
-  '@polkadot-api/cli@0.21.1':
-    resolution: {integrity: sha512-mPOiQxsGW499PgKls/o34vuKQkyPmnUI1wGxy0q/hUl4Dx9AUsTcVUHcm9LvZkHmFq7GfSNFih7Qeh1LXz6L1A==}
-    hasBin: true
-
   '@polkadot-api/cli@0.21.2':
     resolution: {integrity: sha512-Z6BviF0y1xKz0z7pvKTtLnBlbDVFkAGijTOdt7bmMnPz2bSBGBzaEyPH+8iHXhXYHr+q/9w2aet/O0PVpJsaaw==}
     hasBin: true
@@ -1433,11 +1429,6 @@ packages:
     peerDependencies:
       '@polkadot-api/smoldot': '>=0.3'
 
-  '@polkadot-api/sm-provider@0.3.3':
-    resolution: {integrity: sha512-1AEmwhDLyY7l7AZjAgQa5JDWtk3UczOSTdNULZQbZhiXTHzYd9NlcUI+d7/pDGReAGIxN0H+QPsqdXoXst2ZAw==}
-    peerDependencies:
-      '@polkadot-api/smoldot': '>=0.3'
-
   '@polkadot-api/sm-provider@0.3.4':
     resolution: {integrity: sha512-flE9fJL0ESxlKBHOXgWuHgKQJMP059z0BlZP6PRya5yDpUMC5KrtXbvzdaF+o8rDAMxqL+nDf38+P9h/BrmK7A==}
     peerDependencies:
@@ -1445,9 +1436,6 @@ packages:
 
   '@polkadot-api/smoldot@0.3.15':
     resolution: {integrity: sha512-YyV+ytP8FcmKEgLRV7uXepJ5Y6md/7u2F8HKxmkWytmnGXO1z+umg2pHbOxLGifD9V2NhkPY+awpzErtVIzqAA==}
-
-  '@polkadot-api/smoldot@0.4.2':
-    resolution: {integrity: sha512-6gNBSXwdQYfPvLyPq5L/bXPTZiBW9ipvwjhThcOycRVAQs1GqrZ8WyNyuiBI4MIwL8OT4vfHMdg1yv9+4dKdYQ==}
 
   '@polkadot-api/smoldot@0.4.3':
     resolution: {integrity: sha512-M2LpGG0XOeHDIGre2aUr5W3kCz9MjQ8kGlQa1h7aS2XJwlPrjbJe/MCo12FgZKb1TD/ACpqQi9TgO1B2+8F98w==}
@@ -3862,12 +3850,6 @@ packages:
     peerDependencies:
       rxjs: '>=7.8.0'
 
-  polkadot-api@2.1.2:
-    resolution: {integrity: sha512-+fjauJpwePst6uAWuWZ7IQ/JAjTo34UQRwMnj7fvp/CN1UmYOeKuRBB6zL5RNc78Q8LqCbUybHXjevd5MUuN2Q==}
-    hasBin: true
-    peerDependencies:
-      rxjs: '>=7.8.0'
-
   polkadot-api@2.1.3:
     resolution: {integrity: sha512-lbTcLH+oo0f/3+g4hhp7v6WwQKvvzi4v4ClAWispSalLyJV/yRqIbu0ywugpbISXzOL0CWUvYTb8v6CwSSkv3w==}
     hasBin: true
@@ -5235,7 +5217,7 @@ snapshots:
       '@parity/product-sdk-descriptors': 0.4.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-tx': 0.2.3(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       multiformats: 13.4.2
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
       - '@novasamatech/product-sdk'
@@ -5256,7 +5238,7 @@ snapshots:
       '@parity/product-sdk-host': 0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@polkadot-labs/hdkd': 0.0.26
       '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       smoldot: 2.0.40
     transitivePeerDependencies:
       - '@novasamatech/host-api'
@@ -6237,7 +6219,7 @@ snapshots:
       nanoevents: 9.1.0
       nanoid: 5.1.9
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -6253,7 +6235,7 @@ snapshots:
       '@polkadot-api/substrate-bindings': 0.20.2
       '@polkadot/extension-inject': 0.63.1(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@polkadot/api'
       - '@polkadot/util'
@@ -6273,7 +6255,7 @@ snapshots:
     dependencies:
       '@polkadot-api/substrate-bindings': 0.20.1
       '@polkadot-api/utils': 0.4.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -6293,7 +6275,7 @@ snapshots:
       '@scure/sr25519': 2.2.0
       nanoid: 5.1.9
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       scale-ts: 1.6.1
     transitivePeerDependencies:
       - bufferutil
@@ -6549,14 +6531,14 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
-  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))':
+  '@parity/bulletin-sdk@0.3.0(multiformats@13.4.2)(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))':
     dependencies:
       '@ipld/dag-pb': 4.1.5
       '@noble/hashes': 2.2.0
       '@polkadot-labs/hdkd-helpers': 0.0.29
       ipfs-unixfs: 12.0.2
       multiformats: 13.4.2
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
 
   '@parity/dotns-cli@0.6.1(@polkadot/util@14.0.3)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.8.4)':
     dependencies:
@@ -6607,14 +6589,14 @@ snapshots:
 
   '@parity/product-sdk-bulletin@0.4.1(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
-      '@parity/bulletin-sdk': 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))
+      '@parity/bulletin-sdk': 0.3.0(multiformats@13.4.2)(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))
       '@parity/product-sdk-chain-client': 0.4.1(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-descriptors': 0.4.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host': 0.3.0(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger': 0.1.1
       '@parity/product-sdk-tx': 0.2.3(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       multiformats: 13.4.2
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
       - '@novasamatech/product-sdk'
@@ -6629,7 +6611,7 @@ snapshots:
       '@parity/product-sdk-descriptors': 0.4.0(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-host': 0.3.0(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger': 0.1.1
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
       - '@novasamatech/product-sdk'
@@ -6647,7 +6629,7 @@ snapshots:
       '@parity/product-sdk-signer': 0.2.3(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-tx': 0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@polkadot-labs/hdkd-helpers': 0.0.27
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       viem: 2.48.0(typescript@5.9.3)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
@@ -6694,7 +6676,7 @@ snapshots:
 
   '@parity/product-sdk-descriptors@0.4.0(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - bufferutil
       - esbuild
@@ -6705,7 +6687,7 @@ snapshots:
   '@parity/product-sdk-host@0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@parity/product-sdk-logger': 0.1.1
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     optionalDependencies:
       '@novasamatech/host-api': 0.7.9-4
       '@novasamatech/product-sdk': 0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
@@ -6737,7 +6719,7 @@ snapshots:
       '@parity/product-sdk-storage': 0.1.3(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@polkadot-labs/hdkd': 0.0.28
       '@polkadot-labs/hdkd-helpers': 0.0.10
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
       - '@novasamatech/product-sdk'
@@ -6772,7 +6754,7 @@ snapshots:
       '@parity/product-sdk-host': 0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-keys': 0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger': 0.1.1
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     optionalDependencies:
       '@novasamatech/host-api': 0.7.9-4
       '@novasamatech/product-sdk': 0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)
@@ -6844,7 +6826,7 @@ snapshots:
       '@polkadot-labs/hdkd-helpers': 0.0.27
       nanoid: 5.1.9
       neverthrow: 8.2.0
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       qrcode: 1.5.4
       scale-ts: 1.6.1
     transitivePeerDependencies:
@@ -6859,7 +6841,7 @@ snapshots:
       '@parity/product-sdk-keys': 0.2.2(@novasamatech/host-api@0.7.9-4)(@novasamatech/product-sdk@0.7.9-4(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-logger': 0.1.1
       '@polkadot-labs/hdkd-helpers': 0.0.10
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
     transitivePeerDependencies:
       - '@novasamatech/host-api'
       - '@novasamatech/product-sdk'
@@ -7044,41 +7026,6 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@polkadot-api/cli@0.21.1(esbuild@0.27.7)':
-    dependencies:
-      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
-      '@polkadot-api/codegen': 0.22.4
-      '@polkadot-api/ink-contracts': 0.6.2
-      '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.3
-      '@polkadot-api/metadata-compatibility': 0.6.2
-      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
-      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
-      '@polkadot-api/smoldot': 0.4.2
-      '@polkadot-api/substrate-bindings': 0.20.2
-      '@polkadot-api/substrate-client': 0.7.0
-      '@polkadot-api/utils': 0.4.0
-      '@polkadot-api/wasm-executor': 0.2.3
-      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
-      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
-      '@types/node': 25.6.0
-      commander: 14.0.3
-      execa: 9.6.1
-      fs.promises.exists: 1.1.4
-      ora: 9.4.0
-      read-pkg: 10.1.0
-      rollup: 4.60.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
-      rxjs: 7.8.2
-      tsc-prog: 2.3.0(typescript@6.0.3)
-      typescript: 6.0.3
-      write-package: 7.2.0
-    transitivePeerDependencies:
-      - bufferutil
-      - esbuild
-      - supports-color
-      - utf-8-validate
-
   '@polkadot-api/cli@0.21.2(esbuild@0.27.7)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
@@ -7130,9 +7077,9 @@ snapshots:
       '@polkadot-api/substrate-bindings': 0.20.2
       '@polkadot-api/utils': 0.4.0
 
-  '@polkadot-api/common-sdk-utils@0.3.0(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@polkadot-api/common-sdk-utils@0.3.0(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       rxjs: 7.8.2
 
   '@polkadot-api/descriptors@file:stubs/papi-descriptors-stub': {}
@@ -7271,14 +7218,14 @@ snapshots:
     dependencies:
       '@polkadot-api/json-rpc-provider': 0.2.0
 
-  '@polkadot-api/sdk-ink@0.7.0(@polkadot-api/ink-contracts@0.6.2)(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)':
+  '@polkadot-api/sdk-ink@0.7.0(@polkadot-api/ink-contracts@0.6.2)(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:
       '@ethereumjs/rlp': 10.1.1
-      '@polkadot-api/common-sdk-utils': 0.3.0(polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@polkadot-api/common-sdk-utils': 0.3.0(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)
       '@polkadot-api/ink-contracts': 0.6.2
       '@polkadot-api/substrate-bindings': 0.19.0
       abitype: 1.2.3(typescript@5.9.3)
-      polkadot-api: 2.1.2(esbuild@0.27.7)(rxjs@7.8.2)
+      polkadot-api: 2.1.3(esbuild@0.27.7)(rxjs@7.8.2)
       rxjs: 7.8.2
       viem: 2.48.0(typescript@5.9.3)
     transitivePeerDependencies:
@@ -7325,12 +7272,6 @@ snapshots:
       '@polkadot-api/json-rpc-provider-proxy': 0.2.8
       '@polkadot-api/smoldot': 0.3.15
 
-  '@polkadot-api/sm-provider@0.3.3(@polkadot-api/smoldot@0.4.2)':
-    dependencies:
-      '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/json-rpc-provider-proxy': 0.4.0
-      '@polkadot-api/smoldot': 0.4.2
-
   '@polkadot-api/sm-provider@0.3.4(@polkadot-api/smoldot@0.4.3)':
     dependencies:
       '@polkadot-api/json-rpc-provider': 0.2.0
@@ -7341,14 +7282,6 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
       smoldot: 2.0.40
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@polkadot-api/smoldot@0.4.2':
-    dependencies:
-      '@types/node': 25.6.0
-      smoldot: 3.1.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10181,34 +10114,6 @@ snapshots:
       - tsx
       - utf-8-validate
       - yaml
-
-  polkadot-api@2.1.2(esbuild@0.27.7)(rxjs@7.8.2):
-    dependencies:
-      '@polkadot-api/cli': 0.21.1(esbuild@0.27.7)
-      '@polkadot-api/ink-contracts': 0.6.2
-      '@polkadot-api/json-rpc-provider': 0.2.0
-      '@polkadot-api/known-chains': 0.11.3
-      '@polkadot-api/logs-provider': 0.2.0
-      '@polkadot-api/metadata-builders': 0.14.2
-      '@polkadot-api/metadata-compatibility': 0.6.2
-      '@polkadot-api/observable-client': 0.18.5(rxjs@7.8.2)
-      '@polkadot-api/pjs-signer': 0.7.2
-      '@polkadot-api/polkadot-signer': 0.1.6
-      '@polkadot-api/signer': 0.3.2
-      '@polkadot-api/sm-provider': 0.3.3(@polkadot-api/smoldot@0.4.2)
-      '@polkadot-api/smoldot': 0.4.2
-      '@polkadot-api/substrate-bindings': 0.20.2
-      '@polkadot-api/substrate-client': 0.7.0
-      '@polkadot-api/utils': 0.4.0
-      '@polkadot-api/ws-middleware': 0.3.3(rxjs@7.8.2)
-      '@polkadot-api/ws-provider': 0.9.0(rxjs@7.8.2)
-      '@rx-state/core': 0.1.4(rxjs@7.8.2)
-      rxjs: 7.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - esbuild
-      - supports-color
-      - utf-8-validate
 
   polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2):
     dependencies:

--- a/tools/list-registry-apps.ts
+++ b/tools/list-registry-apps.ts
@@ -24,18 +24,10 @@
  *   bun tools/list-registry-apps.ts
  */
 
-import { ContractManager, type CdmJson } from "@parity/product-sdk-contracts";
-import { createDevSigner, getDevPublicKey } from "@parity/product-sdk-tx";
-import { ss58Encode } from "@parity/product-sdk-address";
 import type { HexString } from "polkadot-api";
 import { fetchBulletinJson, getBulletinGateway } from "../src/utils/bulletinGateway.js";
 import { getConnection, destroyConnection } from "../src/utils/connection.js";
-import {
-    PLAYGROUND_REGISTRY_CONTRACT,
-    withRequiredLiveContractAddresses,
-    withoutReviveTraceNoise,
-} from "../src/utils/contractManifest.js";
-import cdmJson from "../cdm.json";
+import { getReadOnlyRegistryContract } from "../src/utils/registry.js";
 
 interface AppMetadata {
     name?: string;
@@ -66,19 +58,9 @@ async function probePublicGithub(repoUrl: string): Promise<{ ok: boolean; status
 async function main(): Promise<number> {
     const client = await getConnection();
     try {
-        const manifest = await withRequiredLiveContractAddresses(
-            cdmJson as unknown as CdmJson,
-            client.raw.assetHub,
-        );
-        const aliceSigner = createDevSigner("Alice");
-        const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
-        const manager = await ContractManager.fromClient(manifest, client.raw.assetHub, {
-            defaultSigner: aliceSigner,
-            defaultOrigin: aliceAddress,
-        });
-        const registry = manager.getContract(PLAYGROUND_REGISTRY_CONTRACT);
+        const registry = await getReadOnlyRegistryContract(client.raw.assetHub);
 
-        const res = await withoutReviveTraceNoise(() => registry.getApps.query(0, 100));
+        const res = await registry.getApps.query(0, 100);
         const value = res.value as { entries: RegistryEntry[]; total: number };
         console.log(`live registry has ${value.total} app(s); inspecting up to 100:\n`);
 

--- a/tools/probe-registry-resolution.ts
+++ b/tools/probe-registry-resolution.ts
@@ -19,9 +19,8 @@
  * Diagnostic probe for issue paritytech/playground-cli#74.
  *
  * Compares the playground-registry address that the CDM meta-registry
- * currently resolves to (the path `dot mod` takes since 2026-04-30) against
- * the address baked into `cdm.json` (the path the e2e setup helper still
- * uses), and reports whether a target domain is registered against each.
+ * currently resolves to against the address baked into `cdm.json`, and
+ * reports whether a target domain is registered against each.
  *
  * Usage:
  *   bun tools/probe-registry-resolution.ts                 # default domain
@@ -35,6 +34,7 @@
 import { ContractManager, type CdmJson } from "@parity/product-sdk-contracts";
 import { createDevSigner, getDevPublicKey } from "@parity/product-sdk-tx";
 import { ss58Encode } from "@parity/product-sdk-address";
+import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 import type { HexString } from "polkadot-api";
 import { getConnection, destroyConnection } from "../src/utils/connection.js";
 import {
@@ -76,7 +76,7 @@ async function queryDomain(
     const manifest = withAddressOverride(cdmJson as unknown as CdmJson, address);
     const aliceSigner = createDevSigner("Alice");
     const aliceAddress = ss58Encode(getDevPublicKey("Alice"));
-    const manager = await ContractManager.fromClient(manifest, rawClient, {
+    const manager = await ContractManager.fromClient(manifest, rawClient, paseo_asset_hub, {
         defaultSigner: aliceSigner,
         defaultOrigin: aliceAddress,
     });

--- a/tools/register-e2e-fixtures.ts
+++ b/tools/register-e2e-fixtures.ts
@@ -26,14 +26,18 @@
 
 import { parseArgs } from "node:util";
 import { destroyConnection } from "../src/utils/connection.js";
+import { checkAllowance, ensureAllowance } from "../src/utils/account/allowance.js";
 import { publishToPlayground, normalizeDomain } from "../src/utils/deploy/playground.js";
+import { getReadOnlyRegistryContract } from "../src/utils/registry.js";
 import { resolveSigner } from "../src/utils/signer.js";
 import { SIGNER, E2E_DOMAINS } from "../e2e/cli/fixtures/accounts.js";
-import { destroyTestClient } from "../e2e/cli/helpers/chain.js";
+import { destroyTestClient, getTestClient } from "../e2e/cli/helpers/chain.js";
 import { fundAccountIfLow } from "../e2e/cli/setup/fund.js";
 
 const DEFAULT_TEMPLATE_DOMAIN = "dot-cli-mod-fixture.dot";
 const DEFAULT_TEMPLATE_REPO = "https://github.com/paritytech/Rock-Paper-Scissors";
+const REGISTRY_READBACK_ATTEMPTS = 5;
+const REGISTRY_READBACK_DELAY_MS = 2_000;
 
 interface Fixture {
 	domain: string;
@@ -88,6 +92,71 @@ function logPlan(fixtures: readonly Fixture[]): void {
 	console.log();
 }
 
+function errorText(error: unknown): string {
+	if (error instanceof Error) return `${error.name}: ${error.message}`;
+	return String(error);
+}
+
+function isBulletinTeardownNoise(error: unknown): boolean {
+	const text = error instanceof Error ? `${error.name}: ${error.message}\n${error.stack ?? ""}` : String(error);
+	return (
+		text.includes("ChainHead disjointed") ||
+		(text.includes("UnsubscriptionError") && text.includes("Not connected"))
+	);
+}
+
+function suppressStandaloneBulletinTeardownNoise(): () => void {
+	const onUncaught = (error: unknown) => {
+		if (isBulletinTeardownNoise(error)) {
+			console.warn(`ignored Bulletin client teardown noise: ${errorText(error)}`);
+			return;
+		}
+		process.off("uncaughtException", onUncaught);
+		throw error;
+	};
+
+	process.prependListener("uncaughtException", onUncaught);
+	return () => process.off("uncaughtException", onUncaught);
+}
+
+async function delay(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatAllowance(status: Awaited<ReturnType<typeof checkAllowance>>): string {
+	if (!status.authorized) return "not authorized";
+	return `${status.remainingTxs} tx / ${status.remainingBytes} bytes`;
+}
+
+async function ensureFixtureStorageAllowance(address: string): Promise<void> {
+	const client = await getTestClient();
+	const before = await checkAllowance(client, address);
+	console.log(`Bulletin allowance ${formatAllowance(before)}`);
+
+	await ensureAllowance(client, address);
+
+	const after = await checkAllowance(client, address);
+	if (formatAllowance(after) !== formatAllowance(before)) {
+		console.log(`Bulletin allowance ${formatAllowance(after)}`);
+	}
+	console.log();
+}
+
+async function verifyRegistryEntry(domain: string, metadataCid: string): Promise<void> {
+	const client = await getTestClient();
+	const registry = await getReadOnlyRegistryContract(client.raw.assetHub);
+
+	for (let attempt = 1; attempt <= REGISTRY_READBACK_ATTEMPTS; attempt++) {
+		const result = await registry.getMetadataUri.query(domain);
+		const value = result.value as { isSome?: boolean; value?: string } | undefined;
+		if (result.success && value?.isSome && value.value === metadataCid) return;
+
+		if (attempt < REGISTRY_READBACK_ATTEMPTS) await delay(REGISTRY_READBACK_DELAY_MS);
+	}
+
+	throw new Error(`Registry readback failed for ${domain}: expected metadata CID ${metadataCid}`);
+}
+
 async function registerFixture(
 	fixture: Fixture,
 	signer: Awaited<ReturnType<typeof resolveSigner>>,
@@ -110,7 +179,10 @@ async function registerFixture(
 		},
 	});
 
+	await verifyRegistryEntry(result.fullDomain, result.metadataCid);
+
 	const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+	console.log("  verified    registry readback");
 	console.log(`  published   ${result.metadataCid} (${elapsed}s)`);
 	console.log();
 }
@@ -145,11 +217,13 @@ async function main(): Promise<number> {
 	}
 
 	const signer = await resolveSigner({ suri: values.suri ?? SIGNER.suri });
+	const restoreErrorHandling = suppressStandaloneBulletinTeardownNoise();
 	try {
 		logPlan(fixtures);
 		console.log(`signer ${signer.address} (${signer.source})`);
 		await fundAccountIfLow({ name: "fixture signer", address: signer.address });
 		console.log();
+		await ensureFixtureStorageAllowance(signer.address);
 
 		for (const [index, fixture] of fixtures.entries()) {
 			await registerFixture(fixture, signer, index + 1, fixtures.length);
@@ -157,6 +231,7 @@ async function main(): Promise<number> {
 		console.log(`registered ${fixtures.length} fixture(s)`);
 		return 0;
 	} finally {
+		restoreErrorHandling();
 		signer.destroy();
 		destroyTestClient();
 		destroyConnection();

--- a/tools/register-e2e-fixtures.ts
+++ b/tools/register-e2e-fixtures.ts
@@ -16,182 +16,149 @@
 // limitations under the License.
 
 /**
- * Register all permanent E2E fixture domains on the live playground-registry
- * contract, signed by the dedicated E2E deployer (SIGNER from
- * e2e/cli/fixtures/accounts.ts). Same-owner re-publish is permitted by the
- * registry contract, so re-running this tool simply updates the metadata in
- * place — idempotent.
+ * Register the fixed E2E playground-registry entries against the active chain.
  *
- * Generalises the old `register-mod-fixture.ts`. The mod fixture
- * (`dot-cli-mod-fixture.dot`) is now one entry in a unified FIXTURES table
- * alongside the new per-cell deploy domains added in Phase 3 (foundry, cdm,
- * hardhat, multi).
- *
- * All fixtures are registered with `visibility = 0` (private) so they don't
- * clutter the public playground.dot grid. The CLI tests that hit these
- * domains use direct `getMetadataUri` queries (`dot mod <domain>`,
- * registry-readback assertions), which are unaffected by visibility.
- *
- * Usage:
- *   bun tools/register-e2e-fixtures.ts                        # register all 5
- *   bun tools/register-e2e-fixtures.ts --domain e2efnd00      # one only
- *   bun tools/register-e2e-fixtures.ts --suri //Alice         # custom signer
- *
- * Auto-tops-up SIGNER from the CLI's funder chain if balance is too low to
- * cover the publish extrinsic, matching the e2e setup behavior.
+ * Uses the same publish path as `dot deploy --playground`: metadata is stored
+ * through `publishToPlayground()`, then the registry entry is written by the
+ * fixture signer. Re-running is idempotent for domains already owned by that
+ * signer.
  */
 
+import { parseArgs } from "node:util";
+import { destroyConnection } from "../src/utils/connection.js";
+import { publishToPlayground, normalizeDomain } from "../src/utils/deploy/playground.js";
 import { resolveSigner } from "../src/utils/signer.js";
-import { publishToPlayground } from "../src/utils/deploy/playground.js";
-import { getConnection, destroyConnection } from "../src/utils/connection.js";
-import { ensureFunded, checkBalance, MIN_BALANCE } from "../src/utils/account/funding.js";
-import { DEDICATED_E2E_DEPLOYER_MNEMONIC } from "../e2e/cli/fixtures/accounts.js";
+import { SIGNER, E2E_DOMAINS } from "../e2e/cli/fixtures/accounts.js";
+import { destroyTestClient } from "../e2e/cli/helpers/chain.js";
+import { fundAccountIfLow } from "../e2e/cli/setup/fund.js";
+
+const DEFAULT_TEMPLATE_DOMAIN = "dot-cli-mod-fixture.dot";
+const DEFAULT_TEMPLATE_REPO = "https://github.com/paritytech/Rock-Paper-Scissors";
 
 interface Fixture {
 	domain: string;
 	repositoryUrl: string | null;
-	purpose: string;
 }
 
-/**
- * Permanent E2E fixture domains. Registering them is a one-shot bootstrap
- * step per registry-contract lifetime; see Phase 3 of the spec.
- *
- * `dot-cli-mod-fixture.dot` is the only one with a repository URL, because
- * `dot mod <domain>` only works when the registered metadata advertises a
- * source repo. The other domains are deploy targets — same-owner re-publish
- * cycles their metadata on every CI run.
- */
 const FIXTURES: readonly Fixture[] = [
 	{
-		domain: "dot-cli-mod-fixture.dot",
-		repositoryUrl: "https://github.com/paritytech/Rock-Paper-Scissors",
-		purpose: "dot mod E2E fixture (clones into a fresh repo)",
+		domain: process.env.TEST_TEMPLATE_DOMAIN ?? DEFAULT_TEMPLATE_DOMAIN,
+		repositoryUrl: process.env.TEST_TEMPLATE_REPO ?? DEFAULT_TEMPLATE_REPO,
 	},
-	{
-		domain: "e2efnd00",
-		repositoryUrl: null,
-		purpose: "pr-deploy-foundry cell",
-	},
-	{
-		domain: "e2ecdm00",
-		repositoryUrl: null,
-		purpose: "pr-deploy-cdm cell",
-	},
-	{
-		domain: "e2ehat00",
-		repositoryUrl: null,
-		purpose: "nightly-deploy-hardhat cell",
-	},
-	{
-		domain: "e2emul00",
-		repositoryUrl: null,
-		purpose: "nightly-deploy-multi cell",
-	},
+	...[
+		E2E_DOMAINS.preflight,
+		E2E_DOMAINS.storage,
+		E2E_DOMAINS.redeploy,
+		E2E_DOMAINS.collision,
+		E2E_DOMAINS.foundry,
+		E2E_DOMAINS.cdm,
+		E2E_DOMAINS.hardhat,
+		E2E_DOMAINS.multi,
+	].map((domain) => ({ domain, repositoryUrl: null })),
 ];
 
-const DEFAULT_SURI = `${DEDICATED_E2E_DEPLOYER_MNEMONIC}//e2e-deployer`;
-const PAS = 10_000_000_000n;
-const TOPUP_TARGET = 500n * PAS;
-const TOPUP_AMOUNT = 1000n * PAS;
-
-interface Args {
-	onlyDomain: string | null;
-	suri: string;
+function usage(): string {
+	return [
+		"Usage: bun tools/register-e2e-fixtures.ts [--domain <domain>] [--suri <suri>]",
+		"",
+		"Fixtures:",
+		...FIXTURES.map((fixture) => `  ${normalizeDomain(fixture.domain).fullDomain}`),
+	].join("\n");
 }
 
-function parseArgs(argv: string[]): Args {
-	const args: Args = { onlyDomain: null, suri: DEFAULT_SURI };
-	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		const next = argv[i + 1];
-		if (arg === "--domain" && next) {
-			args.onlyDomain = next;
-			i++;
-		} else if (arg === "--suri" && next) {
-			args.suri = next;
-			i++;
-		} else if (arg === "--help" || arg === "-h") {
-			console.log("Usage: bun tools/register-e2e-fixtures.ts [--domain X] [--suri Z]");
-			console.log();
-			console.log("Default: registers all permanent E2E fixture domains:");
-			for (const f of FIXTURES) {
-				console.log(`  ${f.domain.padEnd(28)}  — ${f.purpose}`);
-			}
-			process.exit(0);
-		} else {
-			throw new Error(`Unknown arg: ${arg}`);
-		}
-	}
-	return args;
+function selectedFixtures(domain?: string): readonly Fixture[] {
+	if (!domain) return FIXTURES;
+
+	const requested = normalizeDomain(domain).fullDomain.toLowerCase();
+	return FIXTURES.filter(
+		(fixture) => normalizeDomain(fixture.domain).fullDomain.toLowerCase() === requested,
+	);
 }
 
-async function topUpIfLow(client: Awaited<ReturnType<typeof getConnection>>, address: string): Promise<void> {
-	const balance = await checkBalance(client, address, TOPUP_TARGET);
-	console.log(`signer balance: ${balance.free / PAS} PAS`);
-	if (!balance.sufficient) {
-		console.log(`balance below ${TOPUP_TARGET / PAS} PAS — topping up by ${TOPUP_AMOUNT / PAS} PAS…`);
-		await ensureFunded(client, address, TOPUP_TARGET, TOPUP_AMOUNT);
-		const after = await checkBalance(client, address, MIN_BALANCE);
-		console.log(`topped up: ${after.free / PAS} PAS`);
+function describeFixture(fixture: Fixture): string {
+	const fullDomain = normalizeDomain(fixture.domain).fullDomain;
+	return `${fullDomain}  repo=${fixture.repositoryUrl ?? "(none)"}`;
+}
+
+function logPlan(fixtures: readonly Fixture[]): void {
+	console.log(`registering ${fixtures.length} fixture(s) as private Playground apps:`);
+	for (const fixture of fixtures) {
+		console.log(`  - ${describeFixture(fixture)}`);
 	}
 	console.log();
 }
 
-async function registerOne(fixture: Fixture, signer: Awaited<ReturnType<typeof resolveSigner>>): Promise<void> {
-	console.log(`▶ registering ${fixture.domain}`);
-	console.log(`  purpose:    ${fixture.purpose}`);
-	console.log(`  repository: ${fixture.repositoryUrl ?? "(none)"}`);
+async function registerFixture(
+	fixture: Fixture,
+	signer: Awaited<ReturnType<typeof resolveSigner>>,
+	index: number,
+	total: number,
+): Promise<void> {
+	const fullDomain = normalizeDomain(fixture.domain).fullDomain;
+	const start = Date.now();
+	console.log(`[${index}/${total}] ${fullDomain}`);
+	console.log(`  repository  ${fixture.repositoryUrl ?? "(none)"}`);
+	console.log("  visibility  private");
+
 	const result = await publishToPlayground({
 		domain: fixture.domain,
 		publishSigner: signer,
 		repositoryUrl: fixture.repositoryUrl,
 		isPrivate: true,
 		onLogEvent: (event) => {
-			if (event.kind === "info") console.log(`    • ${event.message}`);
+			if (event.kind === "info") console.log(`  ${event.message}`);
 		},
 	});
-	console.log(`  ✓ published ${result.fullDomain}`);
-	console.log(`    metadataCid  ${result.metadataCid}`);
+
+	const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+	console.log(`  published   ${result.metadataCid} (${elapsed}s)`);
 	console.log();
 }
 
 async function main(): Promise<number> {
-	const args = parseArgs(process.argv.slice(2));
+	const { values } = parseArgs({
+		options: {
+			domain: { type: "string" },
+			help: { type: "boolean", short: "h" },
+			suri: { type: "string" },
+		},
+	});
 
-	const normalize = (s: string): string => s.replace(/\.dot$/i, "");
-	const targets = args.onlyDomain
-		? FIXTURES.filter((f) => normalize(f.domain) === normalize(args.onlyDomain ?? ""))
-		: FIXTURES;
+	if (values.help) {
+		console.log(usage());
+		return 0;
+	}
 
-	if (targets.length === 0) {
-		console.error(`No fixture matches --domain ${args.onlyDomain}`);
-		console.error(`Known fixtures: ${FIXTURES.map((f) => f.domain).join(", ")}`);
+	let fixtures: readonly Fixture[];
+	try {
+		fixtures = selectedFixtures(values.domain);
+	} catch (err) {
+		console.error(err instanceof Error ? err.message : String(err));
+		console.error(usage());
 		return 2;
 	}
 
-	console.log(`registering ${targets.length} fixture(s):`);
-	for (const f of targets) console.log(`  - ${f.domain}`);
-	console.log();
+	if (fixtures.length === 0) {
+		console.error(`No fixture matches "${values.domain}".`);
+		console.error(usage());
+		return 2;
+	}
 
-	const signer = await resolveSigner({ suri: args.suri });
-	console.log(`signer  ${signer.address} (${signer.source})`);
-	console.log();
-
+	const signer = await resolveSigner({ suri: values.suri ?? SIGNER.suri });
 	try {
-		const client = await getConnection();
-		// Balance checked once; TOPUP_TARGET (500 PAS) gives ~1000× headroom
-		// for the ~0.1 PAS/publish cost across all 5 fixtures.
-		await topUpIfLow(client, signer.address);
-		for (const fixture of targets) {
-			await registerOne(fixture, signer);
-		}
-		console.log(`✓ all ${targets.length} fixture(s) registered`);
+		logPlan(fixtures);
+		console.log(`signer ${signer.address} (${signer.source})`);
+		await fundAccountIfLow({ name: "fixture signer", address: signer.address });
 		console.log();
-		console.log(`verify with: bun tools/probe-registry-resolution.ts <domain>`);
+
+		for (const [index, fixture] of fixtures.entries()) {
+			await registerFixture(fixture, signer, index + 1, fixtures.length);
+		}
+		console.log(`registered ${fixtures.length} fixture(s)`);
 		return 0;
 	} finally {
 		signer.destroy();
+		destroyTestClient();
 		destroyConnection();
 	}
 }


### PR DESCRIPTION
## Summary
- rewrites `tools/register-e2e-fixtures.ts` as a thin wrapper over the current shared deploy path (`publishToPlayground`)
- reuses the E2E fixture signer/domain constants and shared funding helper instead of duplicating fixture and balance logic
- keeps useful operator logs: run plan, signer, funding state, Bulletin allowance state, fixture repo/visibility, metadata progress, CID, elapsed time, and readback verification
- grants/checks legacy Bulletin storage authorization for the fixture signer before metadata uploads, matching the current non-mobile E2E signer path
- handles standalone-script Bulletin client teardown noise (`ChainHead disjointed` / RxJS `UnsubscriptionError: Not connected`) without adding redundant logic to core deploy code
- verifies each registry publish via `getMetadataUri` before reporting the fixture as published
- moves registry read helpers/tools onto the shared `getReadOnlyRegistryContract` path
- updates the registry probe to the current product-sdk `ContractManager.fromClient(..., descriptor, ...)` API
- aligns direct `polkadot-api` to `^2.1.3` so local client types match product-sdk-contracts

## Runtime State
- All 9 fixture domains were registered and read back from the live registry on paseo-next-v2.
- Default fixture signer: `5DtoCFYY2gqk65CkrJAc44LCPZDvrxQCkCvTc2AoX28bCu65` (`SIGNER.suri`, local mnemonic-derived dev signer).

## Verification
- `bun tools/register-e2e-fixtures.ts --help`
- invalid-domain smoke
- direct registry readback for all 9 fixture domains
- `npx tsc --noEmit --pretty false`
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm build`
- `pnpm test`
