### PR TITLE
fix(e2e): unblock nightly-deploy-moddable cell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -240,6 +240,20 @@ jobs:
                   retention-days: 7
                   if-no-files-found: ignore
 
+            - name: Clean up moddable test fixture repo
+              # Only the moddable cell creates a per-run GH repo; other cells in
+              # this matrix would no-op (the delete would 404). Run on success,
+              # failure, AND cancellation so we never leak a public repo. The
+              # weekly cleanup cron at e2e-cleanup.yml is the backstop, but
+              # deleting here means retries within the same run start clean
+              # and we don't accumulate one orphan per failed nightly.
+              if: always() && matrix.cell == 'nightly-deploy-moddable'
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ secrets.E2E_GH_PAT }}
+              run: |
+                  gh repo delete "paritytech/e2e-cli-moddable-${{ github.run_id }}" --yes 2>/dev/null || true
+
     test-nightly-no-publish:
         name: "E2E · ${{ matrix.cell }}"
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/e2e/cli/helpers/chain.ts
+++ b/e2e/cli/helpers/chain.ts
@@ -22,32 +22,29 @@
 
 import { destroyConnection, getConnection, type PaseoClient } from "../../../src/utils/connection.js";
 
-const CONNECT_TIMEOUT_MS = 30_000;
-
 let clientPromise: Promise<PaseoClient> | null = null;
 let client: PaseoClient | null = null;
 
 /**
  * Get a cached Paseo client. Creates one on first call.
  * Reuses the same connection for all subsequent calls.
+ *
+ * Delegates connect-timeout handling to `getConnection()` — wrapping a second
+ * Promise.race-with-setTimeout here previously stacked an extra un-unref'd
+ * timer on top, leaking the event loop for ~30 s after every short test and
+ * causing vitest teardown to hang past its 5 s budget.
  */
 export async function getTestClient(): Promise<PaseoClient> {
 	if (!clientPromise) {
-		clientPromise = Promise.race([
-			getConnection().then((c) => {
+		clientPromise = getConnection()
+			.then((c) => {
 				client = c;
 				return c;
-			}),
-			new Promise<never>((_, reject) =>
-				setTimeout(
-					() => reject(new Error(`Timed out connecting to Paseo after ${CONNECT_TIMEOUT_MS / 1000}s`)),
-					CONNECT_TIMEOUT_MS,
-				),
-			),
-		]).catch((err) => {
-			clientPromise = null;
-			throw err;
-		});
+			})
+			.catch((err) => {
+				clientPromise = null;
+				throw err;
+			});
 	}
 	return clientPromise;
 }

--- a/e2e/cli/helpers/moddable-setup.ts
+++ b/e2e/cli/helpers/moddable-setup.ts
@@ -22,10 +22,14 @@
  * subsequent `dot deploy --moddable` call has a `origin` URL that
  * `assertPublicGitHubRepo()` will accept.
  *
- * Failures bubble up cleanly so the CI cell fails loudly with the `gh`
- * error message — per the locked design decision (no retries, no
- * auto-renaming). The weekly cleanup cron sweeps repos by topic, so
- * test crashes still get tidied up later.
+ * Idempotent on the GH repo: if `paritytech/<repoName>` already exists
+ * (e.g. from a previous retry attempt within the same workflow run, or a
+ * leftover from a crashed prior run), the helper reuses it instead of
+ * crashing on "Name already exists". This mirrors the real-user re-run
+ * path the CLI itself handles via "using existing origin" — and lets
+ * `nick-fields/retry` actually retry without colliding on the run-scoped
+ * repo name. The weekly cleanup cron sweeps repos by topic, so test
+ * crashes still get tidied up later.
  */
 
 import { execFileSync } from "node:child_process";
@@ -42,6 +46,21 @@ function sh(cmd: string, args: string[], cwd?: string): string {
 		stdio: ["pipe", "pipe", "pipe"],
 		cwd,
 	}).trim();
+}
+
+// `sh` throws on non-zero exit (execFileSync default). For the
+// existence probe we want exit code, not throw — `gh repo view` exits 1
+// when the repo doesn't exist, which is a normal branch here, not a
+// failure.
+function ghRepoExists(qualifiedName: string): boolean {
+	try {
+		execFileSync("gh", ["repo", "view", qualifiedName, "--json", "url"], {
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -81,33 +100,49 @@ export function setupModdableFixture(
 		workDir,
 	);
 
-	// `gh repo create --source --push` does the origin-add + initial push in
-	// one round-trip, which is the same flow a Summit user would use
-	// (`gh repo create <name> --public --source . --push`). Description
-	// makes the auto-cleanup origin obvious to anyone who stumbles on the
-	// repo before the cron sweeps it.
-	sh("gh", [
-		"repo",
-		"create",
-		`${ORG}/${repoName}`,
-		"--public",
-		"--description",
-		"playground-cli E2E moddable test fixture (auto-cleaned)",
-		"--source",
-		workDir,
-		"--push",
-	]);
+	const qualifiedName = `${ORG}/${repoName}`;
+	if (ghRepoExists(qualifiedName)) {
+		// Reuse path — repo already exists (retry attempt within the same
+		// workflow run, or leftover from a crashed earlier run). Add origin
+		// manually and force-push: fixture content is identical between
+		// attempts, so the prior commit SHA is irrelevant. This matches
+		// what the CLI itself does on re-run ("using existing origin (...)").
+		//
+		// `gh auth setup-git` wires gh's credential helper into git globally
+		// so the subsequent raw `git push` can authenticate to github.com
+		// via GH_TOKEN. `gh repo create --push` does this implicitly; we
+		// have to do it explicitly when bypassing gh repo create.
+		// `setup-git` is idempotent.
+		sh("gh", ["auth", "setup-git"]);
+		sh("git", ["remote", "add", "origin", `https://github.com/${qualifiedName}.git`], workDir);
+		sh("git", ["push", "-u", "origin", "main", "--force"], workDir);
+	} else {
+		// Cold path — fresh `gh repo create --source --push` does origin-add
+		// + initial push in one round-trip, matching the Summit-user flow.
+		sh("gh", [
+			"repo",
+			"create",
+			qualifiedName,
+			"--public",
+			"--description",
+			"playground-cli E2E moddable test fixture (auto-cleaned)",
+			"--source",
+			workDir,
+			"--push",
+		]);
+	}
 
-	// Topic-tag separately. `gh repo create` doesn't accept a `--topic`
-	// flag today, and the cleanup cron filters by `--topic e2e-test-fixture`
-	// — so without this edit, the repo would never get swept and would
-	// accumulate indefinitely. Belt-and-braces: if `gh repo edit` fails
-	// (rate limit, transient), the cleanup falls back to name-prefix
-	// matching is NOT implemented today, so this throw is load-bearing.
+	// Topic-tag (idempotent — `--add-topic` is a no-op if already tagged).
+	// `gh repo create` doesn't accept a `--topic` flag today, and the
+	// cleanup cron filters by `--topic e2e-test-fixture` — so without this
+	// edit, the repo would never get swept and would accumulate indefinitely.
+	// Belt-and-braces: if `gh repo edit` fails (rate limit, transient), the
+	// cleanup fallback to name-prefix matching is NOT implemented today, so
+	// this throw is load-bearing.
 	sh("gh", [
 		"repo",
 		"edit",
-		`${ORG}/${repoName}`,
+		qualifiedName,
 		"--add-topic",
 		TOPIC,
 	]);

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -77,13 +77,19 @@ async function connectPaseo(): Promise<PaseoClient> {
 }
 
 function timeoutAfter(ms: number): Promise<never> {
-    return new Promise((_, reject) =>
-        setTimeout(
+    return new Promise((_, reject) => {
+        // .unref() so the timer doesn't keep the event loop alive after Promise.race
+        // resolves with the connection winner. Without it, every short-lived process
+        // that touches getConnection() stays open for `ms` after work completes —
+        // the CLI's scheduleHardExit() papers over it in production, but the e2e
+        // test harness has no such guard and was hanging ~30 s past junit write.
+        const t = setTimeout(
             () =>
                 reject(new Error(`Timed out connecting to Paseo after ${Math.round(ms / 1000)}s`)),
             ms,
-        ),
-    );
+        );
+        t.unref();
+    });
 }
 
 export function getConnection(): Promise<PaseoClient> {


### PR DESCRIPTION
## Summary

Three test-infra fixes for the first-night failure on the moddable cell (issue #202). The CLI itself worked correctly on the failing nightly — exit 0, deploy completed, registry stamped. The cell failed because:

- vitest hung ~30 s after junit was written, killed by the action runner → exit 1 → "attempt 1 failed";
- `nick-fields/retry` re-ran the setup; attempt 2's `gh repo create paritytech/e2e-cli-moddable-<run_id>` collided with attempt 1's leftover repo ("Name already exists") → real failure.

### 1. Drop the un-unref'd 30 s `setTimeout` that caused the vitest hang

`src/utils/connection.ts::timeoutAfter` and the duplicate in `e2e/cli/helpers/chain.ts::getTestClient` both create a `setTimeout(..., 30_000)` inside `Promise.race`. When `connectPaseo()` wins the race, the loser timer is **not** cancelled — it stays pending and keeps Node's event loop alive until it fires. The CLI's `scheduleHardExit()` in `process-guard.ts` papers over this in production; the vitest harness has no equivalent and was hanging past its 5 s `teardownTimeout`, surfacing as:

```
close timed out after 5000ms
Tests closed successfully but something prevents Vite server from exiting
```

Fix: `.unref()` on the timer in `connection.ts`. Removes the redundant wrapper in `chain.ts` (it was layering a second 30 s timeout on top of the one already inside `getConnection()`).

### 2. Make `setupModdableFixture` retry-safe

Probe `gh repo view paritytech/<repoName>` before `gh repo create`. If the repo already exists (retry within the same run, or leftover from a crashed earlier run), reuse it: `git remote add origin … && git push -u origin main --force`. Mirrors what the CLI itself logs on re-run (`using existing origin (...)`). Force-push is safe — fixture content is identical between attempts.

`gh auth setup-git` is invoked before the raw `git push` so HTTPS auth via `GH_TOKEN` flows through gh's credential helper (which `gh repo create --push` does implicitly).

### 3. Cleanup post-step in the workflow

`if: always() && matrix.cell == 'nightly-deploy-moddable'` step that runs `gh repo delete paritytech/e2e-cli-moddable-${{ github.run_id }} --yes || true` after artefacts are uploaded. Runs on success, failure, and cancellation. The weekly `e2e-cleanup.yml` cron stays as the backstop, but per-run cleanup means we don't accumulate one orphan per failed nightly.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint:license` — clean
- [x] `pnpm build` — clean
- [x] `pnpm test` — all unit tests pass (one telemetry test is a known flake under suite-wide contention, passes in isolation)
- [ ] `nightly-deploy-moddable` cell passes on the first attempt (verified via `workflow_dispatch` trigger after merge)
- [ ] Subsequent scheduled nightly is green and #202 auto-closes

Closes #202