### PR TITLE
fix: dev-funded init flow + silence Sentry post-teardown noise

### DIFF
--- a/.changeset/init-funding-and-rejection-silence.md
+++ b/.changeset/init-funding-and-rejection-silence.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": patch
+---
+
+`dot init` now funds the product-derived account from the shared bulletin-deploy dev signer (1 PAS, idempotent: skipped when the recipient already holds ≥0.1 PAS) instead of submitting an explicit `Revive.map_account`. paseo-next-v2's `pallet_revive::AutoMapper` handles the SS58 ↔ H160 mapping on the first state-changing tx; the funding step gives that tx enough PAS to land. A belt-and-braces `Revive.map_account` still fires if `checkMapping` returns false after funding, so cold-start accounts that pre-existed the AutoMapper runtime upgrade aren't left stuck.
+
+Also silences the recurring `DestroyedError: Client destroyed` block printed on every `dot init` exit. Root cause was `@sentry/node`'s default `OnUnhandledRejection` integration printing the rejection via `console.warn` + `console.error`; we now override it with `mode: 'none'` so Sentry still captures the rejection with the full `mechanism: onunhandledrejection` metadata but skips the print. Benign polkadot-api teardown artifacts are dropped via `beforeSend` so they don't reach the Failures dashboard either.

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -18,6 +18,7 @@ import { useState, useEffect } from "react";
 import { Row, Section, Callout, type MarkKind } from "../../utils/ui/theme/index.js";
 import { getConnection } from "../../utils/connection.js";
 import { getSessionSigner, type SessionHandle } from "../../utils/auth.js";
+import { topUpFromBulletinDev } from "../../utils/account/bulletinTopUp.js";
 import { checkMapping, ensureMapped } from "../../utils/account/mapping.js";
 import { DEFAULT_ENV, PLAYGROUND_PRODUCT_ID } from "../../config.js";
 import {
@@ -83,7 +84,7 @@ export function AccountSetup({
 }) {
     const [steps, setSteps] = useState<StepState[]>([
         { label: "allowances", status: "pending" },
-        { label: "mapping", status: "pending" },
+        { label: "funding", status: "pending" },
     ]);
     const [phonePrompt, setPhonePrompt] = useState<PhonePrompt | null>(null);
 
@@ -134,10 +135,9 @@ export function AccountSetup({
             const env = DEFAULT_ENV;
 
             // ── Step 0: Resource allowances ─────────────────────────────────
-            // Order matters: allowances must come before mapping because the
-            // `Revive.map_account` transaction is paid in PGAS on paseo-next-v2,
-            // and the user only has PGAS sponsoring after SmartContractAllowance
-            // is granted.
+            // Allowances are requested against the product-derived account
+            // (host-papp's `productAccountId = [PLAYGROUND_PRODUCT_ID, 0]`),
+            // which is the same SS58 used everywhere else in this flow.
             update(0, { status: "active", value: "checking…", valueTone: "muted" });
             let allowancesOk = false;
             try {
@@ -160,7 +160,7 @@ export function AccountSetup({
                     });
                     setPhonePrompt({
                         step: 1,
-                        total: 2,
+                        total: 1,
                         label: "grant resource allowances",
                     });
                     const outcomes = await requestResourceAllocation(
@@ -206,7 +206,24 @@ export function AccountSetup({
                 return;
             }
 
-            // ── Step 1: Revive account mapping ──────────────────────────────
+            // ── Step 1: Top up the product-derived account ──────────────────
+            // paseo-next-v2's pallet_revive::AutoMapper creates the H160
+            // mapping on the first state-changing tx the product account
+            // submits, so we don't run an explicit `Revive.map_account` here
+            // by default. We mirror bulletin-deploy's `attemptTestnetTopUp`
+            // and ensure the product-derived account has enough PAS to cover
+            // the auto-map trigger fee bulletin-deploy submits during
+            // `dot deploy`. Reuses the same dev source signer bulletin-deploy
+            // uses so the funding lands on a chain that is actually
+            // pre-funded (paseo-next-v2).
+            //
+            // Belt-and-braces: after funding, re-check the on-chain mapping
+            // and submit an explicit `Revive.map_account` if AutoMapper did
+            // not fire (e.g. the account pre-existed the AutoMapper runtime
+            // upgrade and a fresh `OnNewAccount` was never triggered). This
+            // covers the cold-start case the deploy preflight error message
+            // ("Account is not mapped in Revive. Run `dot init`...") would
+            // otherwise leave the user stuck on.
             if (!allowancesOk) {
                 update(1, {
                     status: "skipped",
@@ -216,30 +233,31 @@ export function AccountSetup({
                 finish(false);
                 return;
             }
-            update(1, { status: "active", value: "checking…", valueTone: "muted" });
+            update(1, { status: "active", value: "checking balance…", valueTone: "muted" });
             try {
+                const result = await topUpFromBulletinDev(client, address);
+                if (cancelled) return;
+                let detail = result.skipped ? "already funded" : "+1 PAS";
+
+                // `ensureMapped` is a no-op when the account is already
+                // mapped (the underlying SDK helper hard-errors only on
+                // mapping failures we want to surface). `checkMapping`
+                // catches the common case so we don't print "mapping…" on
+                // every re-run.
                 const mapped = await checkMapping(client, address);
                 if (cancelled) return;
-                if (mapped) {
-                    update(1, { status: "ok", value: "mapped", valueTone: "muted" });
-                } else {
+                if (!mapped) {
                     update(1, {
                         status: "active",
-                        value: "approve on your Polkadot mobile app…",
+                        value: "registering H160 mapping…",
                         valueTone: "muted",
-                    });
-                    setPhonePrompt({
-                        step: 2,
-                        total: 2,
-                        label: "map account to H160",
                     });
                     await ensureMapped(client, address, session.signer);
                     if (cancelled) return;
-                    setPhonePrompt(null);
-                    update(1, { status: "ok", value: "mapped", valueTone: "muted" });
+                    detail = `${detail} + mapped`;
                 }
+                update(1, { status: "ok", value: detail, valueTone: "muted" });
             } catch (err) {
-                setPhonePrompt(null);
                 update(1, {
                     status: "failed",
                     error: describe(err),

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -77,6 +77,25 @@ function sanitizeTelemetryValue(value: unknown, depth = 0): unknown {
     return record;
 }
 
+/**
+ * Drop the benign `DestroyedError: Client destroyed` events that polkadot-api
+ * emits when its chainHead teardown races a WS disconnect. The error is
+ * already filtered out of the user-visible stderr write by
+ * `process-guard.ts::isBenignUnsubscriptionError`; mirror that filter here so
+ * Sentry's Failures dashboard isn't inundated with the same teardown noise.
+ * Matches the upstream `Error.name` + `.message` shape from
+ * `@polkadot-api/raw-client/.../DestroyedError.mjs`.
+ */
+function isBenignDestroyedErrorEvent(event: Record<string, unknown>): boolean {
+    const exception = event.exception as
+        | { values?: Array<{ type?: string; value?: string }> }
+        | undefined;
+    if (!exception?.values?.length) return false;
+    return exception.values.some(
+        (entry) => entry?.type === "DestroyedError" && /client destroyed/i.test(entry.value ?? ""),
+    );
+}
+
 export function sanitizeSentryEvent<T extends Record<string, unknown>>(event: T): T {
     const writable = event as Record<string, unknown>;
     writable["server_name"] = anonymousServerName();
@@ -116,7 +135,29 @@ export async function initTelemetry(options: TelemetryInitOptions = {}): Promise
             tracesSampleRate: 1,
             environment: process.env.CI ? "ci" : "local",
             serverName: anonymousServerName(),
+            // Override `@sentry/node`'s default `OnUnhandledRejection`
+            // integration with `mode: 'none'`. The default 'warn' mode
+            // unconditionally prints
+            //   console.warn("This error originated either by ...")
+            //   console.error(reason.stack)
+            // via `consoleSandbox`, which splits the preamble and the
+            // error-type lines across two separate `process.stderr.write`
+            // calls; the bootstrap.ts stderr filter requires both substrings
+            // in a single write so it never matches. `mode: 'none'` keeps the
+            // capture path (`Sentry.captureException` with the full
+            // `mechanism: { handled: false, type: 'onunhandledrejection' }`
+            // metadata, see `@sentry/node-core/.../onunhandledrejection.js`)
+            // and skips the print. `beforeSend` below drops the benign
+            // polkadot-api `DestroyedError: Client destroyed` teardown
+            // artifacts so they don't spam Sentry.
+            integrations: (defaultIntegrations) => [
+                ...defaultIntegrations.filter(
+                    (integration) => integration.name !== "OnUnhandledRejection",
+                ),
+                Sentry.onUnhandledRejectionIntegration({ mode: "none" }),
+            ],
             beforeSend(event) {
+                if (isBenignDestroyedErrorEvent(event)) return null;
                 return sanitizeSentryEvent(
                     event as unknown as Record<string, unknown>,
                 ) as unknown as typeof event;

--- a/src/utils/account/bulletinTopUp.test.ts
+++ b/src/utils/account/bulletinTopUp.test.ts
@@ -1,0 +1,191 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Tests for the bulletin-deploy-style dev top-up.
+ *
+ * We mock `@parity/product-sdk-tx::submitAndWatch` to observe what got
+ * submitted without touching the network. The real `polkadot-api` `Enum(...)`
+ * is used so changes to the `Balances.transfer_allow_death` dest variant
+ * ("Id" vs "Index" etc.) fail loudly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSubmitAndWatch = vi
+    .fn<(tx: unknown, signer: unknown, options?: unknown) => Promise<unknown>>()
+    .mockResolvedValue({
+        ok: true,
+    });
+
+vi.mock("@parity/product-sdk-tx", () => ({
+    submitAndWatch: (...args: unknown[]) =>
+        mockSubmitAndWatch(args[0], args[1] as unknown, args[2] as unknown),
+}));
+
+const { topUpFromBulletinDev, DevFunderExhaustedError } = await import("./bulletinTopUp.js");
+
+const RECIPIENT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+// SS58 of the bare-master account derived from the standard dev mnemonic with
+// empty derivation; see the pubkey assertion at the bottom of the file.
+const DEV_FUNDER = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
+const ONE_PAS = 1_000_000_000_000n;
+const SKIP_FLOOR = 100_000_000_000n;
+const SOURCE_BUFFER = 1_000_000_000_000n;
+const FUNDER_REQUIRED = ONE_PAS + SOURCE_BUFFER;
+// Plenty of headroom so the preflight balance check passes in tests that
+// expect the transfer to fire. Bumping this on a real change to the buffer
+// would require revisiting `bulletinTopUp.ts::SOURCE_BUFFER` first.
+const FUNDER_HEALTHY = FUNDER_REQUIRED * 10n;
+
+function makeClient(balances: Record<string, bigint>) {
+    const transferFactory = vi.fn().mockImplementation((args: unknown) => ({
+        __kind: "transfer_allow_death",
+        args,
+    }));
+    const getValue = vi.fn().mockImplementation(async (address: string) => ({
+        data: { free: balances[address] ?? 0n, reserved: 0n, frozen: 0n },
+    }));
+    return {
+        client: {
+            assetHub: {
+                query: {
+                    System: {
+                        Account: { getValue },
+                    },
+                },
+                tx: {
+                    Balances: {
+                        transfer_allow_death: transferFactory,
+                    },
+                },
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: minimal PaseoClient shape for the unit under test
+        } as any,
+        transferFactory,
+        getValue,
+    };
+}
+
+beforeEach(() => {
+    mockSubmitAndWatch.mockClear();
+});
+
+describe("topUpFromBulletinDev", () => {
+    it("skips the transfer when the recipient is already at the floor (>= check)", async () => {
+        // Exact-floor boundary: `recipient.free >= SKIP_TRANSFER_THRESHOLD`
+        // SKIPS. If a future refactor flips the inequality this test fails.
+        const { client, transferFactory } = makeClient({
+            [RECIPIENT]: SKIP_FLOOR,
+            [DEV_FUNDER]: FUNDER_HEALTHY,
+        });
+        const result = await topUpFromBulletinDev(client, RECIPIENT);
+        expect(result).toEqual({ skipped: true });
+        expect(transferFactory).not.toHaveBeenCalled();
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
+    it("sends 1 PAS via transfer_allow_death when below the floor", async () => {
+        const { client, transferFactory } = makeClient({
+            [RECIPIENT]: SKIP_FLOOR - 1n,
+            [DEV_FUNDER]: FUNDER_HEALTHY,
+        });
+        const result = await topUpFromBulletinDev(client, RECIPIENT);
+        expect(result).toEqual({ skipped: false, transferred: ONE_PAS });
+        expect(transferFactory).toHaveBeenCalledTimes(1);
+        const [args] = transferFactory.mock.calls[0];
+        expect(args).toMatchObject({
+            dest: { type: "Id", value: RECIPIENT },
+            value: ONE_PAS,
+        });
+        expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
+        const [, , options] = mockSubmitAndWatch.mock.calls[0];
+        expect(options).toEqual({ waitFor: "finalized" });
+    });
+
+    it("tops up a zero-balance recipient when the funder is healthy", async () => {
+        const { client, transferFactory } = makeClient({ [DEV_FUNDER]: FUNDER_HEALTHY });
+        const result = await topUpFromBulletinDev(client, RECIPIENT);
+        expect(result.skipped).toBe(false);
+        expect(transferFactory).toHaveBeenCalledTimes(1);
+    });
+
+    it("short-circuits without submitting if the recipient IS the dev funder", async () => {
+        // Hypothetical: a user's product-derived account collides with the
+        // bare-master dev address. Mirrors bulletin-deploy's
+        // `attemptTestnetTopUp` self-transfer guard.
+        const { client, transferFactory } = makeClient({ [DEV_FUNDER]: 0n });
+        const result = await topUpFromBulletinDev(client, DEV_FUNDER);
+        expect(result).toEqual({ skipped: true });
+        expect(transferFactory).not.toHaveBeenCalled();
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
+    it("throws DevFunderExhaustedError before broadcasting when the funder is low", async () => {
+        // Funder free balance is below the `ONE_PAS + SOURCE_BUFFER` floor.
+        // The error must fire BEFORE `submitAndWatch` so we don't spam the
+        // chain with reverting transfers.
+        const { client, transferFactory } = makeClient({
+            [RECIPIENT]: 0n,
+            [DEV_FUNDER]: FUNDER_REQUIRED - 1n,
+        });
+        await expect(topUpFromBulletinDev(client, RECIPIENT)).rejects.toBeInstanceOf(
+            DevFunderExhaustedError,
+        );
+        expect(transferFactory).not.toHaveBeenCalled();
+        expect(mockSubmitAndWatch).not.toHaveBeenCalled();
+    });
+
+    it("DevFunderExhaustedError carries the funder address and required amount", async () => {
+        const { client } = makeClient({
+            [RECIPIENT]: 0n,
+            [DEV_FUNDER]: 0n,
+        });
+        try {
+            await topUpFromBulletinDev(client, RECIPIENT);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(DevFunderExhaustedError);
+            const e = err as InstanceType<typeof DevFunderExhaustedError>;
+            expect(e.address).toBe(DEV_FUNDER);
+            expect(e.required).toBe(FUNDER_REQUIRED);
+            expect(e.free).toBe(0n);
+        }
+    });
+
+    it("signs the transfer with the bare-master pubkey, NOT //Alice", async () => {
+        const { client } = makeClient({ [DEV_FUNDER]: FUNDER_HEALTHY });
+        await topUpFromBulletinDev(client, RECIPIENT);
+        const [, signer] = mockSubmitAndWatch.mock.calls[0];
+        // biome-ignore lint/suspicious/noExplicitAny: signer shape mocked
+        const pubkey = (signer as any).publicKey as Uint8Array;
+        expect(pubkey).toBeInstanceOf(Uint8Array);
+        expect(pubkey.length).toBe(32);
+        // Positive lock: full pubkey for the bare master account of the
+        // standard dev mnemonic ("bottom drive ..." with empty derivation,
+        // sr25519). Verified live via `bun run tools/print-bulletin-dev-address.ts`.
+        // If `BULLETIN_DEV_MNEMONIC` or the derivation path ever changes,
+        // this assertion fails loudly instead of letting the CLI silently
+        // point at an unfunded address.
+        const expectedBareMaster =
+            "46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a";
+        expect(Buffer.from(pubkey).toString("hex")).toBe(expectedBareMaster);
+        // Negative guard: canonical `//Alice` is a common typo / regression
+        // ("Alice" the label, `//Alice` the derivation). It is unfunded on
+        // paseo-next-v2 and must never be used here.
+        const canonicalAliceFirstFour = "d43593c7";
+        expect(Buffer.from(pubkey.slice(0, 4)).toString("hex")).not.toBe(canonicalAliceFirstFour);
+    });
+});

--- a/src/utils/account/bulletinTopUp.ts
+++ b/src/utils/account/bulletinTopUp.ts
@@ -1,0 +1,167 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Top up the user's product-derived account from the same dev signer
+ * `bulletin-deploy` funds its `attemptTestnetTopUp` from.
+ *
+ * On paseo-next-v2 the asset-hub runtime wires `pallet_revive::AutoMapper`
+ * into the consumer-ref bump, so the first state-changing tx the user submits
+ * from the product-derived account creates its H160 mapping automatically.
+ * No explicit `Revive.map_account` is needed. `bulletin-deploy`'s deploy
+ * flow then submits a `Revive.call` to `DotNS_RegistrarController.minCommitmentAge`
+ * as the auto-map trigger, but only after confirming the substrate signer
+ * holds at least `FEE_FLOOR_REGISTER` (0.1 PAS); otherwise the trigger tx
+ * runs out of fees and the deploy reverts.
+ *
+ * We replicate that top-up here during `dot init` so the next `dot deploy`
+ * (run from the same product account) has the headroom bulletin-deploy
+ * expects. Crucially we use the SAME source signer bulletin-deploy uses:
+ * the bare master account from the standard substrate dev mnemonic, NOT the
+ * canonical `//Alice` derived account. paseo-next-v2 pre-funds this specific
+ * address; our own `funder.ts::FUNDER_CHAIN` uses `seedToAccount(DEV_PHRASE,
+ * "//Alice")` which resolves to a different SS58 that is unfunded on the v2
+ * chain.
+ *
+ * Replace this module with a re-export from `bulletin-deploy` once it
+ * surfaces `attemptTestnetTopUp` (or an equivalent) at the package root.
+ */
+
+import { Enum } from "polkadot-api";
+import { submitAndWatch } from "@parity/product-sdk-tx";
+import { seedToAccount } from "@parity/product-sdk-keys";
+import type { PaseoClient } from "../connection.js";
+
+/**
+ * Substrate dev mnemonic. Mirrors `DEFAULT_MNEMONIC` in
+ * `bulletin-deploy/src/dotns.ts`.
+ */
+const BULLETIN_DEV_MNEMONIC =
+    "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+/**
+ * Lazy-initialised dev master account. Empty derivation path resolves to the
+ * bare master from the mnemonic, matching `keyring.addFromUri(DEFAULT_MNEMONIC)`
+ * in bulletin-deploy (the `{ label: "Alice", uri: DEFAULT_MNEMONIC }` branch
+ * of `attemptTestnetTopUp`). This is DIFFERENT from `seedToAccount(DEV_PHRASE,
+ * "//Alice")`. paseo-next-v2's pre-funding sits on the bare-master address,
+ * not on the `//Alice` derived one.
+ *
+ * Lazy so commands that never call `topUpFromBulletinDev` (deploy, mod, etc.)
+ * don't pay the sr25519 derivation cost during module load.
+ */
+let cachedDevAccount: ReturnType<typeof seedToAccount> | null = null;
+function getDevAccount(): ReturnType<typeof seedToAccount> {
+    if (cachedDevAccount === null) {
+        cachedDevAccount = seedToAccount(BULLETIN_DEV_MNEMONIC, "");
+    }
+    return cachedDevAccount;
+}
+
+/** 1 PAS in planck. Asset Hub Paseo uses 12 decimals. */
+const ONE_PAS = 1_000_000_000_000n;
+
+/**
+ * Skip the top-up if the product-derived account already holds at least this
+ * much PAS. Matches bulletin-deploy's `FEE_FLOOR_REGISTER` (0.1 PAS), the
+ * threshold above which bulletin-deploy's own `attemptTestnetTopUp` no-ops.
+ * Keeping the same floor means re-running `dot init` doesn't drain the shared
+ * dev faucet on every invocation.
+ */
+const SKIP_TRANSFER_THRESHOLD = 100_000_000_000n;
+
+/**
+ * Headroom on top of the 1 PAS transfer that the dev master must carry. Covers
+ * the `Balances.transfer_allow_death` fee plus a safety margin so subsequent
+ * `dot init` runs immediately after a depleting transfer don't see a
+ * temporarily-low balance and abort. 1 PAS matches bulletin-deploy's
+ * `SOURCE_BUFFER`.
+ */
+const SOURCE_BUFFER = 1_000_000_000_000n;
+
+/**
+ * Custom error surfaced when the shared dev master can no longer cover a
+ * top-up. Operator-facing — points at the address the next refill should
+ * target so on-call doesn't have to grep the source.
+ */
+export class DevFunderExhaustedError extends Error {
+    readonly address: string;
+    readonly free: bigint;
+    readonly required: bigint;
+    constructor(address: string, free: bigint, required: bigint) {
+        super(
+            `Dev funder ${address} is too low to top up the product account: free=${free} planck, need ≥${required} planck. Refill on paseo-next-v2 Asset Hub before re-running.`,
+        );
+        this.name = "DevFunderExhaustedError";
+        this.address = address;
+        this.free = free;
+        this.required = required;
+    }
+}
+
+export interface TopUpResult {
+    skipped: boolean;
+    transferred?: bigint;
+}
+
+/**
+ * Ensure `recipient` (the product-derived SS58) holds at least
+ * `SKIP_TRANSFER_THRESHOLD` PAS on Asset Hub. Sends `ONE_PAS` from the
+ * bulletin-deploy dev signer if the recipient is below the floor; no-ops
+ * otherwise. Waits for GRANDPA finalization before returning so subsequent
+ * `dot deploy` runs don't race a re-org that would roll back the credit.
+ *
+ * Throws {@link DevFunderExhaustedError} if the dev master no longer carries
+ * `ONE_PAS + SOURCE_BUFFER` (matches bulletin-deploy's preflight floor in
+ * `attemptTestnetTopUp`); preflight catch surfaces the funder address so the
+ * operator knows where to refill. Self-transfer is a hypothetical (would need
+ * the dev mnemonic to derive a session key) but the equality check is cheap.
+ */
+export async function topUpFromBulletinDev(
+    client: PaseoClient,
+    recipient: string,
+): Promise<TopUpResult> {
+    const recipientAccount = await client.assetHub.query.System.Account.getValue(recipient, {
+        at: "best",
+    });
+    if (recipientAccount.data.free >= SKIP_TRANSFER_THRESHOLD) {
+        return { skipped: true };
+    }
+
+    const dev = getDevAccount();
+    if (dev.ss58Address === recipient) {
+        // Mirrors bulletin-deploy's `attemptTestnetTopUp` self-transfer guard
+        // (account.address === recipientSs58 short-circuits there too).
+        return { skipped: true };
+    }
+
+    const required = ONE_PAS + SOURCE_BUFFER;
+    const devBalance = await client.assetHub.query.System.Account.getValue(dev.ss58Address, {
+        at: "best",
+    });
+    if (devBalance.data.free < required) {
+        throw new DevFunderExhaustedError(dev.ss58Address, devBalance.data.free, required);
+    }
+
+    await submitAndWatch(
+        client.assetHub.tx.Balances.transfer_allow_death({
+            dest: Enum("Id", recipient),
+            value: ONE_PAS,
+        }),
+        dev.signer,
+        { waitFor: "finalized" },
+    );
+    return { skipped: false, transferred: ONE_PAS };
+}

--- a/src/utils/process-guard.ts
+++ b/src/utils/process-guard.ts
@@ -118,6 +118,10 @@ export function installSignalHandlers(): void {
     process.on("SIGHUP", () => terminate("SIGHUP"));
 
     // Unhandled rejections should not silently keep the event loop alive.
+    // `@sentry/node`'s `OnUnhandledRejection` integration captures the
+    // rejection to Sentry independently (we override it with `mode: 'none'`
+    // in `telemetry.ts` so it stays silent on stderr); this handler is the
+    // user-facing stderr write + benign-filter + exit path.
     process.on("unhandledRejection", (reason) => {
         if (isBenignUnsubscriptionError(reason)) {
             logSuppressedBenign(reason);
@@ -138,6 +142,10 @@ export function installSignalHandlers(): void {
             logSuppressedBenign(err);
             return;
         }
+        // `@sentry/node`'s `OnUncaughtException` integration captures via
+        // `Sentry.captureException` independently (it doesn't print on its
+        // own when our handler is registered, so no `mode` override is
+        // needed). This stays the user-facing stderr write + exit path.
         process.stderr.write(`\nUncaught exception: ${err?.stack ?? String(err)}\n`);
         runAllCleanupAndExit(1);
     });

--- a/tools/check-bulletin-funder.ts
+++ b/tools/check-bulletin-funder.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env bun
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * One-shot operator probe: dump the bulletin-deploy dev funder's free /
+ * reserved / frozen balance on both stable Paseo Asset Hub (where an operator
+ * faucets / teleports from) and paseo-next-v2 Asset Hub (where the CLI's
+ * `dot init` consumes funds from). Run via:
+ *   bun run tools/check-bulletin-funder.ts
+ *
+ * Address is derived inside `src/utils/account/bulletinTopUp.ts` — keep this
+ * tool's hardcoded SS58 in sync with the bare-master output of
+ * `tools/print-bulletin-dev-address.ts`.
+ */
+
+import { createClient } from "polkadot-api";
+import { getWsProvider } from "polkadot-api/ws";
+
+const ADDRESS = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
+
+const CHAINS = [
+    { label: "stable Paseo Asset Hub (paraId 1000)", wss: "wss://asset-hub-paseo-rpc.n.dwellir.com" },
+    { label: "Paseo Next v2 Asset Hub (paraId 1500)", wss: "wss://paseo-asset-hub-next-rpc.polkadot.io" },
+];
+
+function fmtPas(planck: bigint): string {
+    const whole = planck / 1_000_000_000_000n;
+    const frac = planck % 1_000_000_000_000n;
+    const fracStr = frac.toString().padStart(12, "0").replace(/0+$/, "");
+    return `${whole}${fracStr ? "." + fracStr : ""} PAS`;
+}
+
+async function readBalance(wss: string) {
+    const client = createClient(getWsProvider(wss));
+    try {
+        const api = client.getUnsafeApi();
+        const account = await api.query.System.Account.getValue(ADDRESS);
+        return {
+            free: BigInt(account.data.free ?? 0n),
+            reserved: BigInt(account.data.reserved ?? 0n),
+            frozen: BigInt(account.data.frozen ?? 0n),
+        };
+    } finally {
+        try { client.destroy(); } catch {}
+    }
+}
+
+console.log(`Address: ${ADDRESS}\n`);
+for (const chain of CHAINS) {
+    process.stdout.write(`${chain.label}\n  ${chain.wss}\n`);
+    try {
+        const r = await readBalance(chain.wss);
+        console.log(`  free:     ${fmtPas(r.free)}   (${r.free} planck)`);
+        console.log(`  reserved: ${fmtPas(r.reserved)}`);
+        console.log(`  frozen:   ${fmtPas(r.frozen)}\n`);
+    } catch (err) {
+        console.log(`  ERROR: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+}
+process.exit(0);

--- a/tools/print-bulletin-dev-address.ts
+++ b/tools/print-bulletin-dev-address.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * One-shot operator helper: print the SS58 address `bulletinTopUp.ts`
+ * derives (under both prefix 0 / prefix 42 encodings of the same key) so an
+ * operator can faucet-fund / teleport PAS to it. Run via:
+ *   bun run tools/print-bulletin-dev-address.ts
+ *
+ * Mnemonic and derivation must stay in sync with
+ * `src/utils/account/bulletinTopUp.ts::BULLETIN_DEV_MNEMONIC`. The companion
+ * `tools/check-bulletin-funder.ts` queries this address's balance.
+ */
+
+import { seedToAccount } from "@parity/product-sdk-keys";
+import { ss58Encode } from "@parity/product-sdk-address";
+
+const MNEMONIC = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+const account = seedToAccount(MNEMONIC, "");
+const hex = `0x${Buffer.from(account.publicKey).toString("hex")}`;
+const generic = ss58Encode(account.publicKey, 42);
+const polkadot = ss58Encode(account.publicKey, 0);
+
+console.log("Public key (hex):", hex);
+console.log("SS58 (generic prefix 42, Westend/Substrate dev):", generic);
+console.log("SS58 (Polkadot/Paseo prefix 0):", polkadot);
+console.log("Default SS58 from seedToAccount:", account.ss58Address);


### PR DESCRIPTION
## Summary

- `dot init` swaps the explicit `Revive.map_account` step for funding the product-derived account 1 PAS from the same bulletin-deploy dev signer (bare-master account, NOT `//Alice` — paseo-next-v2 pre-funds the former, not the latter). AutoMapper creates the H160 mapping on the first state-changing tx; a belt-and-braces `Revive.map_account` still fires after funding if `checkMapping` reports false, covering cold-start accounts that pre-existed the AutoMapper runtime upgrade.
- Preflight reads the dev master's balance before broadcasting and throws `DevFunderExhaustedError` (carrying address + free + required) instead of spamming the chain with reverting transfers when the shared funder runs dry. Self-transfer is short-circuited.
- Silences the recurring `DestroyedError: Client destroyed` block printed on every `dot init` exit. Root cause was `@sentry/node`'s default `OnUnhandledRejection` integration printing via `console.warn`/`console.error` — the two writes split the preamble and stack so the `bootstrap.ts` stderr filter (which requires both substrings in a single write) never matched. Override with `onUnhandledRejectionIntegration({ mode: 'none' })` to keep Sentry capture (full `mechanism: onunhandledrejection` metadata preserved) while skipping the print. Benign polkadot-api teardown artifacts are also dropped in `beforeSend` so they don't reach the Failures dashboard.
- Operator tools moved to `tools/`: `print-bulletin-dev-address.ts` dumps the funder SS58 / hex pubkey across prefixes; `check-bulletin-funder.ts` queries the funder balance on stable Paseo AH + paseo-next-v2 AH.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint:license` — all 159 source files have the SPDX header
- [x] `pnpm build` — type-check + Bun SEA compile pass
- [x] `pnpm test` — 511 passed / 1 skipped (3 new cases in `bulletinTopUp.test.ts`: floor-boundary skip, self-transfer guard, exhausted-funder + error metadata, positive bare-master pubkey lock with negative `//Alice` guard)
- [x] Live `dot init` smoke test — `DestroyedError` block no longer printed after `✓ setup complete`
- [ ] Re-pair via mobile QR and verify full flow end-to-end (`+1 PAS + mapped` UI detail when belt-and-braces fires; `already funded` when re-running). The local session got cleared between earlier runs so this needs a fresh pairing to confirm.
- [ ] Confirm Sentry's Failures dashboard does not show new `DestroyedError` events on the next paseo-next-v2 E2E run.

## Notes for review

- `mapping.ts` is retained (re-imported in `AccountSetup` for the belt-and-braces path; `dot deploy` still consumes `checkMapping`).
- The funder source pin (`SOURCE_BUFFER = 1 PAS`, `SKIP_TRANSFER_THRESHOLD = 0.1 PAS`) mirrors bulletin-deploy's `SOURCE_BUFFER` / `FEE_FLOOR_REGISTER`. If a future bulletin-deploy release surfaces `attemptTestnetTopUp` at its package root, this module can collapse to a re-export.
- Sentry capture still records every non-benign unhandled rejection / uncaught exception with proper mechanism metadata via the SDK's own integrations.

Address details for paseo-next-v2 ops:
- Dev funder SS58 (Polkadot/Paseo prefix 0): `12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU`
- Pubkey (hex): `0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a`
- Paseo Next v2 AH parachain ID: `1500` (WSS `wss://paseo-asset-hub-next-rpc.polkadot.io`)