### PR TITLE
fix(registry): catch up to @w3s/playground-registry v11

### DIFF
--- a/cdm.json
+++ b/cdm.json
@@ -14,8 +14,8 @@
   "contracts": {
     "929b5c63e2cb5202": {
       "@w3s/playground-registry": {
-        "version": 7,
-        "address": "0xea3fb6C5cDA79FEEf5b2d42a9122fC1BAFaF647F",
+        "version": 11,
+        "address": "0x109BBf68F41B570Fd6d3b7bDE9b8e18779FDd8Db",
         "abi": [
           {
             "type": "constructor",
@@ -51,6 +51,18 @@
                     "type": "address"
                   }
                 ]
+              },
+              {
+                "name": "modded_from",
+                "type": "string"
+              },
+              {
+                "name": "is_moddable",
+                "type": "bool"
+              },
+              {
+                "name": "is_dev_signer",
+                "type": "bool"
               }
             ],
             "outputs": [],
@@ -99,6 +111,30 @@
               {
                 "name": "reviewer",
                 "type": "address"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "star",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "unstar",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
               }
             ],
             "outputs": [],
@@ -245,6 +281,39 @@
             "inputs": [
               {
                 "name": "addr",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "setBlacklisted",
+            "inputs": [
+              {
+                "name": "accounts",
+                "type": "address[]"
+              },
+              {
+                "name": "value",
+                "type": "bool"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "isBlacklisted",
+            "inputs": [
+              {
+                "name": "account",
                 "type": "address"
               }
             ],
@@ -475,6 +544,144 @@
           },
           {
             "type": "function",
+            "name": "getPoints",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint128"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getTopBuilders",
+            "inputs": [
+              {
+                "name": "start",
+                "type": "uint32"
+              },
+              {
+                "name": "count",
+                "type": "uint32"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple[]",
+                "components": [
+                  {
+                    "name": "account",
+                    "type": "address"
+                  },
+                  {
+                    "name": "score",
+                    "type": "uint128"
+                  }
+                ]
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getModCount",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint32"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getStarCount",
+            "inputs": [
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "uint32"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "hasStarred",
+            "inputs": [
+              {
+                "name": "voter",
+                "type": "address"
+              },
+              {
+                "name": "domain",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getPointBreakdown",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "tuple",
+                "components": [
+                  {
+                    "name": "launch_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "mod_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "star_points",
+                    "type": "uint128"
+                  },
+                  {
+                    "name": "total",
+                    "type": "uint128"
+                  }
+                ]
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
             "name": "setFrozen",
             "inputs": [
               {
@@ -527,6 +734,10 @@
               {
                 "name": "metadata_uri",
                 "type": "string"
+              },
+              {
+                "name": "is_moddable",
+                "type": "bool"
               }
             ],
             "outputs": [],
@@ -559,6 +770,10 @@
                   {
                     "name": "metadata_uri",
                     "type": "string"
+                  },
+                  {
+                    "name": "is_moddable",
+                    "type": "bool"
                   }
                 ]
               }
@@ -577,9 +792,100 @@
             ],
             "outputs": [],
             "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "setUsername",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "clearUsername",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+          },
+          {
+            "type": "function",
+            "name": "getUsername",
+            "inputs": [
+              {
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getUsernames",
+            "inputs": [
+              {
+                "name": "accounts",
+                "type": "address[]"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "string[]"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "getUsernameOwner",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "address"
+              }
+            ],
+            "stateMutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "isUsernameAvailable",
+            "inputs": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "prospective_caller",
+                "type": "address"
+              }
+            ],
+            "outputs": [
+              {
+                "name": "",
+                "type": "bool"
+              }
+            ],
+            "stateMutability": "view"
           }
         ],
-        "metadataCid": "bafk2bzacedinnjvwctmltwri2xkmzhe26gt3ou7dimujsnwbinst3t33n2qgy"
+        "metadataCid": "bafk2bzaceatxst44simdeefvybqtrytkbsxhpktn7cjfhpuei6soggmped4oi"
       }
     }
   }

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -326,10 +326,15 @@ describe("publishToPlayground", () => {
                 expect.objectContaining({ __kind: "store" }),
                 bulletinStorageSigner,
             );
-            expect(publishTx).toHaveBeenCalledWith("my-app.dot", "bafymeta", 1, {
-                isSome: false,
-                value: "0x0000000000000000000000000000000000000000",
-            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-app.dot",
+                "bafymeta",
+                1,
+                { isSome: false, value: "0x0000000000000000000000000000000000000000" },
+                "", // modded_from: capture-at-mod-time not yet wired (V1 P0)
+                true, // is_moddable: repositoryUrl is set
+                false, // is_dev_signer: fakeSigner.source === "session"
+            );
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -388,10 +393,15 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
             claimedOwnerH160: "0x1234567890abcdef1234567890abcdef12345678",
         });
-        expect(publishTx).toHaveBeenCalledWith("claimed-app.dot", "bafymeta", 1, {
-            isSome: true,
-            value: "0x1234567890abcdef1234567890abcdef12345678",
-        });
+        expect(publishTx).toHaveBeenCalledWith(
+            "claimed-app.dot",
+            "bafymeta",
+            1,
+            { isSome: true, value: "0x1234567890abcdef1234567890abcdef12345678" },
+            "",
+            false, // is_moddable: repositoryUrl was null
+            false,
+        );
     });
 
     it("passes visibility=0 when isPrivate is true", async () => {
@@ -402,10 +412,39 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
             isPrivate: true,
         });
-        expect(publishTx).toHaveBeenCalledWith("secret.dot", "bafymeta", 0, {
-            isSome: false,
-            value: "0x0000000000000000000000000000000000000000",
+        expect(publishTx).toHaveBeenCalledWith(
+            "secret.dot",
+            "bafymeta",
+            0,
+            { isSome: false, value: "0x0000000000000000000000000000000000000000" },
+            "",
+            true,
+            false,
+        );
+    });
+
+    it("passes is_dev_signer=true and the right is_moddable when the signer source is dev", async () => {
+        // Catches regressions where the dev-mode publish path stops flagging
+        // itself as dev — the contract uses `is_dev_signer` to skip the
+        // launch-points award for the deployer (Alice / `--suri` etc.).
+        // Pairing is_moddable=false here exercises both new params in a
+        // single call, rather than only the default `true` case from above.
+        const devSigner: ResolvedSigner = { ...fakeSigner, source: "dev" };
+        await publishToPlayground({
+            domain: "dev-deploy.dot",
+            publishSigner: devSigner,
+            repositoryUrl: null,
+            cwd: "/definitely/not/a/repo",
         });
+        expect(publishTx).toHaveBeenCalledWith(
+            "dev-deploy.dot",
+            "bafymeta",
+            1,
+            { isSome: false, value: "0x0000000000000000000000000000000000000000" },
+            "",
+            false,
+            true,
+        );
     });
 
     it("retries up to 3 times on registry publish failure", async () => {

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -18,8 +18,8 @@
  *
  * We upload the metadata JSON through Bulletin `TransactionStorage.store`
  * with the product-scoped RFC-0010 Bulletin allowance account, then call
- * `registry.publish(domain, metadataCid, visibility, owner)` ourselves via
- * `getRegistryContract()`.
+ * `registry.publish(domain, metadataCid, visibility, owner, modded_from,
+ * is_moddable, is_dev_signer)` ourselves via `getRegistryContract()`.
  * Publishing is always signed by the user's product account so the contract's
  * `env::caller()` matches their address — that's what drives the playground-app
  * "myApps" view.
@@ -290,6 +290,21 @@ export async function publishToPlayground(
                       value: "0x0000000000000000000000000000000000000000" as const,
                   };
 
+            // v11 of `@w3s/playground-registry` extended `publish()` with three
+            // tail params used by the new points / leaderboard / mod-credit
+            // surface. `modded_from` carries the source domain when this app was
+            // created via `dot mod <domain>` — capture-at-mod-time is not yet
+            // wired up in the CLI (spec V1 P0), so we pass `""` (the contract's
+            // sentinel for "no source"). `is_moddable` is the same signal the
+            // app metadata already carries — true when a public GitHub
+            // `repositoryUrl` is recorded. `is_dev_signer` lets the contract
+            // award launch points only when a real user account signs the
+            // publish, not when Alice / `--suri` does on the user's behalf in
+            // dev mode.
+            const moddedFrom = "";
+            const isModdable = options.repositoryUrl !== null;
+            const isDevSigner = options.publishSigner.source === "dev";
+
             let lastError: unknown;
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
@@ -299,6 +314,9 @@ export async function publishToPlayground(
                         metadataCid,
                         visibility,
                         owner,
+                        moddedFrom,
+                        isModdable,
+                        isDevSigner,
                     );
                     if (result && result.ok === false) {
                         throw new Error("Registry publish transaction reverted");


### PR DESCRIPTION
## Summary

Tonight's nightly (#207) failed across **five cells** on `Revive.ContractReverted` from `registry.publish()`. Root cause: the contract was redeployed in [playground-app PR #204](https://github.com/paritytech/playground-app/pull/204) (\"feat(registry): points, leaderboard, star toggle, mod credit\") with three new required tail params. The CLI's pinned ABI was still v7's four-arg signature, so every publish call reverted on signature mismatch.

This PR catches the CLI up.

## Changes

### `cdm.json`

Replaces the `@w3s/playground-registry` entry under target `929b5c63e2cb5202` with the v11 block ported verbatim from playground-app's cdm.json (same target hash, same Paseo Next v2 chain endpoints — only contract address, version, metadataCid, and ABI change).

- Before: `0xea3fb6C5cDA79FEEf5b2d42a9122fC1BAFaF647F` v7
- After: `0x109BBf68F41B570Fd6d3b7bDE9b8e18779FDd8Db` v11

### `src/utils/deploy/playground.ts`

`registry.publish.tx(...)` now passes the three new tail params:

| New param | Value | Why |
|---|---|---|
| `modded_from` | `""` | Capture-at-mod-time isn't yet wired up in the CLI (V1 P0 per spec). Empty string is the contract's sentinel for \"no source\". |
| `is_moddable` | `repositoryUrl !== null` | Same signal the app metadata already carries — true for `--moddable` deploys. |
| `is_dev_signer` | `publishSigner.source === \"dev\"` | True for Alice / `--suri` flows. The contract uses this to skip the launch-points award when a shared dev key signs on the user's behalf. |

### `src/utils/deploy/playground.test.ts`

Three existing `toHaveBeenCalledWith` assertions now check the full 7-arg signature. Adds one new test (\"passes is_dev_signer=true and the right is_moddable when the signer source is dev\") that exercises both new param variants in a single publish, paired with `is_moddable=false`, so a future regression hard-coding either to a default would surface immediately.

## Follow-up not addressed here

- `modded_from` capture-at-mod-time. \`dot mod <domain>\` needs to write the source domain to local metadata, threaded to `publishToPlayground` and passed here. V1 P0 per the spec — separate PR.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm lint:license` — clean
- [x] `pnpm build` — clean
- [x] `pnpm test` — 497 passed / 1 skipped
- [ ] workflow_dispatch nightly on this branch — moddable cell goes green on first attempt
- [ ] Subsequent scheduled nightly green; #207 auto-closes

Closes #207