### PR TITLE
Update contract registry metadata

### DIFF
--- a/cdm.json
+++ b/cdm.json
@@ -14,8 +14,8 @@
   "contracts": {
     "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 4,
-        "address": "0x4A2A04037D50aFA31C3DA7277468f6df2F7e474f",
+        "version": 7,
+        "address": "0xea3fb6C5cDA79FEEf5b2d42a9122fC1BAFaF647F",
         "abi": [
           {
             "type": "constructor",
@@ -579,7 +579,7 @@
             "stateMutability": "nonpayable"
           }
         ],
-        "metadataCid": "bafk2bzaceajiw66tkplioguc76xyqxda6sxs2dvvpmthgr65xpnvy3rdbxx4w"
+        "metadataCid": "bafk2bzacedinnjvwctmltwri2xkmzhe26gt3ou7dimujsnwbinst3t33n2qgy"
       }
     }
   }

--- a/cdm.json
+++ b/cdm.json
@@ -1,21 +1,21 @@
 {
   "targets": {
-    "8e7e0cf0a51d8e5e": {
+    "929b5c63e2cb5202": {
       "asset-hub": "wss://paseo-asset-hub-next-rpc.polkadot.io",
       "bulletin": "https://paseo-bulletin-next-ipfs.polkadot.io/ipfs",
-      "registry": "0x5c7b23d386ff622c7f7a4e7a95d5c7a67b10a00d"
+      "registry": "0xa7ae171c78f06c248a9b2556c793aa1df5c9173a"
     }
   },
   "dependencies": {
-    "8e7e0cf0a51d8e5e": {
+    "929b5c63e2cb5202": {
       "@w3s/playground-registry": "latest"
     }
   },
   "contracts": {
-    "8e7e0cf0a51d8e5e": {
+    "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 0,
-        "address": "0xE6A1cAd79b4b1b209fFF12CD5F9FF7a8F9782e55",
+        "version": 1,
+        "address": "0xbC8C7d2d4032b360901129288d5eEf39b2981a8b",
         "abi": [
           {
             "type": "constructor",
@@ -37,6 +37,20 @@
               {
                 "name": "visibility",
                 "type": "uint8"
+              },
+              {
+                "name": "owner",
+                "type": "tuple",
+                "components": [
+                  {
+                    "name": "isSome",
+                    "type": "bool"
+                  },
+                  {
+                    "name": "value",
+                    "type": "address"
+                  }
+                ]
               }
             ],
             "outputs": [],
@@ -344,6 +358,10 @@
                   {
                     "name": "visibility",
                     "type": "uint8"
+                  },
+                  {
+                    "name": "publisher",
+                    "type": "address"
                   }
                 ]
               }
@@ -399,6 +417,10 @@
                       {
                         "name": "visibility",
                         "type": "uint8"
+                      },
+                      {
+                        "name": "publisher",
+                        "type": "address"
                       }
                     ]
                   }
@@ -450,9 +472,114 @@
               }
             ],
             "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "setFrozen",
+            "inputs": [
+              {
+                "name": "value",
+                "type": "bool"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "isFrozen",
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "refreshReputationReference",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "importApp",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              },
+              {
+                "name": "owner",
+                "type": "address"
+              },
+              {
+                "name": "publisher",
+                "type": "address"
+              },
+              {
+                "name": "visibility",
+                "type": "uint8"
+              },
+              {
+                "name": "metadata_uri",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "importApps",
+            "inputs": [
+              {
+                "name": "apps",
+                "type": "tuple[]",
+                "components": [
+                  {
+                    "name": "domain",
+                    "type": "string"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address"
+                  },
+                  {
+                    "name": "publisher",
+                    "type": "address"
+                  },
+                  {
+                    "name": "visibility",
+                    "type": "uint8"
+                  },
+                  {
+                    "name": "metadata_uri",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "importPinned",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
           }
         ],
-        "metadataCid": "bafk2bzacedmabtpbb7ji7hwwctxez7ppsxhin6my7kiykovm6pt3mpsbhk7lm"
+        "metadataCid": "bafk2bzaced4t7n46fsnvkjsajlndhmeq3kuq4wqodeha5w5v5lwyjrg22ahou"
       }
     }
   }

--- a/cdm.json
+++ b/cdm.json
@@ -14,8 +14,8 @@
   "contracts": {
     "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 1,
-        "address": "0xbC8C7d2d4032b360901129288d5eEf39b2981a8b",
+        "version": 4,
+        "address": "0x4A2A04037D50aFA31C3DA7277468f6df2F7e474f",
         "abi": [
           {
             "type": "constructor",
@@ -579,7 +579,7 @@
             "stateMutability": "nonpayable"
           }
         ],
-        "metadataCid": "bafk2bzaced4t7n46fsnvkjsajlndhmeq3kuq4wqodeha5w5v5lwyjrg22ahou"
+        "metadataCid": "bafk2bzaceajiw66tkplioguc76xyqxda6sxs2dvvpmthgr65xpnvy3rdbxx4w"
       }
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0)
 
 packages:
 
@@ -4180,6 +4180,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -4406,8 +4411,8 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  terser@5.47.1:
-    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7788,7 +7793,7 @@ snapshots:
       metro: 0.84.4
       metro-config: 0.84.4
       metro-core: 0.84.4
-      semver: 7.8.0
+      semver: 7.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8238,13 +8243,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9677,7 +9682,7 @@ snapshots:
   metro-minify-terser@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
-      terser: 5.47.1
+      terser: 5.48.0
 
   metro-resolver@0.84.4:
     dependencies:
@@ -10349,7 +10354,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.27.0
-      semver: 7.8.0
+      semver: 7.8.1
       stacktrace-parser: 0.1.11
       tinyglobby: 0.2.16
       whatwg-fetch: 3.6.20
@@ -10561,6 +10566,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.0: {}
+
+  semver@7.8.1: {}
 
   send@0.19.2:
     dependencies:
@@ -10809,7 +10816,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser@5.47.1:
+  terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -11015,13 +11022,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -11036,7 +11043,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0):
+  vite@7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11047,14 +11054,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
-      terser: 5.47.1
+      terser: 5.48.0
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -11072,8 +11079,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(terser@5.47.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/src/commands/contractDeployUi.tsx
+++ b/src/commands/contractDeployUi.tsx
@@ -458,13 +458,6 @@ function formatBytes(bytes: number): string {
     return `${(bytes / 1_000_000).toFixed(1)}MB`;
 }
 
-function truncateMiddle(value: string, maxLength: number): string {
-    if (value.length <= maxLength) return value;
-    const prefix = Math.max(4, Math.floor((maxLength - 3) * 0.6));
-    const suffix = Math.max(4, maxLength - 3 - prefix);
-    return `${value.slice(0, prefix)}...${value.slice(-suffix)}`;
-}
-
 function shortHash(value: string): string {
     if (value.startsWith("0x")) return value.slice(2, 6);
     return value.slice(-4);

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -326,7 +326,10 @@ describe("publishToPlayground", () => {
                 expect.objectContaining({ __kind: "store" }),
                 bulletinStorageSigner,
             );
-            expect(publishTx).toHaveBeenCalledWith("my-app.dot", "bafymeta", 1);
+            expect(publishTx).toHaveBeenCalledWith("my-app.dot", "bafymeta", 1, {
+                isSome: false,
+                value: "0x0000000000000000000000000000000000000000",
+            });
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -385,7 +388,10 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
             isPrivate: true,
         });
-        expect(publishTx).toHaveBeenCalledWith("secret.dot", "bafymeta", 0);
+        expect(publishTx).toHaveBeenCalledWith("secret.dot", "bafymeta", 0, {
+            isSome: false,
+            value: "0x0000000000000000000000000000000000000000",
+        });
     });
 
     it("retries up to 3 times on registry publish failure", async () => {

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -18,7 +18,8 @@
  *
  * We upload the metadata JSON through Bulletin `TransactionStorage.store`
  * with the product-scoped RFC-0010 Bulletin allowance account, then call
- * `registry.publish(domain, metadataCid)` ourselves via `getRegistryContract()`.
+ * `registry.publish(domain, metadataCid, visibility, owner)` ourselves via
+ * `getRegistryContract()`.
  * Publishing is always signed by the user's product account so the contract's
  * `env::caller()` matches their address — that's what drives the playground-app
  * "myApps" view.
@@ -269,7 +270,10 @@ export async function publishToPlayground(
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
                     const visibility = options.isPrivate ? 0 : 1;
-                    const result = await registry.publish.tx(fullDomain, metadataCid, visibility);
+                    const result = await registry.publish.tx(fullDomain, metadataCid, visibility, {
+                        isSome: false,
+                        value: "0x0000000000000000000000000000000000000000",
+                    });
                     if (result && result.ok === false) {
                         throw new Error("Registry publish transaction reverted");
                     }


### PR DESCRIPTION
## Summary
- update `cdm.json` to the latest playground registry deployment and ABI
- refresh the lockfile after the registry metadata update
- remove an unused contract deploy UI helper

## Verification
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm test`