### PR TITLE
chore: refine post-install next-step prompt

### DIFF
--- a/.changeset/clean-install-next-step.md
+++ b/.changeset/clean-install-next-step.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Refine the post-install prompt: the "next step" box now surfaces a single canonical command (`playground init`) and notes the `pg` alias once on a dimmed tip line, instead of presenting `playground init` and `pg init` as co-equal commands with a "both work the same" line.

--- a/install.sh
+++ b/install.sh
@@ -85,18 +85,20 @@ echo -e "$CMD is ready! Setting up dependencies…"
 echo ""
 if ! "$INSTALL_DIR/bin/$CMD" init --yes; then
   INIT_EXIT=$?
-  echo -e "\n\033[33mDependency setup failed. Run \033[1m$CMD init\033[0;33m (or \033[1m$ALIAS init\033[0;33m) when ready.\033[0m" >&2
+  echo -e "\n\033[33mDependency setup failed. Run \033[1m$CMD init\033[0;33m when ready.\033[0m" >&2
   exit "$INIT_EXIT"
 fi
 
 # Final "what to run next" prompt, styled to match the yellow rounded-border
 # Callout the TUI uses for phone-signing notifications (see
 # src/utils/ui/theme/Callout.tsx). Mirrored in bash so it shows the moment the
-# curl install finishes.
-Y='\033[33m'; B='\033[1m'; R='\033[0m'
+# curl install finishes. Like npm/gh/cargo, we surface a single canonical
+# command and note the alias once, dimmed — not two commands billed as equals.
+Y='\033[33m'; B='\033[1m'; D='\033[2m'; R='\033[0m'
 echo ""
-echo -e "${Y}╭─ ${B}next step${R}${Y} ──────────────────────────────╮${R}"
-echo -e "${Y}│${R} Run ${B}$CMD init${R} or ${B}$ALIAS init${R} to log in ${Y}│${R}"
-echo -e "${Y}│${R} with the Polkadot mobile app.            ${Y}│${R}"
-echo -e "${Y}│${R} Both commands work the same.             ${Y}│${R}"
-echo -e "${Y}╰──────────────────────────────────────────╯${R}"
+echo -e "${Y}╭─ ${B}Next step${R}${Y} ────────────────────────────╮${R}"
+echo -e "${Y}│${R} Log in with the Polkadot mobile app:   ${Y}│${R}"
+echo -e "${Y}│${R}                                        ${Y}│${R}"
+echo -e "${Y}│${R}   ${B}$CMD init${R}                      ${Y}│${R}"
+echo -e "${Y}╰────────────────────────────────────────╯${R}"
+echo -e "${D}  Tip: ${ALIAS} is a short alias for ${CMD}.${R}"


### PR DESCRIPTION
## What

The post-install `install.sh` output previously showed `playground init` and `pg init` as co-equal commands, followed by a literal "Both commands work the same." line. This reads as childish next to how serious CLIs (npm, gh, cargo, vercel) present a next step.

This change surfaces a **single canonical command** and demotes the alias to one dimmed tip line below the box.

**Before:**
```
╭─ next step ──────────────────────────────╮
│ Run playground init or pg init to log in │
│ with the Polkadot mobile app.            │
│ Both commands work the same.             │
╰──────────────────────────────────────────╯
```

**After:**
```
╭─ Next step ────────────────────────────╮
│ Log in with the Polkadot mobile app:   │
│                                         │
│   playground init                      │
╰────────────────────────────────────────╯
  Tip: pg is a short alias for playground.
```

Also drops the `(or pg init)` parenthetical from the dependency-setup failure message for the same reason.

## Notes
- Box rows verified to a uniform 42 columns.
- Patch changeset included.