### PR TITLE
Fix Bulletin allowance slot key handling

### DIFF
--- a/.changeset/fix-init-product-account-display.md
+++ b/.changeset/fix-init-product-account-display.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Keep Bulletin out of the mobile allowance request, show the Bulletin authorization faucet for the locally cached Bulletin account, and let `dot logout` recover from stale sessions missing the product-derivation root key.
+Request Bulletin allowance through the mobile resource-allocation flow again, normalize returned slot-account keys before caching/signing, keep the Bulletin faucet as a fallback when the returned account is not usable on-chain, and let `dot logout` recover from stale sessions missing the product-derivation root key.

--- a/.changeset/normalize-bulletin-slot-account-keys.md
+++ b/.changeset/normalize-bulletin-slot-account-keys.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Request Bulletin allowance through the mobile resource-allocation flow, normalize returned slot-account keys before caching/signing, and keep the Bulletin authorization faucet as a fallback when the returned account is not usable on-chain.
+Request Bulletin allowance through the mobile resource-allocation flow, normalize returned slot-account keys before caching/signing, and point users back to mobile approval when the returned account is not usable on-chain.

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -28,11 +28,10 @@ import {
     type AllocatableResource,
 } from "../../utils/allowances/host.js";
 import { hasAllowance, markAllowance } from "../../utils/allowances/marker.js";
-import { hasUsableBulletinSlotAuthorization } from "../../utils/allowances/bulletin.js";
+import { getBulletinSlotAuthorization } from "../../utils/allowances/bulletin.js";
 import {
-    getOrCreateSlotAccountKey,
-    getSlotAccountAddress,
     hasSlotAccountKey,
+    readSlotAccountKey,
     storeSlotAccountKeysFromOutcomes,
 } from "../../utils/allowances/slotKeys.js";
 
@@ -148,49 +147,45 @@ export function AccountSetup({
             const env = DEFAULT_ENV;
 
             // ── Step 0: Resource allowances ─────────────────────────────────
-            // Allowances are requested against the product-derived account
-            // (host-papp's `productAccountId = [PLAYGROUND_PRODUCT_ID, 0]`),
-            // which is the same SS58 used everywhere else in this flow. Bulletin
-            // is intentionally not requested from mobile here: the CLI creates
-            // a local slot account and tells the user to authorize that account
-            // through the Bulletin faucet until product-sdk exposes the proper
-            // host-side preimage path.
+            // The CLI acts as the Host for terminal sessions: request RFC-0010
+            // allocations from mobile, cache returned slot keys, then use the
+            // Bulletin slot key for metadata uploads.
             update(0, { status: "active", value: "checking…", valueTone: "muted" });
             let accountSetupOk = true;
             try {
                 const tags = PLAYGROUND_RESOURCES.map((r) => r.tag);
                 const marked = await Promise.all(tags.map((t) => hasAllowance(env, address, t)));
                 const slotKeys = await Promise.all([
+                    hasSlotAccountKey(env, address, "BulletInAllowance"),
                     hasSlotAccountKey(env, address, "StatementStoreAllowance"),
                 ]);
-                const bulletinKey = await getOrCreateSlotAccountKey(
-                    env,
-                    address,
-                    "BulletInAllowance",
-                );
-                if (cancelled) return;
-                let bulletinUsable = false;
-                try {
-                    bulletinUsable = await hasUsableBulletinSlotAuthorization(
-                        client.bulletin,
-                        bulletinKey,
-                        1,
-                    );
-                } catch {
-                    bulletinUsable = false;
-                }
-                if (cancelled) return;
-                const slotAccountAddress = getSlotAccountAddress(bulletinKey);
-                setBulletinWarning(
-                    bulletinUsable
-                        ? null
-                        : {
-                              slotAccountAddress,
-                          },
-                );
-                if (bulletinUsable) {
-                    await markAllowance(env, address, "BulletInAllowance", "host");
-                }
+
+                const refreshBulletinWarning = async () => {
+                    const bulletinKey = await readSlotAccountKey(env, address, "BulletInAllowance");
+                    if (!bulletinKey) {
+                        setBulletinWarning(null);
+                        return;
+                    }
+                    try {
+                        const authorization = await getBulletinSlotAuthorization(
+                            client.bulletin,
+                            bulletinKey,
+                            1,
+                        );
+                        setBulletinWarning(
+                            authorization.usable
+                                ? null
+                                : { slotAccountAddress: authorization.address },
+                        );
+                        if (authorization.usable) {
+                            await markAllowance(env, address, "BulletInAllowance", "host");
+                        }
+                    } catch {
+                        setBulletinWarning(null);
+                    }
+                };
+
+                await refreshBulletinWarning();
 
                 const allMarked = marked.every(Boolean) && slotKeys.every(Boolean);
                 if (allMarked) {
@@ -224,6 +219,7 @@ export function AccountSetup({
                     for (const resource of summary.granted) {
                         await markAllowance(env, address, resource.tag, "host");
                     }
+                    await refreshBulletinWarning();
 
                     if (summary.rejected.length > 0 || summary.unavailable.length > 0) {
                         const denied = [...summary.rejected, ...summary.unavailable]

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -154,9 +154,9 @@ export function AccountSetup({
                     hasSlotAccountKey(env, address, "StatementStoreAllowance"),
                 ]);
 
-                const refreshBulletinAllowanceMarker = async () => {
+                const refreshBulletinAllowanceMarker = async (): Promise<boolean> => {
                     const bulletinKey = await readSlotAccountKey(env, address, "BulletInAllowance");
-                    if (!bulletinKey) return;
+                    if (!bulletinKey) return false;
                     try {
                         const authorization = await getBulletinSlotAuthorization(
                             client.bulletin,
@@ -166,12 +166,18 @@ export function AccountSetup({
                         if (authorization.usable) {
                             await markAllowance(env, address, "BulletInAllowance", "host");
                         }
-                    } catch {}
+                        return authorization.usable;
+                    } catch {
+                        return false;
+                    }
                 };
 
-                await refreshBulletinAllowanceMarker();
+                const bulletinReady = await refreshBulletinAllowanceMarker();
 
-                const allMarked = marked.every(Boolean) && slotKeys.every(Boolean);
+                const resourcesReady = tags.every((tag, index) =>
+                    tag === "BulletInAllowance" ? bulletinReady : marked[index],
+                );
+                const allMarked = resourcesReady && slotKeys.every(Boolean);
                 if (allMarked) {
                     update(0, {
                         status: "ok",
@@ -201,6 +207,7 @@ export function AccountSetup({
                     // RFC-0010 allocation outcomes are independent: keep any
                     // successful keys even if a sibling resource was denied.
                     for (const resource of summary.granted) {
+                        if (resource.tag === "BulletInAllowance") continue;
                         await markAllowance(env, address, resource.tag, "host");
                     }
                     await refreshBulletinAllowanceMarker();

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -20,7 +20,7 @@ import { getConnection } from "../../utils/connection.js";
 import { getSessionSigner, type SessionHandle } from "../../utils/auth.js";
 import { topUpFromBulletinDev } from "../../utils/account/bulletinTopUp.js";
 import { checkMapping, ensureMapped } from "../../utils/account/mapping.js";
-import { DEFAULT_ENV, PLAYGROUND_PRODUCT_ID, getChainConfig } from "../../config.js";
+import { DEFAULT_ENV, PLAYGROUND_PRODUCT_ID } from "../../config.js";
 import {
     PLAYGROUND_RESOURCES,
     requestResourceAllocation,
@@ -67,10 +67,6 @@ interface PhonePrompt {
     label: string;
 }
 
-interface BulletinWarning {
-    slotAccountAddress: string;
-}
-
 /** Human-readable name for a resource tag, used in failure messages. */
 function describeResource(r: AllocatableResource): string {
     switch (r.tag) {
@@ -97,8 +93,6 @@ export function AccountSetup({
         { label: "funding", status: "pending" },
     ]);
     const [phonePrompt, setPhonePrompt] = useState<PhonePrompt | null>(null);
-    const [bulletinWarning, setBulletinWarning] = useState<BulletinWarning | null>(null);
-    const bulletinAuthorizationUrl = getChainConfig(DEFAULT_ENV).bulletinAuthorizationUrl;
 
     useEffect(() => {
         let cancelled = false;
@@ -160,32 +154,22 @@ export function AccountSetup({
                     hasSlotAccountKey(env, address, "StatementStoreAllowance"),
                 ]);
 
-                const refreshBulletinWarning = async () => {
+                const refreshBulletinAllowanceMarker = async () => {
                     const bulletinKey = await readSlotAccountKey(env, address, "BulletInAllowance");
-                    if (!bulletinKey) {
-                        setBulletinWarning(null);
-                        return;
-                    }
+                    if (!bulletinKey) return;
                     try {
                         const authorization = await getBulletinSlotAuthorization(
                             client.bulletin,
                             bulletinKey,
                             1,
                         );
-                        setBulletinWarning(
-                            authorization.usable
-                                ? null
-                                : { slotAccountAddress: authorization.address },
-                        );
                         if (authorization.usable) {
                             await markAllowance(env, address, "BulletInAllowance", "host");
                         }
-                    } catch {
-                        setBulletinWarning(null);
-                    }
+                    } catch {}
                 };
 
-                await refreshBulletinWarning();
+                await refreshBulletinAllowanceMarker();
 
                 const allMarked = marked.every(Boolean) && slotKeys.every(Boolean);
                 if (allMarked) {
@@ -219,7 +203,7 @@ export function AccountSetup({
                     for (const resource of summary.granted) {
                         await markAllowance(env, address, resource.tag, "host");
                     }
-                    await refreshBulletinWarning();
+                    await refreshBulletinAllowanceMarker();
 
                     if (summary.rejected.length > 0 || summary.unavailable.length > 0) {
                         const denied = [...summary.rejected, ...summary.unavailable]
@@ -342,35 +326,6 @@ export function AccountSetup({
                         approve step {phonePrompt.step} of {phonePrompt.total}:{" "}
                         <Text bold>{phonePrompt.label}</Text>
                     </Text>
-                </Callout>
-            )}
-            {bulletinWarning && (
-                <Callout tone="warning" title="Bulletin authorization needed">
-                    {bulletinAuthorizationUrl ? (
-                        <>
-                            <Text>
-                                Open the Bulletin authorization faucet at{" "}
-                                <Text bold>{bulletinAuthorizationUrl}</Text>
-                            </Text>
-                            <Text>
-                                and authorize account{" "}
-                                <Text bold>{bulletinWarning.slotAccountAddress}</Text>
-                                {", then re-run "}
-                                <Text bold>dot init</Text>.
-                            </Text>
-                        </>
-                    ) : (
-                        <>
-                            <Text>
-                                Bulletin allowance account{" "}
-                                <Text bold>{bulletinWarning.slotAccountAddress}</Text> is not
-                                authorized yet.
-                            </Text>
-                            <Text>
-                                Re-run <Text bold>dot init</Text> after authorizing it.
-                            </Text>
-                        </>
-                    )}
                 </Callout>
             )}
         </Box>

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,13 +66,6 @@ export interface ChainConfig {
     bulletinAuthorizeV2: boolean;
     /** Public faucet URL, or null when allowances replace the funder flow. */
     faucetUrl: string | null;
-    /**
-     * Web faucet URL for manually authorizing the CLI's Bulletin slot account.
-     * Surfaced in `bulletinAuthorizationHelp` so the user has a recovery path
-     * on testnets. `null` on production / closed-devnet envs where allowances
-     * are pre-allocated and no manual path exists.
-     */
-    bulletinAuthorizationUrl: string | null;
 }
 
 // Paseo Next v2 — the active env. DotNS contracts are owned by
@@ -91,7 +84,6 @@ const PASEO_NEXT_V2: ChainConfig = {
     autoAccountMapping: true,
     bulletinAuthorizeV2: true,
     faucetUrl: null,
-    bulletinAuthorizationUrl: "https://paritytech.github.io/polkadot-bulletin-chain/authorizations",
 };
 
 const CONFIGS: Partial<Record<Env, ChainConfig>> = {

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -36,8 +36,20 @@ import { readSlotAccountKey, storeSlotAccountKey } from "./slotKeys.js";
 import { getChainConfig } from "../../config.js";
 
 const KEY = secretFromSeed(new Uint8Array(32).fill(7));
+const MOBILE_KEY = schnorrkelBytesFromScureSecret(KEY);
 const ENV = "paseo-next-v2";
 const OWNER = "5Owner";
+
+function schnorrkelBytesFromScureSecret(secret: Uint8Array): Uint8Array {
+    const raw = new Uint8Array(secret);
+    let carry = 0;
+    for (let i = 31; i >= 0; i--) {
+        const value = secret[i] + carry * 256;
+        raw[i] = value >> 3;
+        carry = value & 0x07;
+    }
+    return raw;
+}
 
 let root: string | null = null;
 
@@ -101,7 +113,6 @@ describe("Bulletin allowance authorization", () => {
             remainingBytes: 100n,
             expiration: 1,
         });
-
         const signer = await getBulletinAllowanceSigner({
             env: ENV,
             ownerAddress: OWNER,
@@ -118,8 +129,104 @@ describe("Bulletin allowance authorization", () => {
         expect(signer.publicKey).toHaveLength(32);
     });
 
-    it("creates a local slot key and points to the faucet when it is not authorized", async () => {
+    it("normalizes and uses a mobile-returned slot key when none is cached", async () => {
+        const owner = `${OWNER}-mobile`;
+        const requestResourceAllocation = vi.fn(async () => ({
+            isErr: () => false,
+            value: [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: MOBILE_KEY },
+                    },
+                },
+            ],
+        }));
         checkAuthorizationMock.mockResolvedValueOnce({
+            authorized: true,
+            remainingTransactions: 1,
+            remainingBytes: 100n,
+            expiration: 1,
+        });
+        await expect(readSlotAccountKey(ENV, owner, "BulletInAllowance")).resolves.toBeNull();
+
+        const signer = await getBulletinAllowanceSigner({
+            env: ENV,
+            ownerAddress: owner,
+            publishSigner: {
+                source: "session",
+                address: owner,
+                signer: {} as any,
+                userSession: { requestResourceAllocation } as any,
+                destroy() {},
+            },
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+        });
+
+        expect(requestResourceAllocation).toHaveBeenCalledWith({
+            callingProductId: "playground.dot",
+            resources: [{ tag: "BulletInAllowance", value: undefined }],
+            onExisting: "Ignore",
+        });
+        expect(signer.publicKey).toHaveLength(32);
+        await expect(readSlotAccountKey(ENV, owner, "BulletInAllowance")).resolves.toEqual(KEY);
+    });
+
+    it("requests an additional Bulletin slot when cached authorization lacks quota", async () => {
+        await storeSlotAccountKey(ENV, OWNER, "BulletInAllowance", KEY);
+        const requestResourceAllocation = vi.fn(async () => ({
+            isErr: () => false,
+            value: [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: MOBILE_KEY },
+                    },
+                },
+            ],
+        }));
+        checkAuthorizationMock
+            .mockResolvedValueOnce({
+                authorized: true,
+                remainingTransactions: 0,
+                remainingBytes: 100n,
+                expiration: 1,
+            })
+            .mockResolvedValueOnce({
+                authorized: true,
+                remainingTransactions: 1,
+                remainingBytes: 100n,
+                expiration: 1,
+            });
+
+        const signer = await getBulletinAllowanceSigner({
+            env: ENV,
+            ownerAddress: OWNER,
+            publishSigner: {
+                source: "session",
+                address: OWNER,
+                signer: {} as any,
+                userSession: { requestResourceAllocation } as any,
+                destroy() {},
+            },
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+        });
+
+        expect(requestResourceAllocation).toHaveBeenCalledWith({
+            callingProductId: "playground.dot",
+            resources: [{ tag: "BulletInAllowance", value: undefined }],
+            onExisting: "Increase",
+        });
+        expect(signer.publicKey).toHaveLength(32);
+    });
+
+    it("points to the faucet when the cached slot key is not authorized", async () => {
+        await storeSlotAccountKey(ENV, OWNER, "BulletInAllowance", KEY);
+        checkAuthorizationMock.mockResolvedValue({
             authorized: false,
             remainingTransactions: 0,
             remainingBytes: 0n,
@@ -134,14 +241,13 @@ describe("Bulletin allowance authorization", () => {
                     source: "session",
                     address: OWNER,
                     signer: {} as any,
+                    userSession: { requestResourceAllocation: vi.fn() } as any,
                     destroy() {},
                 },
                 bulletinApi: {} as any,
                 requiredBytes: 50,
             }),
         ).rejects.toThrow(/Bulletin authorization faucet/);
-
-        await expect(readSlotAccountKey(ENV, OWNER, "BulletInAllowance")).resolves.toHaveLength(64);
     });
 });
 

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -31,7 +31,9 @@ import { getBulletinAllowanceSigner, hasUsableBulletinSlotAuthorization } from "
 import { readSlotAccountKey, storeSlotAccountKey } from "./slotKeys.js";
 
 const KEY = secretFromSeed(new Uint8Array(32).fill(7));
+const KEY_2 = secretFromSeed(new Uint8Array(32).fill(8));
 const MOBILE_KEY = schnorrkelBytesFromScureSecret(KEY);
+const MOBILE_KEY_2 = schnorrkelBytesFromScureSecret(KEY_2);
 const ENV = "paseo-next-v2";
 const OWNER = "5Owner";
 
@@ -213,8 +215,63 @@ describe("Bulletin allowance authorization", () => {
         expect(signer.publicKey).toHaveLength(32);
     });
 
+    it("syncs with mobile when the cached slot key is not authorized", async () => {
+        await storeSlotAccountKey(ENV, OWNER, "BulletInAllowance", KEY);
+        const requestResourceAllocation = vi.fn(async () => ({
+            isErr: () => false,
+            value: [
+                {
+                    tag: "Allocated",
+                    value: {
+                        tag: "BulletInAllowance",
+                        value: { slotAccountKey: MOBILE_KEY_2 },
+                    },
+                },
+            ],
+        }));
+        checkAuthorizationMock
+            .mockResolvedValueOnce({
+                authorized: false,
+                remainingTransactions: 0,
+                remainingBytes: 0n,
+                expiration: 0,
+            })
+            .mockResolvedValueOnce({
+                authorized: true,
+                remainingTransactions: 1,
+                remainingBytes: 100n,
+                expiration: 1,
+            });
+
+        const signer = await getBulletinAllowanceSigner({
+            env: ENV,
+            ownerAddress: OWNER,
+            publishSigner: {
+                source: "session",
+                address: OWNER,
+                signer: {} as any,
+                userSession: { requestResourceAllocation } as any,
+                destroy() {},
+            },
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+        });
+
+        expect(requestResourceAllocation).toHaveBeenCalledWith({
+            callingProductId: "playground.dot",
+            resources: [{ tag: "BulletInAllowance", value: undefined }],
+            onExisting: "Ignore",
+        });
+        expect(signer.publicKey).toHaveLength(32);
+        await expect(readSlotAccountKey(ENV, OWNER, "BulletInAllowance")).resolves.toEqual(KEY_2);
+    });
+
     it("points back to mobile approval when the cached slot key is not authorized", async () => {
         await storeSlotAccountKey(ENV, OWNER, "BulletInAllowance", KEY);
+        const requestResourceAllocation = vi.fn(async () => ({
+            isErr: () => false,
+            value: [{ tag: "Rejected", value: undefined }],
+        }));
         checkAuthorizationMock.mockResolvedValue({
             authorized: false,
             remainingTransactions: 0,
@@ -230,12 +287,17 @@ describe("Bulletin allowance authorization", () => {
                     source: "session",
                     address: OWNER,
                     signer: {} as any,
-                    userSession: { requestResourceAllocation: vi.fn() } as any,
+                    userSession: { requestResourceAllocation } as any,
                     destroy() {},
                 },
                 bulletinApi: {} as any,
                 requiredBytes: 50,
             }),
         ).rejects.toThrow(/Re-run `dot init` and approve on your phone/);
+        expect(requestResourceAllocation).toHaveBeenCalledWith({
+            callingProductId: "playground.dot",
+            resources: [{ tag: "BulletInAllowance", value: undefined }],
+            onExisting: "Ignore",
+        });
     });
 });

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -27,13 +27,8 @@ vi.mock("@parity/product-sdk-bulletin", () => ({
     checkAuthorization: checkAuthorizationMock,
 }));
 
-import {
-    bulletinAuthorizationHelp,
-    getBulletinAllowanceSigner,
-    hasUsableBulletinSlotAuthorization,
-} from "./bulletin.js";
+import { getBulletinAllowanceSigner, hasUsableBulletinSlotAuthorization } from "./bulletin.js";
 import { readSlotAccountKey, storeSlotAccountKey } from "./slotKeys.js";
-import { getChainConfig } from "../../config.js";
 
 const KEY = secretFromSeed(new Uint8Array(32).fill(7));
 const MOBILE_KEY = schnorrkelBytesFromScureSecret(KEY);
@@ -66,12 +61,6 @@ afterEach(async () => {
 });
 
 describe("Bulletin allowance authorization", () => {
-    it("formats manual authorization help for slot-account recovery", () => {
-        expect(bulletinAuthorizationHelp("5Slot")).toBe(
-            "Open the Bulletin authorization faucet at https://paritytech.github.io/polkadot-bulletin-chain/authorizations and authorize account 5Slot, then re-run `dot init`.",
-        );
-    });
-
     it("checks the slot account address derived from the returned private key", async () => {
         checkAuthorizationMock.mockResolvedValue({
             authorized: true,
@@ -224,7 +213,7 @@ describe("Bulletin allowance authorization", () => {
         expect(signer.publicKey).toHaveLength(32);
     });
 
-    it("points to the faucet when the cached slot key is not authorized", async () => {
+    it("points back to mobile approval when the cached slot key is not authorized", async () => {
         await storeSlotAccountKey(ENV, OWNER, "BulletInAllowance", KEY);
         checkAuthorizationMock.mockResolvedValue({
             authorized: false,
@@ -247,41 +236,6 @@ describe("Bulletin allowance authorization", () => {
                 bulletinApi: {} as any,
                 requiredBytes: 50,
             }),
-        ).rejects.toThrow(/Bulletin authorization faucet/);
-    });
-});
-
-describe("bulletinAuthorizationHelp", () => {
-    const ADDR = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-
-    it("includes the explicitly-passed faucet URL + slot account SS58", () => {
-        const help = bulletinAuthorizationHelp(ADDR, "https://example.test/faucet");
-        expect(help).toContain("https://example.test/faucet");
-        expect(help).toContain(ADDR);
-        // The user needs an actionable instruction, not just a URL drop —
-        // make sure the "re-run dot init" hint stays in the string.
-        expect(help).toMatch(/re-run.*dot init/i);
-    });
-
-    it("falls back to a no-faucet message when no faucet URL is configured", () => {
-        const help = bulletinAuthorizationHelp(ADDR, null);
-        // Mainnet / closed Summit devnet won't have a public faucet — the
-        // help must not invite users to a URL that doesn't apply.
-        expect(help).not.toMatch(/https?:\/\//);
-        expect(help).toContain(ADDR);
-        expect(help).toMatch(/not authorized/i);
-    });
-
-    it("defaults to the active env's bulletinAuthorizationUrl when no URL passed", () => {
-        const help = bulletinAuthorizationHelp(ADDR);
-        const cfgUrl = getChainConfig().bulletinAuthorizationUrl;
-        if (cfgUrl) {
-            expect(help).toContain(cfgUrl);
-            // Pin the literal path component so a future rename of the
-            // constant can't silently produce a wrong user-facing URL.
-            expect(help).toMatch(/paritytech\.github\.io\/polkadot-bulletin-chain\/authorizations/);
-        } else {
-            expect(help).not.toMatch(/https?:\/\//);
-        }
+        ).rejects.toThrow(/Re-run `dot init` and approve on your phone/);
     });
 });

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -19,7 +19,7 @@ import { PLAYGROUND_PRODUCT_ID, type Env } from "../../config.js";
 import type { ResolvedSigner } from "../signer.js";
 import {
     createSlotAccountSigner,
-    getSlotAccountKeyCandidates,
+    getSlotAccountAddress,
     readSlotAccountKey,
     storeSlotAccountKeysFromOutcomes,
 } from "./slotKeys.js";
@@ -69,23 +69,14 @@ export async function getBulletinSlotAuthorization(
     slotAccountKey: Uint8Array,
     requiredBytes = 0,
 ): Promise<BulletinSlotAuthorization> {
-    const candidates = getSlotAccountKeyCandidates(slotAccountKey);
-    const checked: BulletinSlotAuthorization[] = [];
-
-    for (const candidate of candidates) {
-        const status = await checkAuthorization(bulletinApi, candidate.address);
-        const usable = hasUsableAuthorization(status, requiredBytes);
-        const authorization = {
-            slotAccountKey: candidate.slotAccountKey,
-            address: candidate.address,
-            status,
-            usable,
-        };
-        if (usable || status.authorized) return authorization;
-        checked.push(authorization);
-    }
-
-    return checked.find((authorization) => authorization.status.authorized) ?? checked[0];
+    const address = getSlotAccountAddress(slotAccountKey);
+    const status = await checkAuthorization(bulletinApi, address);
+    return {
+        slotAccountKey,
+        address,
+        status,
+        usable: hasUsableAuthorization(status, requiredBytes),
+    };
 }
 
 function allocatedBulletinKey(outcomes: AllocationOutcome[]): Uint8Array | null {
@@ -153,6 +144,14 @@ export async function getBulletinAllowanceSigner({
     if (!bulletinApi) return createSlotAccountSigner(key);
 
     let authorization = await getBulletinSlotAuthorization(bulletinApi, key, requiredBytes);
+    if (!authorization.usable && !authorization.status.authorized) {
+        key = await requestBulletinAllowanceKey(
+            { env, ownerAddress, publishSigner, bulletinApi, requiredBytes },
+            "Ignore",
+        );
+        authorization = await getBulletinSlotAuthorization(bulletinApi, key, requiredBytes);
+    }
+
     if (!authorization.usable && authorization.status.authorized) {
         key = await requestBulletinAllowanceKey(
             { env, ownerAddress, publishSigner, bulletinApi, requiredBytes },

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -15,13 +15,15 @@
 
 import type { PolkadotSigner } from "polkadot-api";
 import { checkAuthorization, type BulletinApi } from "@parity/product-sdk-bulletin";
-import { getChainConfig, type Env } from "../../config.js";
+import { getChainConfig, PLAYGROUND_PRODUCT_ID, type Env } from "../../config.js";
 import type { ResolvedSigner } from "../signer.js";
 import {
     createSlotAccountSigner,
-    getOrCreateSlotAccountKey,
-    getSlotAccountAddress,
+    getSlotAccountKeyCandidates,
+    readSlotAccountKey,
+    storeSlotAccountKeysFromOutcomes,
 } from "./slotKeys.js";
+import { requestResourceAllocation, type AllocationOutcome } from "./host.js";
 
 export interface BulletinAllowanceSignerOptions {
     env: Env;
@@ -51,20 +53,91 @@ function hasUsableAuthorization(
     );
 }
 
+export interface BulletinSlotAuthorization {
+    slotAccountKey: Uint8Array;
+    address: string;
+    status: Awaited<ReturnType<typeof checkAuthorization>>;
+    usable: boolean;
+}
+
 export async function hasUsableBulletinSlotAuthorization(
     bulletinApi: BulletinApi,
     slotAccountKey: Uint8Array,
     requiredBytes = 0,
 ): Promise<boolean> {
-    const status = await getBulletinSlotAuthorization(bulletinApi, slotAccountKey);
-    return hasUsableAuthorization(status, requiredBytes);
+    const authorization = await getBulletinSlotAuthorization(
+        bulletinApi,
+        slotAccountKey,
+        requiredBytes,
+    );
+    return authorization.usable;
 }
 
-async function getBulletinSlotAuthorization(
+export async function getBulletinSlotAuthorization(
     bulletinApi: BulletinApi,
     slotAccountKey: Uint8Array,
-): Promise<Awaited<ReturnType<typeof checkAuthorization>>> {
-    return await checkAuthorization(bulletinApi, getSlotAccountAddress(slotAccountKey));
+    requiredBytes = 0,
+): Promise<BulletinSlotAuthorization> {
+    const candidates = getSlotAccountKeyCandidates(slotAccountKey);
+    const checked: BulletinSlotAuthorization[] = [];
+
+    for (const candidate of candidates) {
+        const status = await checkAuthorization(bulletinApi, candidate.address);
+        const usable = hasUsableAuthorization(status, requiredBytes);
+        const authorization = {
+            slotAccountKey: candidate.slotAccountKey,
+            address: candidate.address,
+            status,
+            usable,
+        };
+        if (usable || status.authorized) return authorization;
+        checked.push(authorization);
+    }
+
+    return checked.find((authorization) => authorization.status.authorized) ?? checked[0];
+}
+
+function allocatedBulletinKey(outcomes: AllocationOutcome[]): Uint8Array | null {
+    for (const outcome of outcomes) {
+        if (outcome.tag !== "Allocated") continue;
+        const value = outcome.value as
+            | { tag?: string; value?: { slotAccountKey?: Uint8Array } }
+            | undefined;
+        if (value?.tag !== "BulletInAllowance") continue;
+        return value.value?.slotAccountKey instanceof Uint8Array
+            ? value.value.slotAccountKey
+            : null;
+    }
+    return null;
+}
+
+async function requestBulletinAllowanceKey(
+    { env, ownerAddress, publishSigner }: BulletinAllowanceSignerOptions,
+    onExisting: "Ignore" | "Increase",
+): Promise<Uint8Array> {
+    if (!publishSigner.userSession) {
+        throw new Error(
+            'No Bulletin allowance account cached. Run "dot init" to grant allowances.',
+        );
+    }
+
+    const outcomes = await requestResourceAllocation(
+        publishSigner.userSession,
+        PLAYGROUND_PRODUCT_ID,
+        [{ tag: "BulletInAllowance", value: undefined }],
+        onExisting,
+    );
+    await storeSlotAccountKeysFromOutcomes(env, ownerAddress, outcomes);
+
+    const key = allocatedBulletinKey(outcomes);
+    const cached = await readSlotAccountKey(env, ownerAddress, "BulletInAllowance");
+    if (cached) return cached;
+
+    if (key) return key;
+    const outcome = outcomes[0];
+    throw new Error(
+        `Bulletin allowance allocation ${outcome?.tag ?? "returned no outcome"}. Re-run \`dot init\` and approve on your phone.`,
+    );
 }
 
 export async function getBulletinAllowanceSigner({
@@ -78,21 +151,35 @@ export async function getBulletinAllowanceSigner({
     // supplied a local key and owns making sure it has Bulletin allowance.
     if (publishSigner.source === "dev") return publishSigner.signer;
 
-    const key = await getOrCreateSlotAccountKey(env, ownerAddress, "BulletInAllowance");
+    let key = await readSlotAccountKey(env, ownerAddress, "BulletInAllowance");
+    if (!key) {
+        key = await requestBulletinAllowanceKey(
+            { env, ownerAddress, publishSigner, bulletinApi, requiredBytes },
+            "Ignore",
+        );
+    }
 
     if (!bulletinApi) return createSlotAccountSigner(key);
 
-    const status = await getBulletinSlotAuthorization(bulletinApi, key);
-    if (!hasUsableAuthorization(status, requiredBytes)) {
-        const address = getSlotAccountAddress(key);
+    let authorization = await getBulletinSlotAuthorization(bulletinApi, key, requiredBytes);
+    if (!authorization.usable && authorization.status.authorized) {
+        key = await requestBulletinAllowanceKey(
+            { env, ownerAddress, publishSigner, bulletinApi, requiredBytes },
+            "Increase",
+        );
+        authorization = await getBulletinSlotAuthorization(bulletinApi, key, requiredBytes);
+    }
+
+    if (!authorization.usable) {
+        const address = authorization.address;
         throw new Error(
-            status.authorized
+            authorization.status.authorized
                 ? `Bulletin allowance for ${address} is live but does not have enough quota. ${bulletinAuthorizationHelp(address)}`
                 : `Bulletin allowance account ${address} is not authorized. ${bulletinAuthorizationHelp(address)}`,
         );
     }
 
-    return createSlotAccountSigner(key);
+    return createSlotAccountSigner(authorization.slotAccountKey);
 }
 
 export function isInvalidPaymentError(err: unknown): boolean {

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -15,7 +15,7 @@
 
 import type { PolkadotSigner } from "polkadot-api";
 import { checkAuthorization, type BulletinApi } from "@parity/product-sdk-bulletin";
-import { getChainConfig, PLAYGROUND_PRODUCT_ID, type Env } from "../../config.js";
+import { PLAYGROUND_PRODUCT_ID, type Env } from "../../config.js";
 import type { ResolvedSigner } from "../signer.js";
 import {
     createSlotAccountSigner,
@@ -31,15 +31,6 @@ export interface BulletinAllowanceSignerOptions {
     publishSigner: ResolvedSigner;
     bulletinApi?: BulletinApi;
     requiredBytes?: number;
-}
-
-export function bulletinAuthorizationHelp(
-    slotAccountAddress: string,
-    faucetUrl: string | null = getChainConfig().bulletinAuthorizationUrl,
-): string {
-    return faucetUrl
-        ? `Open the Bulletin authorization faucet at ${faucetUrl} and authorize account ${slotAccountAddress}, then re-run \`dot init\`.`
-        : `Bulletin allowance account ${slotAccountAddress} is not authorized yet. Re-run \`dot init\` after authorizing it.`;
 }
 
 function hasUsableAuthorization(
@@ -174,8 +165,8 @@ export async function getBulletinAllowanceSigner({
         const address = authorization.address;
         throw new Error(
             authorization.status.authorized
-                ? `Bulletin allowance for ${address} is live but does not have enough quota. ${bulletinAuthorizationHelp(address)}`
-                : `Bulletin allowance account ${address} is not authorized. ${bulletinAuthorizationHelp(address)}`,
+                ? `Bulletin allowance for ${address} is live but does not have enough quota. Re-run \`dot init\` and approve on your phone.`
+                : `Bulletin allowance account ${address} is not authorized. Re-run \`dot init\` and approve on your phone.`,
         );
     }
 

--- a/src/utils/allowances/host.test.ts
+++ b/src/utils/allowances/host.test.ts
@@ -23,9 +23,9 @@ import {
 } from "./host.js";
 
 describe("PLAYGROUND_RESOURCES", () => {
-    it("requests mobile-granted StatementStore + SmartContract resources by default", () => {
+    it("requests mobile-granted Bulletin + StatementStore + SmartContract resources by default", () => {
         const tags = PLAYGROUND_RESOURCES.map((r) => r.tag);
-        expect(tags).not.toContain("BulletInAllowance");
+        expect(tags).toContain("BulletInAllowance");
         expect(tags).toContain("StatementStoreAllowance");
         expect(tags).toContain("SmartContractAllowance");
     });

--- a/src/utils/allowances/host.ts
+++ b/src/utils/allowances/host.ts
@@ -42,9 +42,6 @@ import type { UserSession } from "@parity/product-sdk-terminal";
  *
  *   StatementStoreAllowance — write to the SSS (host_chat, allowance ring).
  *   BulletInAllowance       — write to Bulletin (TransactionStorage.store).
- *                             Not requested by `dot init` today; the CLI uses
- *                             a locally cached slot key and asks the user to
- *                             authorize it through the Bulletin faucet.
  *   SmartContractAllowance  — PGAS sponsoring for Revive contract calls.
  *                             The `value` is the derivation index of the
  *                             product account (0 for the default playground
@@ -77,6 +74,7 @@ export type OnExistingAllowancePolicy = "Ignore" | "Increase";
 
 /** Default mobile-granted resource set for the playground product. */
 export const PLAYGROUND_RESOURCES: AllocatableResource[] = [
+    { tag: "BulletInAllowance", value: undefined },
     { tag: "StatementStoreAllowance", value: undefined },
     // derivation index 0 = playground42.dot's default product account.
     { tag: "SmartContractAllowance", value: 0 },

--- a/src/utils/allowances/slotKeys.test.ts
+++ b/src/utils/allowances/slotKeys.test.ts
@@ -23,6 +23,7 @@ import {
     createSlotAccountSigner,
     extractSlotAccountKey,
     getOrCreateSlotAccountKey,
+    getSlotAccountKeyCandidates,
     hasSlotAccountKey,
     readSlotAccountKey,
     storeSlotAccountKey,
@@ -33,6 +34,18 @@ import type { AllocationOutcome } from "./host.js";
 const ADDR = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const KEY = secretFromSeed(new Uint8Array(32).fill(7));
 const KEY_2 = secretFromSeed(new Uint8Array(32).fill(8));
+const MINI_SECRET = new Uint8Array(32).fill(9);
+
+function schnorrkelBytesFromScureSecret(secret: Uint8Array): Uint8Array {
+    const raw = new Uint8Array(secret);
+    let carry = 0;
+    for (let i = 31; i >= 0; i--) {
+        const value = secret[i] + carry * 256;
+        raw[i] = value >> 3;
+        carry = value & 0x07;
+    }
+    return raw;
+}
 
 let tempRoot: string;
 let originalPolkadotRoot: string | undefined;
@@ -74,15 +87,17 @@ describe("slot account key cache", () => {
         );
     });
 
-    it("extracts and stores slot account keys from allocation outcomes", async () => {
+    it("extracts and stores normalized slot account keys from allocation outcomes", async () => {
+        const mobileKey = schnorrkelBytesFromScureSecret(KEY);
+        const mobileKey2 = schnorrkelBytesFromScureSecret(KEY_2);
         const outcomes: AllocationOutcome[] = [
             {
                 tag: "Allocated",
-                value: { tag: "BulletInAllowance", value: { slotAccountKey: KEY } },
+                value: { tag: "BulletInAllowance", value: { slotAccountKey: mobileKey } },
             },
             {
                 tag: "Allocated",
-                value: { tag: "StatementStoreAllowance", value: { slotAccountKey: KEY_2 } },
+                value: { tag: "StatementStoreAllowance", value: { slotAccountKey: mobileKey2 } },
             },
             { tag: "Allocated", value: { tag: "SmartContractAllowance", value: undefined } },
         ];
@@ -102,14 +117,19 @@ describe("slot account key cache", () => {
         // and the second-returned sibling key would be dropped. The
         // batched read-modify-write must keep both keys.
         const otherKey = secretFromSeed(new Uint8Array(32).fill(13));
+        const mobileKey = schnorrkelBytesFromScureSecret(KEY);
+        const otherMobileKey = schnorrkelBytesFromScureSecret(otherKey);
         const outcomes: AllocationOutcome[] = [
             {
                 tag: "Allocated",
-                value: { tag: "BulletInAllowance", value: { slotAccountKey: KEY } },
+                value: { tag: "BulletInAllowance", value: { slotAccountKey: mobileKey } },
             },
             {
                 tag: "Allocated",
-                value: { tag: "StatementStoreAllowance", value: { slotAccountKey: otherKey } },
+                value: {
+                    tag: "StatementStoreAllowance",
+                    value: { slotAccountKey: otherMobileKey },
+                },
             },
         ];
 
@@ -126,6 +146,21 @@ describe("slot account key cache", () => {
 
         expect(signer.publicKey).toHaveLength(32);
         await expect(signer.signBytes(new Uint8Array([1, 2, 3]))).resolves.toHaveLength(64);
+    });
+
+    it("creates a signer from a 32-byte mini-secret slot account key", async () => {
+        const signer = createSlotAccountSigner(MINI_SECRET);
+
+        expect(signer.publicKey).toHaveLength(32);
+        await expect(signer.signBytes(new Uint8Array([1, 2, 3]))).resolves.toHaveLength(64);
+    });
+
+    it("returns compatibility candidates for legacy unnormalized 64-byte keys", () => {
+        const mobileKey = schnorrkelBytesFromScureSecret(KEY);
+        const candidates = getSlotAccountKeyCandidates(mobileKey);
+
+        expect(candidates).toHaveLength(2);
+        expect(candidates[1].slotAccountKey).toEqual(KEY);
     });
 
     it("creates and then reuses a local slot key when none is cached", async () => {

--- a/src/utils/allowances/slotKeys.test.ts
+++ b/src/utils/allowances/slotKeys.test.ts
@@ -23,7 +23,6 @@ import {
     createSlotAccountSigner,
     extractSlotAccountKey,
     getOrCreateSlotAccountKey,
-    getSlotAccountKeyCandidates,
     hasSlotAccountKey,
     readSlotAccountKey,
     storeSlotAccountKey,
@@ -153,14 +152,6 @@ describe("slot account key cache", () => {
 
         expect(signer.publicKey).toHaveLength(32);
         await expect(signer.signBytes(new Uint8Array([1, 2, 3]))).resolves.toHaveLength(64);
-    });
-
-    it("returns compatibility candidates for legacy unnormalized 64-byte keys", () => {
-        const mobileKey = schnorrkelBytesFromScureSecret(KEY);
-        const candidates = getSlotAccountKeyCandidates(mobileKey);
-
-        expect(candidates).toHaveLength(2);
-        expect(candidates[1].slotAccountKey).toEqual(KEY);
     });
 
     it("creates and then reuses a local slot key when none is cached", async () => {

--- a/src/utils/allowances/slotKeys.ts
+++ b/src/utils/allowances/slotKeys.ts
@@ -137,45 +137,6 @@ function slotAccountSigningSecret(key: Uint8Array): Uint8Array {
     return normalized.length === 32 ? secretFromSeed(normalized) : normalized;
 }
 
-export interface SlotAccountKeyCandidate {
-    slotAccountKey: Uint8Array;
-    publicKey: Uint8Array;
-    address: string;
-}
-
-export function getSlotAccountKeyCandidates(slotAccountKey: Uint8Array): SlotAccountKeyCandidate[] {
-    const normalized = normalizeSlotAccountKey(slotAccountKey);
-    const secrets =
-        normalized.length === 32
-            ? [secretFromSeed(normalized)]
-            : [normalized, normalizeSchnorrkelSecretKeyBytes(normalized)];
-    const seen = new Set<string>();
-    const candidates: SlotAccountKeyCandidate[] = [];
-
-    for (const secret of secrets) {
-        let publicKey: Uint8Array;
-        try {
-            publicKey = getPublicKey(secret);
-        } catch {
-            continue;
-        }
-        const publicKeyHex = toHex(publicKey);
-        if (seen.has(publicKeyHex)) continue;
-        seen.add(publicKeyHex);
-        candidates.push({
-            slotAccountKey: secret,
-            publicKey,
-            address: AccountId().dec(publicKey),
-        });
-    }
-
-    if (candidates.length === 0) {
-        throw new Error("Unable to derive sr25519 public key from slot account key");
-    }
-
-    return candidates;
-}
-
 export async function readSlotAccountKey(
     env: Env,
     address: string,
@@ -291,7 +252,7 @@ export function createSlotAccountSigner(slotAccountKey: Uint8Array): PolkadotSig
 }
 
 export function getSlotAccountAddress(slotAccountKey: Uint8Array): string {
-    return getSlotAccountKeyCandidates(slotAccountKey)[0].address;
+    return AccountId().dec(getPublicKey(slotAccountSigningSecret(slotAccountKey)));
 }
 
 /** Visible for tests; not part of the public API. @internal */

--- a/src/utils/allowances/slotKeys.ts
+++ b/src/utils/allowances/slotKeys.ts
@@ -96,10 +96,84 @@ function isSlotAccountResource(tag: ResourceTag): tag is SlotAccountResourceTag 
 }
 
 function normalizeSlotAccountKey(key: Uint8Array): Uint8Array {
-    if (key.length !== 64) {
-        throw new Error(`Expected 64-byte sr25519 slot account key, got ${key.length} bytes`);
+    if (key.length !== 32 && key.length !== 64) {
+        throw new Error(
+            `Expected 32-byte sr25519 mini-secret or 64-byte slot account key, got ${key.length} bytes`,
+        );
     }
     return new Uint8Array(key);
+}
+
+function encodeSchnorrkelScalarForScure(secret: Uint8Array): Uint8Array {
+    const encoded = new Uint8Array(32);
+    let carry = 0;
+    for (let i = 0; i < 32; i++) {
+        const value = secret[i] * 8 + carry;
+        encoded[i] = value & 0xff;
+        carry = value >> 8;
+    }
+    return encoded;
+}
+
+function normalizeSchnorrkelSecretKeyBytes(secret: Uint8Array): Uint8Array {
+    const normalized = new Uint8Array(secret);
+    normalized.set(encodeSchnorrkelScalarForScure(secret.subarray(0, 32)), 0);
+    return normalized;
+}
+
+function normalizeAllocatedSlotAccountKey(key: Uint8Array): Uint8Array {
+    const normalized = normalizeSlotAccountKey(key);
+    if (normalized.length === 32) return normalized;
+
+    // Account Protocol mobile implementations hand over schnorrkel
+    // `SecretKey::to_bytes()` material. @scure/sr25519 signs with the
+    // `to_ed25519_bytes()` scalar representation, so normalize the scalar
+    // half before caching keys returned by `requestResourceAllocation`.
+    return normalizeSchnorrkelSecretKeyBytes(normalized);
+}
+
+function slotAccountSigningSecret(key: Uint8Array): Uint8Array {
+    const normalized = normalizeSlotAccountKey(key);
+    return normalized.length === 32 ? secretFromSeed(normalized) : normalized;
+}
+
+export interface SlotAccountKeyCandidate {
+    slotAccountKey: Uint8Array;
+    publicKey: Uint8Array;
+    address: string;
+}
+
+export function getSlotAccountKeyCandidates(slotAccountKey: Uint8Array): SlotAccountKeyCandidate[] {
+    const normalized = normalizeSlotAccountKey(slotAccountKey);
+    const secrets =
+        normalized.length === 32
+            ? [secretFromSeed(normalized)]
+            : [normalized, normalizeSchnorrkelSecretKeyBytes(normalized)];
+    const seen = new Set<string>();
+    const candidates: SlotAccountKeyCandidate[] = [];
+
+    for (const secret of secrets) {
+        let publicKey: Uint8Array;
+        try {
+            publicKey = getPublicKey(secret);
+        } catch {
+            continue;
+        }
+        const publicKeyHex = toHex(publicKey);
+        if (seen.has(publicKeyHex)) continue;
+        seen.add(publicKeyHex);
+        candidates.push({
+            slotAccountKey: secret,
+            publicKey,
+            address: AccountId().dec(publicKey),
+        });
+    }
+
+    if (candidates.length === 0) {
+        throw new Error("Unable to derive sr25519 public key from slot account key");
+    }
+
+    return candidates;
 }
 
 export async function readSlotAccountKey(
@@ -165,7 +239,7 @@ export function extractSlotAccountKey(
             | undefined;
         if (allocated?.tag !== resource) continue;
         const key = allocated.value?.slotAccountKey;
-        return key instanceof Uint8Array ? normalizeSlotAccountKey(key) : null;
+        return key instanceof Uint8Array ? normalizeAllocatedSlotAccountKey(key) : null;
     }
     return null;
 }
@@ -199,7 +273,7 @@ export async function storeSlotAccountKeysFromOutcomes(
         const envBucket = file.envs[env] ?? {};
         const addrBucket = envBucket[address] ?? {};
         addrBucket[allocated.tag] = {
-            slotAccountKey: toHex(normalizeSlotAccountKey(key)) as `0x${string}`,
+            slotAccountKey: toHex(normalizeAllocatedSlotAccountKey(key)) as `0x${string}`,
             storedAt,
         };
         envBucket[address] = addrBucket;
@@ -211,14 +285,20 @@ export async function storeSlotAccountKeysFromOutcomes(
 }
 
 export function createSlotAccountSigner(slotAccountKey: Uint8Array): PolkadotSigner {
-    const secret = normalizeSlotAccountKey(slotAccountKey);
+    const secret = slotAccountSigningSecret(slotAccountKey);
     const publicKey = getPublicKey(secret);
     return getPolkadotSigner(publicKey, "Sr25519", (payload) => sign(secret, payload));
 }
 
 export function getSlotAccountAddress(slotAccountKey: Uint8Array): string {
-    return AccountId().dec(getPublicKey(normalizeSlotAccountKey(slotAccountKey)));
+    return getSlotAccountKeyCandidates(slotAccountKey)[0].address;
 }
 
 /** Visible for tests; not part of the public API. @internal */
-export const _internal = { getKeyPath, loadFile, saveFile };
+export const _internal = {
+    getKeyPath,
+    loadFile,
+    saveFile,
+    normalizeAllocatedSlotAccountKey,
+    normalizeSchnorrkelSecretKeyBytes,
+};


### PR DESCRIPTION
## Summary

- request Bulletin allowance during init through the RFC10 resource-allocation flow again
- normalize mobile-returned Bulletin slot-account keys before caching/signing
- verify cached Bulletin allowance against chain state and request an additional allocation when cached allowance exists but quota is insufficient
- keep the Bulletin authorization faucet message as the fallback when the returned account is still not usable on-chain

## Testing

- `pnpm exec vitest run src/utils/allowances/host.test.ts src/utils/allowances/slotKeys.test.ts src/utils/allowances/bulletin.test.ts src/commands/init/completion.test.ts src/utils/deploy/playground.test.ts`
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm test`
- `pnpm build`
