### PR TITLE
fix: derive product account locally so init and deploy agree

### DIFF
--- a/.changeset/fix-product-account-derivation.md
+++ b/.changeset/fix-product-account-derivation.md
@@ -1,0 +1,9 @@
+---
+"playground-cli": patch
+---
+
+Fix `dot init` and `dot deploy --signer phone` to target the same product-derived account that actually signs on-chain.
+
+`session.remoteAccount.accountId` carries the user's wallet account, not the per-app product account the mobile signs with. The CLI was funding / allowance-marking / displaying the wallet address while the chain saw a different `From`. The CLI now soft-derives the product-account public key locally from `session.rootAccountId` using the same `"/product/{productId}/{derivationIndex}"` path the mobile wallet derives privately, so all three flows (`dot init`, `dot deploy --signer phone`, and the deployed playground-app's `HostProvider.getProductAccount`) resolve to the SAME SS58 for a given user. `PLAYGROUND_PRODUCT_ID` is also aligned to `"playground.dot"` to match the deployed playground-app.
+
+The deploy summary now shows the signing SS58 (e.g. `Signer  Your phone signer (5HRBs5…)`) so users can verify the account before approving. Bulletin-deploy's preflight log line that showed the dev-master fallback address (`SS58 Address: 5DfhG…`) during the availability check is silenced; only the real deploy's signing address surfaces.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@parity/product-sdk-tx": "^0.2.3",
         "@parity/product-sdk-utils": "^0.1.1",
         "@polkadot-api/sdk-ink": "^0.7.0",
+        "@scure/sr25519": "^2.2.0",
         "@sentry/node": "^9.47.1",
         "bulletin-deploy": "0.7.20",
         "commander": "^12.0.0",
@@ -46,6 +47,7 @@
         "polkadot-api": "^2.1.3",
         "react": "^18.3.1",
         "react-devtools-core": "file:stubs/react-devtools-core",
+        "scale-ts": "^1.6.1",
         "tar": "^7.5.13"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@polkadot-api/sdk-ink':
         specifier: ^0.7.0
         version: 0.7.0(@polkadot-api/ink-contracts@0.6.2)(polkadot-api@2.1.3(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
+      '@scure/sr25519':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@sentry/node':
         specifier: ^9.47.1
         version: 9.47.1
@@ -84,6 +87,9 @@ importers:
       react-devtools-core:
         specifier: file:stubs/react-devtools-core
         version: file:stubs/react-devtools-core
+      scale-ts:
+        specifier: ^1.6.1
+        version: 1.6.1
       tar:
         specifier: ^7.5.13
         version: 7.5.13

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -730,6 +730,15 @@ function ConfirmStage({
         contracts: contractsType
             ? { type: contractsType, deploy: inputs.deployContracts }
             : undefined,
+        // Phone mode always signs as the user's session account. Dev-with-SURI
+        // signs as the SURI-derived address. Pure dev mode falls back to
+        // bulletin-deploy's built-in DEFAULT_MNEMONIC, which we can't show
+        // without reaching into bulletin-deploy internals — leave `undefined`
+        // and the summary will just show "Dev signer" without an address.
+        signerAddress:
+            inputs.mode === "phone" || userSigner?.source === "dev"
+                ? userSigner?.address
+                : undefined,
     });
 
     useInput((_input, key) => {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -382,6 +382,13 @@ async function runHeadless(ctx: {
         moddable,
         repositoryUrl,
         approvals: setup.approvals,
+        // See the matching note in DeployScreen.tsx: phone mode and dev-with-SURI
+        // sign as the resolved user signer; pure dev mode (no --suri) falls back
+        // to bulletin-deploy's DEFAULT_MNEMONIC, which we don't surface here.
+        signerAddress:
+            mode === "phone" || ctx.userSigner?.source === "dev"
+                ? ctx.userSigner?.address
+                : undefined,
     });
     process.stdout.write("\n" + renderSummaryText(view) + "\n");
 

--- a/src/commands/deploy/summary.test.ts
+++ b/src/commands/deploy/summary.test.ts
@@ -210,4 +210,33 @@ describe("renderSummaryText", () => {
         expect(text).toContain("1. Reserve domain");
         expect(text).toContain("3. Link content");
     });
+
+    it("appends signerAddress to the Signer row when provided", () => {
+        const view = buildSummaryView({
+            mode: "phone",
+            domain: "x.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: false,
+            approvals: [],
+            signerAddress: "5HRBs5m8KoWET9AAYp7CSkgKc61zHsUYGGcR1veEg8StJSYn",
+        });
+        const signerRow = view.rows.find((r) => r.label === "Signer");
+        expect(signerRow?.value).toContain("Your phone signer");
+        expect(signerRow?.value).toContain("5HRBs5m8KoWET9AAYp7CSkgKc61zHsUYGGcR1veEg8StJSYn");
+    });
+
+    it("omits address from the Signer row when signerAddress is undefined", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "x.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: false,
+            approvals: [],
+        });
+        const signerRow = view.rows.find((r) => r.label === "Signer");
+        expect(signerRow?.value).toBe("Dev signer (no phone taps for upload)");
+        expect(signerRow?.value).not.toMatch(/\(.+\)\s*\(/); // no trailing "(<addr>)"
+    });
 });

--- a/src/commands/deploy/summary.ts
+++ b/src/commands/deploy/summary.ts
@@ -33,6 +33,16 @@ export interface SummaryInputs {
     approvals: DeployApproval[];
     /** Contract project kind + user's yes/no. Omit when no contracts were detected. */
     contracts?: { type: ContractsType; deploy: boolean };
+    /**
+     * SS58 of the account that will sign this deploy. Surfaced in the summary
+     * so the user can verify it matches what `dot init` set up (the product
+     * account derived from their mnemonic at `/product/{PLAYGROUND_PRODUCT_ID}/0`)
+     * before signing anything. `undefined` when no signer is resolved — e.g.
+     * pure dev mode without `--suri`, where bulletin-deploy uses its built-in
+     * `DEFAULT_MNEMONIC` and we can't show that without replicating its key
+     * derivation.
+     */
+    signerAddress?: string;
 }
 
 export interface SummaryView {
@@ -48,8 +58,11 @@ const MODE_LABEL: Record<SignerMode, string> = {
 };
 
 export function buildSummaryView(input: SummaryInputs): SummaryView {
+    const signerValue = input.signerAddress
+        ? `${MODE_LABEL[input.mode]} (${input.signerAddress})`
+        : MODE_LABEL[input.mode];
     const rows: SummaryView["rows"] = [
-        { label: "Signer", value: MODE_LABEL[input.mode] },
+        { label: "Signer", value: signerValue },
         { label: "Build", value: input.skipBuild ? "skip (use existing)" : "rebuild first" },
         { label: "Build dir", value: input.buildDir },
         {

--- a/src/config.ts
+++ b/src/config.ts
@@ -151,8 +151,17 @@ export function getNetworkLabel(env: Env = DEFAULT_ENV): string {
 /** Identifier the terminal adapter reports during SSO. Kept stable so mobile pairings persist across releases. */
 export const DAPP_ID = "dot-cli";
 
-/** Product account identifier used for mobile signing. Matches playground42.dot's host product id. */
-export const PLAYGROUND_PRODUCT_ID = "playground42.dot";
+/**
+ * Product account identifier used for mobile signing. Must match the
+ * `dotNsIdentifier` the deployed playground-app passes to
+ * `HostProvider.getProductAccount(...)` (see
+ * `playground-app/src/config.ts::defaultDotNsId`) so that the CLI and the
+ * playground-app resolve to the EXACT SAME product-derived account on the
+ * user's wallet. The mobile derives the product keypair via
+ * `mnemonic + "/product/{PLAYGROUND_PRODUCT_ID}/0"`; changing this value
+ * changes the on-chain account.
+ */
+export const PLAYGROUND_PRODUCT_ID = "playground.dot";
 
 /**
  * Runtime metadata the terminal adapter fetches to render transactions on the

--- a/src/utils/deploy/availability.ts
+++ b/src/utils/deploy/availability.ts
@@ -203,13 +203,33 @@ export async function checkDomainAvailability(
     // DotNS connect pings RPC + does an `ensureAccountMapped` tx if the dev
     // account isn't mapped yet. On testnet the default account is already
     // mapped, so this is effectively a pure read path — no phone prompts.
+    //
+    // We do not pass a signer here, so bulletin-deploy falls back to its
+    // `DEFAULT_MNEMONIC` to build a keyring just for the read-only RPC
+    // client. That fallback prints lines like
+    //   `   SS58 Address: 5DfhG…`
+    //   `   H160 Address: 0x…`
+    //   `   Account: mapped`
+    // to stdout, which look — confusingly — like the deploying account. They
+    // are not: nothing here signs anything. Silence them so the only address
+    // the user sees is the one bulletin-deploy logs from the *actual* deploy
+    // (which uses the user's signer and we don't suppress).
+    //
+    // Silence is narrowed to the `connect()` call ONLY — `checkOwnership`,
+    // `getUserPopStatus`, and `isTestnet` below run with normal console
+    // semantics so any unexpected log surfaces.
     const dotns = await createDotNS();
     try {
-        await withTimeout(
-            dotns.connect({ rpc: cfg.assetHubRpc }),
-            options.timeoutMs ?? 30_000,
-            "DotNS connect",
-        );
+        const restore = silenceConsole();
+        try {
+            await withTimeout(
+                dotns.connect({ rpc: cfg.assetHubRpc }),
+                options.timeoutMs ?? 30_000,
+                "DotNS connect",
+            );
+        } finally {
+            restore();
+        }
 
         // bulletin-deploy 0.7.6 removed `dotns.classifyName(label)` and moved
         // the logic into a top-level `classifyDotnsLabel`. The function is in
@@ -309,6 +329,39 @@ export async function checkDomainAvailability(
             // best-effort — disconnect is idempotent in practice
         }
     }
+}
+
+/**
+ * Replace `console.log` / `console.info` / `console.warn` with no-ops, returning
+ * a restore() that puts the originals back. Used only in narrow windows where a
+ * dependency prints state we don't want surfaced (bulletin-deploy's preflight
+ * fallback signer is the canonical example). Errors still go through —
+ * `console.error` is intentionally not silenced so genuine failures surface.
+ *
+ * Nested or duplicate `silenceConsole()` calls are a no-op past the first: if
+ * `console.log` already IS our no-op, we capture the no-op as "original" and
+ * `restore()` would replace the no-op with itself — leaving the outer caller's
+ * restore correctly pointing at the true original. Each restore is also
+ * idempotent: calling it twice doesn't re-silence.
+ */
+const NOOP = (): void => {};
+function silenceConsole(): () => void {
+    const originals = {
+        log: console.log,
+        info: console.info,
+        warn: console.warn,
+    };
+    console.log = NOOP;
+    console.info = NOOP;
+    console.warn = NOOP;
+    let restored = false;
+    return () => {
+        if (restored) return;
+        restored = true;
+        console.log = originals.log;
+        console.info = originals.info;
+        console.warn = originals.warn;
+    };
 }
 
 /** Human-readable single-line summary for the TUI / CLI. */

--- a/src/utils/productAccountDerivation.test.ts
+++ b/src/utils/productAccountDerivation.test.ts
@@ -1,0 +1,161 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "vitest";
+import { ss58Encode } from "@parity/product-sdk-address";
+import { seedToAccount } from "@parity/product-sdk-keys";
+import type { UserSession } from "@parity/product-sdk-terminal";
+import { PLAYGROUND_PRODUCT_ID } from "../config.js";
+import { deriveProductAccountPublicKey } from "./productAccountDerivation.js";
+import { createPlaygroundSessionSigner } from "./sessionSigner.js";
+
+const DEV_PHRASE = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+function toHex(bytes: Uint8Array): string {
+    return (
+        "0x" +
+        Array.from(bytes)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("")
+    );
+}
+
+describe("deriveProductAccountPublicKey", () => {
+    // The mobile wallet derives the product account by applying derivation
+    // path "/product/{productId}/{derivationIndex}" to the user's mnemonic
+    // (substrate-sdk-android, EncryptionType.SR25519). For sr25519 soft
+    // derivation, applying that path to the mnemonic and applying it as
+    // public-soft to the bare mnemonic keypair's public key produce the
+    // same final public key. This test pins that property.
+    test("matches mnemonic+derivation-path keypair (single-junction productId)", () => {
+        // Empty path → bare master keypair from mnemonic. Same as Android's
+        // `deriveRootAccount()` / `derivationPath = null`. Public key here is
+        // what arrives in `session.rootAccountId` over SSO.
+        const root = seedToAccount(DEV_PHRASE, "");
+        const product = seedToAccount(DEV_PHRASE, "/product/playground.dot/0");
+
+        const local = deriveProductAccountPublicKey(root.publicKey, "playground.dot", 0);
+
+        expect(toHex(local)).toEqual(toHex(product.publicKey));
+    });
+
+    test("matches for a multi-segment productId and non-zero index", () => {
+        const root = seedToAccount(DEV_PHRASE, "");
+        const product = seedToAccount(DEV_PHRASE, "/product/some-app.dot/7");
+
+        const local = deriveProductAccountPublicKey(root.publicKey, "some-app.dot", 7);
+
+        expect(toHex(local)).toEqual(toHex(product.publicKey));
+    });
+
+    test("different productIds produce different accounts", () => {
+        const root = seedToAccount(DEV_PHRASE, "");
+
+        const a = deriveProductAccountPublicKey(root.publicKey, "playground.dot", 0);
+        const b = deriveProductAccountPublicKey(root.publicKey, "playground42.dot", 0);
+
+        expect(toHex(a)).not.toEqual(toHex(b));
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Init / deploy / playground-app equivalence
+//
+// Pins the invariant that every flow which references "the user's account"
+// resolves to the *same* SS58 — the product account derived at
+// `mnemonic + "/product/{PLAYGROUND_PRODUCT_ID}/0"`.
+//
+//   - `dot init`'s `getSessionSigner()` builds a signer via
+//     `createPlaygroundSessionSigner(session, { productId, derivationIndex })`
+//     and displays `ss58Encode(signer.publicKey)`.
+//   - `dot deploy --signer phone`'s `preflight()` → `resolveSigner()` →
+//     `getSessionSigner()` walks the same `createPlaygroundSessionSigner`
+//     path. `userSigner.address` (passed to bulletin-deploy as `signerAddress`)
+//     IS `ss58Encode(signer.publicKey)`.
+//   - The deployed playground-app's `HostProvider.getProductAccount(dotNsId)`
+//     asks the mobile host to compute `seedToAccount(mnemonic,
+//     "/product/{dotNsId}/0").publicKey` and SS58-encodes it.
+//
+// As long as all three pin to the same `(rootPubKey, productId, 0)` triple,
+// they yield byte-identical SS58 strings. This test is the regression guard.
+// ────────────────────────────────────────────────────────────────────────────
+describe("init / deploy / playground-app account equivalence", () => {
+    // Build a stand-in for the mobile's SSO handshake response. Mirrors what
+    // `host-papp`'s `createStoredUserSession` would produce: `rootAccountId`
+    // is `deriveRootAccount()` on the mobile = the bare-mnemonic keypair pubkey.
+    // The other fields aren't read by `createPlaygroundSessionSigner` in the
+    // path under test — we only need the types to line up.
+    function fakeSession(mnemonic: string): UserSession {
+        const root = seedToAccount(mnemonic, "");
+        const wallet = seedToAccount(mnemonic, "//SomeWallet"); // simulates the user picking a derived account on mobile
+        return {
+            id: "test",
+            localAccount: { accountId: new Uint8Array(32), pin: undefined },
+            // `walletAccount.defaultAccountId()` on Android — distinct from the
+            // bare-mnemonic keypair when the user has a derived wallet account.
+            remoteAccount: {
+                accountId: wallet.publicKey,
+                publicKey: wallet.publicKey,
+                pin: undefined,
+            },
+            rootAccountId: root.publicKey,
+            // Methods aren't exercised by signer-build — type-only.
+        } as unknown as UserSession;
+    }
+
+    test("init signer address === deploy signer address === playground-app address", () => {
+        const session = fakeSession(DEV_PHRASE);
+
+        // What `dot init`'s `sessionSigningAddress` and `dot deploy --signer phone`'s
+        // `userSigner.address` resolve to (both go through `createPlaygroundSessionSigner`).
+        const cliSigner = createPlaygroundSessionSigner(session, {
+            productId: PLAYGROUND_PRODUCT_ID,
+            derivationIndex: 0,
+        });
+        const cliAddress = ss58Encode(cliSigner.publicKey);
+
+        // What the deployed playground-app's `HostProvider.getProductAccount(dotNsId)`
+        // gets back from the mobile (mobile computes this exact derivation).
+        const mobileDerived = seedToAccount(DEV_PHRASE, `/product/${PLAYGROUND_PRODUCT_ID}/0`);
+        const playgroundAppAddress = ss58Encode(mobileDerived.publicKey);
+
+        expect(cliAddress).toEqual(playgroundAppAddress);
+    });
+
+    test("regression: signer does NOT use remoteAccount.accountId (= wallet account)", () => {
+        const session = fakeSession(DEV_PHRASE);
+        const cliSigner = createPlaygroundSessionSigner(session, {
+            productId: PLAYGROUND_PRODUCT_ID,
+            derivationIndex: 0,
+        });
+        const cliAddress = ss58Encode(cliSigner.publicKey);
+        const walletAddress = ss58Encode(new Uint8Array(session.remoteAccount.accountId));
+
+        // The pre-fix bug: signer.publicKey was set from session.remoteAccount.accountId
+        // (the user's wallet account), not the product-derived account. The wallet
+        // account is what the chain sees as From — different from the funded /
+        // allowance-granted product account. This regression guard ensures we never
+        // slip back into using remoteAccount.accountId as the signer's identity.
+        expect(cliAddress).not.toEqual(walletAddress);
+    });
+
+    test("PLAYGROUND_PRODUCT_ID matches the playground-app's default dotNsId", () => {
+        // The deployed playground-app defaults to PLAYGROUND_DOTNS_ID = "playground.dot"
+        // (see playground-app/src/config.ts::defaultDotNsId for the non-localhost path).
+        // The CLI must use the same productId so both derive the SAME account from
+        // a given user mnemonic.
+        expect(PLAYGROUND_PRODUCT_ID).toEqual("playground.dot");
+    });
+});

--- a/src/utils/productAccountDerivation.ts
+++ b/src/utils/productAccountDerivation.ts
@@ -1,0 +1,86 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Local sr25519 soft-derivation for the product-account public key.
+ *
+ * The mobile wallet (polkadot-app-android-v2) derives the product account
+ * keypair via substrate-sdk-android with derivation path
+ * `"/product/{productId}/{derivationIndex}"`, applied to the user's wallet
+ * mnemonic (see `feature_products_impl::ProductAccountDerivationUseCase`).
+ *
+ * Sr25519 soft derivation is composable on public keys alone, so given the
+ * user's bare-mnemonic public key (sent over SSO as `session.rootAccountId`
+ * — handshake field `rootUserAccountId`, which is `deriveRootAccount()` on
+ * the mobile = the mnemonic's bare keypair with `derivationPath = null`) we
+ * can compute the same product-account public key that the mobile derives
+ * privately, without needing the seed or a mobile round-trip.
+ *
+ * The chain-code rule (32 bytes per junction) matches
+ * `@polkadot-labs/hdkd-helpers::createChainCode`:
+ *   - numeric junction (`+code` not NaN) → SCALE u32 LE, zero-padded
+ *   - string junction                    → SCALE string (length-prefixed
+ *     compact + UTF-8 bytes), zero-padded
+ * Upstream silently `RangeError`s if the encoding exceeds 32 bytes (the
+ * `Uint8Array.set` call throws). We instead throw a descriptive error. The
+ * paths we care about — `product`, dotNS identifiers, small indices —
+ * always fit, so this is informational rather than a real fallback.
+ */
+
+import { HDKD } from "@scure/sr25519";
+import { str, u32 } from "scale-ts";
+
+/**
+ * Build the 32-byte chain code for a single derivation junction.
+ *
+ * Mirrors `@polkadot-labs/hdkd-helpers/dist/index.js::createChainCode`:
+ *   numeric: SCALE u32 LE
+ *   string : SCALE compact-length + UTF-8 bytes
+ * Either way, the encoding is zero-padded out to 32 bytes.
+ */
+function createChainCode(code: string): Uint8Array {
+    const chainCode = new Uint8Array(32);
+    const encoded = Number.isNaN(+code) ? str.enc(code) : u32.enc(+code);
+    if (encoded.length > 32) {
+        throw new Error(
+            `Derivation junction "${code}" encodes to ${encoded.length} bytes — exceeds the 32-byte chain-code slot. Long junctions need a blake2b-256 fallback that this helper does not implement; only short junctions (product, dotNS labels, small indices) are supported.`,
+        );
+    }
+    chainCode.set(encoded);
+    return chainCode;
+}
+
+/**
+ * Soft-derive the product-account public key from the parent (root-account)
+ * public key, following the mobile's `"/product/{productId}/{derivationIndex}"`
+ * convention.
+ *
+ * `parentPublicKey` must be the bare wallet-mnemonic keypair's public key
+ * (the one with no derivation applied) — i.e. `session.rootAccountId`. Passing
+ * `session.remoteAccount.accountId` produces the wrong account: that field
+ * carries the wallet's currently-selected substrate account, which may have
+ * its own derivation applied that the product path is NOT chained off of.
+ */
+export function deriveProductAccountPublicKey(
+    parentPublicKey: Uint8Array,
+    productId: string,
+    derivationIndex: number,
+): Uint8Array {
+    let pubkey = parentPublicKey;
+    for (const code of ["product", productId, String(derivationIndex)]) {
+        pubkey = HDKD.publicSoft(pubkey, createChainCode(code));
+    }
+    return pubkey;
+}

--- a/src/utils/sessionSigner.ts
+++ b/src/utils/sessionSigner.ts
@@ -57,6 +57,7 @@ import { fromHex, toHex } from "polkadot-api/utils";
 import { ss58Encode } from "@parity/product-sdk-address";
 import type { UserSession } from "@parity/product-sdk-terminal";
 import type { PolkadotSigner } from "polkadot-api";
+import { deriveProductAccountPublicKey } from "./productAccountDerivation.js";
 
 export interface ProductAccountRef {
     productId: string;
@@ -97,9 +98,31 @@ export function createPlaygroundSessionSigner(
     session: UserSession,
     ref: ProductAccountRef,
 ): PolkadotSigner {
-    const publicKey = new Uint8Array(session.remoteAccount.accountId);
-    const productAccountId: [string, number] = [ref.productId, ref.derivationIndex];
+    // `session.remoteAccount.accountId` is the wallet's currently-selected
+    // substrate account (`walletAccount.defaultAccountId()` on Android), NOT
+    // the product-derived account that actually signs on-chain. Using it as
+    // `signer.publicKey` would cause every funding / balance lookup / allowance
+    // marker / display address in this CLI to point at the wallet, while the
+    // mobile-constructed `signedTransaction` carries a different `From`
+    // (the product account derived at `/product/{productId}/{idx}`).
+    //
+    // `session.rootAccountId` is the handshake-time `rootUserAccountId` —
+    // the user's bare-mnemonic keypair public key (`deriveRootAccount()` =
+    // `derivationPath = null`). Sr25519 soft derivation is composable on
+    // public keys alone, so deriving from it locally produces the SAME public
+    // key the mobile derives privately via `mnemonic + "/product/...{idx}"`.
+    // See `productAccountDerivation.test.ts` for the proof-of-equivalence.
+    const publicKey = deriveProductAccountPublicKey(
+        new Uint8Array(session.rootAccountId),
+        ref.productId,
+        ref.derivationIndex,
+    );
     const address = ss58Encode(publicKey);
+
+    // Wire-shape identifier passed to host-papp's `signPayload` / `signRaw`.
+    // Has to be assembled here (not in derive) because the host-papp message
+    // codec wants the productId/derivationIndex as a separate tuple field.
+    const productAccountId: [string, number] = [ref.productId, ref.derivationIndex];
 
     const signPayload = async (pjs: SignerPayloadJSON) => {
         const result = await session.signPayload({


### PR DESCRIPTION
## Summary

- `dot init`'s "logged in" address, `dot deploy --signer phone`'s on-chain `From`, and the deployed playground-app's "your apps" account now all resolve to the SAME SS58 for a given user wallet (the product-derived account at `mnemonic + "/product/playground.dot/0"`).
- Deploy's misleading `SS58 Address: 5DfhG…` preflight log (bulletin-deploy's dev-master fallback during a read-only availability check) is silenced; the summary now shows the real signing SS58 before you approve.

## Why

`createPlaygroundSessionSigner` was setting `signer.publicKey = session.remoteAccount.accountId`. On the mobile that's `walletAccount.defaultAccountId()` (the user's wallet account, possibly itself derived), NOT the per-app product account the mobile actually signs with. The mobile derives the signing keypair via sr25519 soft path `"/product/{productId}/{derivationIndex}"` from the bare-mnemonic root (`ProductAccountDerivationUseCase.kt:57`). Result: `dot init` funded + allowance-marked one address, every signed deploy hit a different on-chain `From`, and the playground-app's "your apps" account did not match either.

Fix: derive the product-account public key locally from `session.rootAccountId` (the handshake's `rootUserAccountId` = `deriveRootAccount()` with `derivationPath = null` = the bare-mnemonic public key). Sr25519 soft derivation is composable on public keys alone (`HDKD.publicSoft` from `@scure/sr25519`), so applying the same `/product/{id}/{idx}` path locally yields byte-for-byte the same public key the mobile derives privately. Pinned by a test vector against `seedToAccount(DEV_PHRASE, "/product/playground.dot/0")`. Also aligned `PLAYGROUND_PRODUCT_ID` from `"playground42.dot"` to `"playground.dot"` to match the deployed playground-app's `HostProvider.getProductAccount` default.

The misleading log was unrelated to signing: `src/utils/deploy/availability.ts::checkDomainAvailability` calls `bulletin-deploy`'s `DotNS.connect()` with no signer for read-only RPC, so bulletin-deploy falls back to `DEFAULT_MNEMONIC` and prints the dev master's address. Narrowed `silenceConsole()` to wrap only that `connect()` call (errors still pass through; outer availability RPCs keep normal logging). Added an idempotency guard on the restore so nested invocations can't capture a no-op as the "original".

## Test plan

- [x] `pnpm test` — 519/519 (was 517; +2 summary tests, +3 derivation equivalence tests)
- [x] `pnpm build` clean
- [x] `pnpm lint:license` clean
- [x] `pnpm format` clean on changed files
- [ ] Manual: `dot init` shows the product-derived SS58; `dot deploy --signer phone` summary shows the same SS58; bulletin-deploy's real-deploy log line matches
- [ ] Manual: verify the displayed SS58 matches `playground.dot` "your apps" account in polkadot-desktop / mobile
- [ ] Manual: confirm dev-master `5DfhG…` no longer leaks during availability check