### PR TITLE
fix(e2e): tag chaos deploy transactions as e2e in bulletin-deploy dashboard

### DIFF
--- a/e2e/cli/chaos.test.ts
+++ b/e2e/cli/chaos.test.ts
@@ -84,7 +84,7 @@ describe("dot deploy — chaos", () => {
 			),
 			{
 				cwd: REPO_ROOT,
-				env: { ...process.env, DOT_TAG: "e2e-chaos-sigint", DOT_TELEMETRY: "1" },
+				env: { ...process.env, DOT_TAG: "e2e-chaos-sigint", DEPLOY_TAG: process.env.DEPLOY_TAG ?? "e2e-cli-chaos-sigint", DOT_TELEMETRY: "1" },
 				reject: false,
 			},
 		);
@@ -169,6 +169,7 @@ describe("dot deploy — chaos RPC failover", () => {
 				env: {
 					...process.env,
 					DOT_TAG: "e2e-chaos-rpc",
+					DEPLOY_TAG: process.env.DEPLOY_TAG ?? "e2e-cli-chaos-rpc",
 					DOT_TELEMETRY: "1",
 					DOT_BULLETIN_RPC: "ws://127.0.0.1:1/",
 				},


### PR DESCRIPTION
## Summary

Both chaos tests (`nightly-chaos-sigint`, `nightly-chaos-rpc`) spawn the CLI via `execa` directly — not through the `dot()` helper — so they can get a signalable child handle. The `dot.ts` helper normally computes `DEPLOY_TAG` from `DOT_TAG` before spawning; without it, bulletin-deploy emits spans with no `deploy.tag`, making chaos transactions appear as real-user traffic in bulletin-deploy's Sentry dashboard.

Adds `DEPLOY_TAG` to both `env` objects, mirroring the derivation in `dot.ts`:
- `e2e-cli-chaos-sigint` for the SIGINT mid-deploy test
- `e2e-cli-chaos-rpc` for the RPC failover test

Respects any explicit `DEPLOY_TAG` override from the outer environment (consistent with `dot.ts` behaviour).

## Test plan

- [ ] CI: all PR cells green (no logic change — only env tagging)
- [ ] Nightly: chaos cells emit `deploy.tag:e2e-cli-chaos-*` spans visible in bulletin-deploy's E2E dashboard