### PR TITLE
feat(init): show registry username + account-in-use row

### DIFF
--- a/.changeset/registry-username-display.md
+++ b/.changeset/registry-username-display.md
@@ -4,11 +4,13 @@
 
 `dot init` now shows the user's registry username (the handle set on the
 playground.dot profile) when one has been claimed, falling back to the
-People-parachain identity name and then to the H160 — same precedence as
+People-parachain identity name and then to the H160, same precedence as
 the playground-app. Also surfaces an "account in use" row with the
 derivation path + H160 so the user can verify the exact account that
 signs on their behalf.
 
-No new dependencies. Read-only — silent fallback if the resolved
-registry contract doesn't expose `getUsername` (e.g. running against an
-older @w3s deploy).
+`dot deploy --playground` now matches the v8 registry contract's 7-arg
+`publish()` signature (adds `modded_from`, `is_moddable`, `is_dev_signer`),
+which unblocks publishes against the freshly deployed v8 on Paseo Asset
+Hub Next. `cdm.json` is refreshed to the v8 ABI; the runtime keeps
+resolving the live contract address from the on-chain meta-registry.

--- a/.changeset/registry-username-display.md
+++ b/.changeset/registry-username-display.md
@@ -1,0 +1,14 @@
+---
+"playground-cli": patch
+---
+
+`dot init` now shows the user's registry username (the handle set on the
+playground.dot profile) when one has been claimed, falling back to the
+People-parachain identity name and then to the H160 — same precedence as
+the playground-app. Also surfaces an "account in use" row with the
+derivation path + H160 so the user can verify the exact account that
+signs on their behalf.
+
+No new dependencies. Read-only — silent fallback if the resolved
+registry contract doesn't expose `getUsername` (e.g. running against an
+older @w3s deploy).

--- a/.changeset/registry-username-display.md
+++ b/.changeset/registry-username-display.md
@@ -9,8 +9,9 @@ the playground-app. Also surfaces an "account in use" row with the
 derivation path + H160 so the user can verify the exact account that
 signs on their behalf.
 
-`dot deploy --playground` now matches the v8 registry contract's 7-arg
+`dot deploy --playground` now matches the v11 registry contract's 7-arg
 `publish()` signature (adds `modded_from`, `is_moddable`, `is_dev_signer`),
-which unblocks publishes against the freshly deployed v8 on Paseo Asset
-Hub Next. `cdm.json` is refreshed to the v8 ABI; the runtime keeps
-resolving the live contract address from the on-chain meta-registry.
+which unblocks publishes against the freshly deployed playground registry
+on Paseo Asset Hub Next. `cdm.json` is refreshed to the v11 manifest; the
+runtime keeps resolving the live contract address from the on-chain
+meta-registry.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,11 +132,18 @@ jobs:
               run: |
                   sudo apt-get update -q
                   sudo apt-get install -y -q --no-install-recommends build-essential pkg-config
-                  if ! command -v rustup >/dev/null 2>&1; then
-                    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-                  fi
+                  # Parity self-hosted runners ship rustup on PATH at a
+                  # non-standard location (not $HOME/.cargo). The previous
+                  # guarded install left $HOME/.cargo/env missing, then
+                  # `source` aborted the step under `set -e`. Run rustup-init
+                  # unconditionally (it's idempotent and `-y` suppresses
+                  # prompts), and source the env file only if it exists.
+                  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
                   echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-                  source "$HOME/.cargo/env"
+                  if [ -f "$HOME/.cargo/env" ]; then
+                    # shellcheck disable=SC1091
+                    source "$HOME/.cargo/env"
+                  fi
                   rustup toolchain install nightly --profile minimal --component rust-src
                   rustup default nightly
                   curl -fsSL https://raw.githubusercontent.com/paritytech/contract-dependency-manager/main/install.sh | bash

--- a/cdm.json
+++ b/cdm.json
@@ -14,8 +14,8 @@
   "contracts": {
     "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 8,
-        "address": "0x252461a7b650e98b75c11632c6b7fb4439EF5e32",
+        "version": 11,
+        "address": "0x109BBf68F41B570Fd6d3b7bDE9b8e18779FDd8Db",
         "abi": [
           {
             "type": "constructor",
@@ -885,7 +885,7 @@
             "stateMutability": "view"
           }
         ],
-        "metadataCid": "bafk2bzacedinnjvwctmltwri2xkmzhe26gt3ou7dimujsnwbinst3t33n2qgy"
+        "metadataCid": "bafk2bzaceatxst44simdeefvybqtrytkbsxhpktn7cjfhpuei6soggmped4oi"
       }
     }
   }

--- a/cdm.json
+++ b/cdm.json
@@ -14,8 +14,8 @@
   "contracts": {
     "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 7,
-        "address": "0xea3fb6C5cDA79FEEf5b2d42a9122fC1BAFaF647F",
+        "version": 8,
+        "address": "0x252461a7b650e98b75c11632c6b7fb4439EF5e32",
         "abi": [
           {
             "type": "constructor",
@@ -51,6 +51,18 @@
                     "type": "address"
                   }
                 ]
+              },
+              {
+                "name": "modded_from",
+                "type": "string"
+              },
+              {
+                "name": "is_moddable",
+                "type": "bool"
+              },
+              {
+                "name": "is_dev_signer",
+                "type": "bool"
               }
             ],
             "outputs": [],
@@ -99,6 +111,30 @@
               {
                 "name": "reviewer",
                 "type": "address"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "star",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "unstar",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
               }
             ],
             "outputs": [],
@@ -245,6 +281,39 @@
             "inputs": [
               {
                 "name": "addr",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "setBlacklisted",
+            "inputs": [
+              {
+                "name": "accounts",
+                "type": "address[]"
+              },
+              {
+                "name": "value",
+                "type": "bool"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "isBlacklisted",
+            "inputs": [
+              {
+                "name": "account",
                 "type": "address"
               }
             ],
@@ -475,6 +544,144 @@
           },
           {
             "type": "function",
+            "name": "getPoints",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint128"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getTopBuilders",
+            "inputs": [
+              {
+                "name": "start",
+                "type": "uint32"
+              },
+              {
+                "name": "count",
+                "type": "uint32"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple[]",
+                "components": [
+                  {
+                    "name": "account",
+                    "type": "address"
+                  },
+                  {
+                    "name": "score",
+                    "type": "uint128"
+                  }
+                ]
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getModCount",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint32"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getStarCount",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint32"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "hasStarred",
+            "inputs": [
+              {
+                "name": "voter",
+                "type": "address"
+              },
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getPointBreakdown",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "components": [
+                  {
+                    "name": "launch_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "mod_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "star_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "total",
+                    "type": "uint128"
+                  }
+                ]
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
             "name": "setFrozen",
             "inputs": [
               {
@@ -527,6 +734,10 @@
               {
                 "name": "metadata_uri",
                 "type": "string"
+              },
+              {
+                "name": "is_moddable",
+                "type": "bool"
               }
             ],
             "outputs": [],
@@ -559,6 +770,10 @@
                   {
                     "name": "metadata_uri",
                     "type": "string"
+                  },
+                  {
+                    "name": "is_moddable",
+                    "type": "bool"
                   }
                 ]
               }
@@ -577,6 +792,97 @@
             ],
             "outputs": [],
             "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "setUsername",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "clearUsername",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "getUsername",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getUsernames",
+            "inputs": [
+              {
+                "name": "accounts",
+                "type": "address[]"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string[]"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getUsernameOwner",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "isUsernameAvailable",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "prospective_caller",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
           }
         ],
         "metadataCid": "bafk2bzacedinnjvwctmltwri2xkmzhe26gt3ou7dimujsnwbinst3t33n2qgy"

--- a/src/commands/init/IdentityLines.tsx
+++ b/src/commands/init/IdentityLines.tsx
@@ -16,7 +16,13 @@
 import { useEffect, useState } from "react";
 import { Row, Section } from "../../utils/ui/theme/index.js";
 import type { SessionAddresses } from "../../utils/auth.js";
-import { formatUsernameLine, lookupUsername, type UsernameLookup } from "../../utils/username.js";
+import {
+    formatUsernameLine,
+    lookupUsername,
+    lookupRegistryUsername,
+    type UsernameLookup,
+} from "../../utils/username.js";
+import { PLAYGROUND_PRODUCT_ID } from "../../config.js";
 
 /**
  * Three-line identity block shown after a successful login:
@@ -44,19 +50,36 @@ import { formatUsernameLine, lookupUsername, type UsernameLookup } from "../../u
  * identities fall through to the strings from `formatUsernameLine`.
  */
 export function IdentityLines({ addresses }: { addresses: SessionAddresses }) {
-    const [username, setUsername] = useState<UsernameLookup>({ kind: "loading" });
+    const [walletUsername, setWalletUsername] = useState<UsernameLookup>({ kind: "loading" });
+    // null means "lookup completed, no registry username set"; undefined means
+    // "still loading". Display rule: prefer registry > People > fall back to
+    // the H160 — same precedence the playground-app uses in `displayNameForAccount`.
+    const [registryUsername, setRegistryUsername] = useState<string | null | undefined>(undefined);
 
     useEffect(() => {
         let cancelled = false;
         lookupUsername(addresses.rootAddress).then((result) => {
-            if (!cancelled) setUsername(result);
+            if (!cancelled) setWalletUsername(result);
+        });
+        lookupRegistryUsername(addresses.productH160 as `0x${string}`).then((result) => {
+            if (!cancelled) setRegistryUsername(result);
         });
         return () => {
             cancelled = true;
         };
-    }, [addresses.rootAddress]);
+    }, [addresses.rootAddress, addresses.productH160]);
 
-    const usernameTone = username.kind === "found" ? "default" : "muted";
+    const usernameLine = registryUsername
+        ? registryUsername
+        : registryUsername === undefined
+          ? "(looking up...)"
+          : formatUsernameLine(walletUsername);
+    const usernameTone = registryUsername || walletUsername.kind === "found" ? "default" : "muted";
+    const usernameSource = registryUsername
+        ? "playground"
+        : walletUsername.kind === "found"
+          ? "polkadot"
+          : null;
 
     return (
         <Section>
@@ -64,15 +87,16 @@ export function IdentityLines({ addresses }: { addresses: SessionAddresses }) {
             <Row
                 mark="ok"
                 label="username"
-                value={formatUsernameLine(username)}
+                value={usernameSource ? `${usernameLine} (${usernameSource})` : usernameLine}
                 tone={usernameTone}
             />
             <Row
                 mark="ok"
-                label="product account"
-                value={`${addresses.productAddress} (${addresses.productH160})`}
+                label="account in use"
+                value={`${PLAYGROUND_PRODUCT_ID}/0 — ${addresses.productH160}`}
                 tone="muted"
             />
+            <Row mark="ok" label="product account" value={addresses.productAddress} tone="muted" />
         </Section>
     );
 }

--- a/src/commands/init/IdentityLines.tsx
+++ b/src/commands/init/IdentityLines.tsx
@@ -25,29 +25,45 @@ import {
 import { PLAYGROUND_PRODUCT_ID } from "../../config.js";
 
 /**
- * Three-line identity block shown after a successful login:
+ * Four-row identity block shown after a successful login:
  *
- *   logged in       <wallet root SS58>
- *   username        alice.dot
- *   product account <product SS58> (<product 0x H160>)
+ *   logged in        <wallet root SS58>
+ *   username         <name> (playground|polkadot)
+ *   account in use   playground.dot/0 — <product 0x H160>
+ *   product account  <product SS58>
  *
  * `logged in` is the SSO-handshake `rootAccountId` (bare-mnemonic on
- * current mobile builds). It is the storage key for the username
- * lookup. It is NOT the same address mobile shows as "Wallet account"
- * on its debug screen — that uses the hard `//wallet` derivation which
- * the host can't reproduce.
+ * current mobile builds). It is the storage key for the People-parachain
+ * username lookup. It is NOT the same address mobile shows as "Wallet
+ * account" on its debug screen — that uses the hard `//wallet`
+ * derivation which the host can't reproduce.
  *
- * `product account` is the playground-scoped account derived via
- * `product/playground.dot/0` off the root; this is what signs txs on
- * the CLI. The SS58 + H160 are taken straight off the auth-derived
- * pair so they never drift — the bug we had previously was running
+ * `username` follows a two-tier precedence, same first tier as the
+ * playground-app's `displayNameForAccount`:
+ *   1. registry username — the handle the user set in the playground-app
+ *      profile (`registry.setUsername`), keyed on the product H160 since
+ *      that's the `caller()` the contract records.
+ *   2. People-parachain identity from `lookupUsername` — the chain-wide
+ *      handle, keyed on the root SS58.
+ * The source ("playground" vs "polkadot") is suffixed so it's obvious
+ * which surface the user is seeing. If neither resolves, the row falls
+ * through to `formatUsernameLine`'s `(no username set on chain)`.
+ *
+ * `account in use` surfaces the derivation slug + the H160 that signs
+ * on the user's behalf, so the user can verify the exact account
+ * without inspecting the SS58. `product account` keeps the SS58 form
+ * on its own row.
+ *
+ * Both lookups are async, fired in parallel, each cancellable. The
+ * People-parachain query has a 10s timeout inside `lookupUsername`;
+ * the registry query degrades silently to `null` on any error
+ * (`lookupRegistryUsername`) so older deploys without `getUsername`
+ * fall through to tier 2 without surfacing an error to the user.
+ *
+ * The SS58 + H160 are taken straight off the auth-derived pair so
+ * they never drift — the bug we had previously was running
  * `deriveProductAccountPublicKey` again on the already-derived SS58
  * and producing a doubly-derived ghost address.
- *
- * The username lookup is async (queries People parachain) and has a
- * 10s timeout inside `lookupUsername`. A `(looking up...)` placeholder
- * renders while the lookup is in flight; failures and missing
- * identities fall through to the strings from `formatUsernameLine`.
  */
 export function IdentityLines({ addresses }: { addresses: SessionAddresses }) {
     const [walletUsername, setWalletUsername] = useState<UsernameLookup>({ kind: "loading" });

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -326,10 +326,18 @@ describe("publishToPlayground", () => {
                 expect.objectContaining({ __kind: "store" }),
                 bulletinStorageSigner,
             );
-            expect(publishTx).toHaveBeenCalledWith("my-app.dot", "bafymeta", 1, {
-                isSome: false,
-                value: "0x0000000000000000000000000000000000000000",
-            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-app.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "",
+                false,
+                false,
+            );
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -388,10 +396,18 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
             claimedOwnerH160: "0x1234567890abcdef1234567890abcdef12345678",
         });
-        expect(publishTx).toHaveBeenCalledWith("claimed-app.dot", "bafymeta", 1, {
-            isSome: true,
-            value: "0x1234567890abcdef1234567890abcdef12345678",
-        });
+        expect(publishTx).toHaveBeenCalledWith(
+            "claimed-app.dot",
+            "bafymeta",
+            1,
+            {
+                isSome: true,
+                value: "0x1234567890abcdef1234567890abcdef12345678",
+            },
+            "",
+            false,
+            false,
+        );
     });
 
     it("passes visibility=0 when isPrivate is true", async () => {
@@ -402,10 +418,41 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
             isPrivate: true,
         });
-        expect(publishTx).toHaveBeenCalledWith("secret.dot", "bafymeta", 0, {
-            isSome: false,
-            value: "0x0000000000000000000000000000000000000000",
+        expect(publishTx).toHaveBeenCalledWith(
+            "secret.dot",
+            "bafymeta",
+            0,
+            {
+                isSome: false,
+                value: "0x0000000000000000000000000000000000000000",
+            },
+            "",
+            false,
+            false,
+        );
+    });
+
+    it("forwards isModdable and isDevSigner to registry.publish", async () => {
+        await publishToPlayground({
+            domain: "modded-by-dev",
+            publishSigner: fakeSigner,
+            repositoryUrl: "https://github.com/foo/bar",
+            cwd: "/definitely/not/a/repo",
+            isModdable: true,
+            isDevSigner: true,
         });
+        expect(publishTx).toHaveBeenCalledWith(
+            "modded-by-dev.dot",
+            "bafymeta",
+            1,
+            {
+                isSome: false,
+                value: "0x0000000000000000000000000000000000000000",
+            },
+            "",
+            true,
+            true,
+        );
     });
 
     it("retries up to 3 times on registry publish failure", async () => {

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -83,6 +83,27 @@ export interface PublishToPlaygroundOptions {
      * to its owner in the playground. Defaults to public (visibility=1).
      */
     isPrivate?: boolean;
+    /**
+     * Whether the published source is moddable (a public GitHub origin is
+     * recorded in metadata and listed in the `dot mod` picker). The contract
+     * records this bit so the playground-app filter doesn't need to fetch
+     * each metadata JSON to know.
+     */
+    isModdable?: boolean;
+    /**
+     * Domain (`<label>.dot`) the user `dot mod`'d this app from, or `""` if
+     * this is a first-party publish. Recorded on-chain so the playground-app
+     * can render a "modded from" badge. Capture is not yet built in the CLI;
+     * for now this is always `""`.
+     */
+    moddedFrom?: string;
+    /**
+     * True when the publish is signed by the dev signer (Alice / `--suri`)
+     * rather than the user's session. The contract surfaces this bit on each
+     * `AppInfo` so the playground-app can distinguish phone-published apps
+     * from dev-published throwaways.
+     */
+    isDevSigner?: boolean;
 }
 
 export interface PublishToPlaygroundResult {
@@ -294,11 +315,17 @@ export async function publishToPlayground(
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
                     const visibility = options.isPrivate ? 0 : 1;
+                    const moddedFrom = options.moddedFrom ?? "";
+                    const isModdable = options.isModdable ?? false;
+                    const isDevSigner = options.isDevSigner ?? false;
                     const result = await registry.publish.tx(
                         fullDomain,
                         metadataCid,
                         visibility,
                         owner,
+                        moddedFrom,
+                        isModdable,
+                        isDevSigner,
                     );
                     if (result && result.ok === false) {
                         throw new Error("Registry publish transaction reverted");

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -173,6 +173,46 @@ describe("runDeploy", () => {
         if (plan?.kind === "plan") expect(plan.approvals).toHaveLength(0);
     });
 
+    it("threads isModdable + isDevSigner into publishToPlayground", async () => {
+        // Phone-mode publish: isDevSigner=false, isModdable=true.
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            domain: "phone-mod",
+            mode: "phone",
+            publishToPlayground: true,
+            moddable: true,
+            repositoryUrl: "https://github.com/foo/bar",
+            userSigner: fakeUserSigner,
+            onEvent: push,
+        });
+        const phoneCall = (publishToPlaygroundMock.mock.calls as unknown[][])[0]?.[0] as
+            | { isModdable?: boolean; isDevSigner?: boolean }
+            | undefined;
+        expect(phoneCall?.isModdable).toBe(true);
+        expect(phoneCall?.isDevSigner).toBe(false);
+
+        publishToPlaygroundMock.mockClear();
+
+        // Dev-mode publish (no session): isDevSigner=true, isModdable=false.
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            domain: "dev-throwaway",
+            mode: "dev",
+            publishToPlayground: true,
+            moddable: false,
+            userSigner: null,
+            onEvent: push,
+        });
+        const devCall = (publishToPlaygroundMock.mock.calls as unknown[][])[0]?.[0] as
+            | { isModdable?: boolean; isDevSigner?: boolean }
+            | undefined;
+        expect(devCall?.isModdable).toBe(false);
+        expect(devCall?.isDevSigner).toBe(true);
+    });
+
     it("phone mode with playground: 4 planned approvals, DotNS uses phone signer", async () => {
         const { events, push } = collectEvents();
         const outcome = await runDeploy({

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -193,6 +193,8 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     onLogEvent: (event) => options.onEvent({ kind: "storage-event", event }),
                     env: options.env,
                     isPrivate: options.playgroundPrivate,
+                    isModdable: options.moddable ?? false,
+                    isDevSigner: setup.publishSigner.source === "dev",
                 }),
         );
         metadataCid = pub.metadataCid;

--- a/src/utils/username.test.ts
+++ b/src/utils/username.test.ts
@@ -16,6 +16,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatUsernameLine, type UsernameLookup } from "./username.js";
 
+const ZERO_H160 = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+
 describe("formatUsernameLine", () => {
     it("returns the full username when present", () => {
         const lookup: UsernameLookup = {
@@ -146,5 +148,86 @@ describe("lookupUsername", () => {
         const { lookupUsername } = await import("./username.js");
         await lookupUsername("5GGpUaN7XNaUp3nEVDPBSR4SQLxFxQsiPHbFwf69Apr3HgDZ");
         expect(mockDestroy).toHaveBeenCalledTimes(1);
+    });
+});
+
+// Mocks for `lookupRegistryUsername`. We don't reuse the lookupUsername mocks
+// because that function uses its own polkadot-api client; `lookupRegistryUsername`
+// goes through the shared `getConnection()` and the read-only registry contract.
+const mockGetConnection = vi.fn();
+const mockGetReadOnlyRegistryContract = vi.fn();
+
+vi.mock("./connection.js", () => ({
+    getConnection: () => mockGetConnection(),
+}));
+
+vi.mock("./registry.js", () => ({
+    getReadOnlyRegistryContract: (rawClient: unknown) => mockGetReadOnlyRegistryContract(rawClient),
+}));
+
+describe("lookupRegistryUsername", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        mockGetConnection.mockReset();
+        mockGetReadOnlyRegistryContract.mockReset();
+
+        // Default: a connection whose raw.assetHub is just a sentinel object —
+        // we never touch it directly, only forward it to the contract factory.
+        mockGetConnection.mockResolvedValue({ raw: { assetHub: { _sentinel: "assetHub" } } });
+    });
+
+    // Regression guard for the v7-deploy degradation path. The CLI ships against
+    // the latest manifest but a target chain may still be running an older
+    // contract that has no `getUsername` method — the SDK returns a registry
+    // handle whose `.getUsername` is undefined. We must NOT throw; the row falls
+    // through to the People-parachain name.
+    it("returns null when the registry has no getUsername method (older contract)", async () => {
+        mockGetReadOnlyRegistryContract.mockResolvedValue({}); // no getUsername key at all
+        const { lookupRegistryUsername } = await import("./username.js");
+        await expect(lookupRegistryUsername(ZERO_H160)).resolves.toBeNull();
+    });
+
+    it("returns null when getUsername exists but .query is undefined", async () => {
+        mockGetReadOnlyRegistryContract.mockResolvedValue({ getUsername: {} });
+        const { lookupRegistryUsername } = await import("./username.js");
+        await expect(lookupRegistryUsername(ZERO_H160)).resolves.toBeNull();
+    });
+
+    it("returns null when the query result is success=false", async () => {
+        mockGetReadOnlyRegistryContract.mockResolvedValue({
+            getUsername: {
+                query: vi.fn().mockResolvedValue({ success: false, value: "ignored" }),
+            },
+        });
+        const { lookupRegistryUsername } = await import("./username.js");
+        await expect(lookupRegistryUsername(ZERO_H160)).resolves.toBeNull();
+    });
+
+    it("returns null when the returned value is the empty-string sentinel", async () => {
+        mockGetReadOnlyRegistryContract.mockResolvedValue({
+            getUsername: {
+                query: vi.fn().mockResolvedValue({ success: true, value: "" }),
+            },
+        });
+        const { lookupRegistryUsername } = await import("./username.js");
+        await expect(lookupRegistryUsername(ZERO_H160)).resolves.toBeNull();
+    });
+
+    it("returns the username on a successful query", async () => {
+        const queryFn = vi.fn().mockResolvedValue({ success: true, value: "alice" });
+        mockGetReadOnlyRegistryContract.mockResolvedValue({ getUsername: { query: queryFn } });
+        const h160 = "0xabcdef0123456789abcdef0123456789abcdef01" as `0x${string}`;
+
+        const { lookupRegistryUsername } = await import("./username.js");
+        const result = await lookupRegistryUsername(h160);
+
+        expect(result).toBe("alice");
+        expect(queryFn).toHaveBeenCalledWith(h160);
+    });
+
+    it("swallows thrown errors and returns null (display-time fallback)", async () => {
+        mockGetReadOnlyRegistryContract.mockRejectedValue(new Error("rpc went poof"));
+        const { lookupRegistryUsername } = await import("./username.js");
+        await expect(lookupRegistryUsername(ZERO_H160)).resolves.toBeNull();
     });
 });

--- a/src/utils/username.ts
+++ b/src/utils/username.ts
@@ -46,6 +46,8 @@
 import { createClient } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
 import { getChainConfig } from "../config.js";
+import { getReadOnlyRegistryContract } from "./registry.js";
+import { getConnection } from "./connection.js";
 
 // Cold-start WS connects to paseo-people-next-system-rpc on a slow conference
 // network can take a few seconds before metadata + the first query are ready.
@@ -135,5 +137,53 @@ export async function lookupUsername(rootAccountSs58: string): Promise<UsernameL
         // Fire-and-forget. The CLI's process-guard catches benign
         // post-destroy artifacts from polkadot-api's chainHead unfollow race.
         client.destroy();
+    }
+}
+
+/**
+ * Look up the user's playground-registry username (the handle they set in
+ * the playground-app's profile, NOT the People-parachain identity above).
+ *
+ * Keyed on the H160 of the **product account**, because that's the
+ * `caller()` the on-chain `set_username` records. For phone-mode users
+ * that's `SessionAddresses.productH160`; for dev / `--suri` flows it's
+ * the H160 derived from the local signer. Returns `null` for "no
+ * username set" so callers can fall back to the People-parachain name or
+ * the H160. Re-uses the shared `getConnection()` client so the lookup
+ * piggybacks on whatever the calling command already opened, and a
+ * connection close is the calling code's job.
+ *
+ * BACKWARD COMPATIBILITY: the CLI resolves the registry contract via
+ * `@w3s/playground-registry` (see `contractManifest.ts`). The
+ * `get_username` method only exists on v13+; on the still-deployed
+ * @w3s v7 (and any production until the v13 cutover ships) the SDK throws
+ * `Cannot read properties of undefined (reading 'query')`. We catch and
+ * return null so `IdentityLines` quietly degrades to the People-parachain
+ * name. After the @w3s v13 deploy + `dot contract install` the call
+ * starts returning real values automatically — no CLI release needed.
+ *
+ * Errors are swallowed (logged via the catch) and reported as `null` —
+ * this is a display-time enhancement, never a hard failure path.
+ */
+export async function lookupRegistryUsername(productH160: `0x${string}`): Promise<string | null> {
+    try {
+        const client = await getConnection();
+        const registry = await getReadOnlyRegistryContract(client.raw.assetHub);
+        // The .query property is undefined on older registries → optional chain.
+        const getUsername = (
+            registry as unknown as {
+                getUsername?: {
+                    query?: (h160: `0x${string}`) => Promise<{ success: boolean; value: unknown }>;
+                };
+            }
+        ).getUsername;
+        if (!getUsername?.query) return null;
+        const res = await getUsername.query(productH160);
+        if (!res.success) return null;
+        const value = res.value;
+        if (typeof value !== "string" || value === "") return null;
+        return value;
+    } catch {
+        return null;
     }
 }

--- a/src/utils/username.ts
+++ b/src/utils/username.ts
@@ -155,14 +155,14 @@ export async function lookupUsername(rootAccountSs58: string): Promise<UsernameL
  *
  * BACKWARD COMPATIBILITY: the CLI resolves the registry contract via
  * `@w3s/playground-registry` (see `contractManifest.ts`). The
- * `get_username` method only exists on v13+; on the still-deployed
- * @w3s v7 (and any production until the v13 cutover ships) the SDK throws
- * `Cannot read properties of undefined (reading 'query')`. We catch and
- * return null so `IdentityLines` quietly degrades to the People-parachain
- * name. After the @w3s v13 deploy + `dot contract install` the call
- * starts returning real values automatically — no CLI release needed.
+ * `getUsername` method only exists on v8+; against the older v7 the SDK
+ * throws `Cannot read properties of undefined (reading 'query')`. We
+ * catch and return null so `IdentityLines` quietly degrades to the
+ * People-parachain name. Once a target chain has the v8 contract live
+ * the call starts returning real values automatically, no CLI release
+ * needed.
  *
- * Errors are swallowed (logged via the catch) and reported as `null` —
+ * Errors are swallowed (logged via the catch) and reported as `null`:
  * this is a display-time enhancement, never a hard failure path.
  */
 export async function lookupRegistryUsername(productH160: `0x${string}`): Promise<string | null> {


### PR DESCRIPTION
## Summary

- `dot init` now displays the user's playground.dot registry username (the handle set via the playground-app profile) when claimed, with precedence: registry username → People-parachain identity → H160. Mirrors `displayNameForAccount` in playground-app so the CLI and web UI agree on what the user is called.
- Adds an "account in use" row showing the derivation path (`playground.dot/0`) and the full H160 that signs on the user's behalf.
- Read-only — silent fallback when the resolved registry doesn't expose `get_username` yet (e.g. against an older @w3s deploy). Picks up real values automatically once `dot contract install` refreshes against a newer ABI.

## Companion change

This pairs with playground-app#204 which adds the username surface to the registry contract. No release coordination required: the CLI side degrades gracefully if the contract doesn't have the method yet.

## Test plan

- [ ] `pnpm test` — all 496 unit tests pass
- [ ] `pnpm format:check` clean (Biome)
- [ ] `pnpm lint:license` clean
- [ ] `pnpm build` clean (Bun SEA)
- [ ] Manual: `dot init` against the new @w3s shows `username` + `account in use` rows; if no username claimed yet, falls back to the People-parachain name
- [ ] Manual: `dot init` against an older registry deploy (no `get_username` method) doesn't error, just falls back to People-parachain name