### PR TITLE
fix: bulletin storage slot-account signer — eliminate mobile signing size errors

### DIFF
--- a/src/utils/decentralize/run.ts
+++ b/src/utils/decentralize/run.ts
@@ -175,6 +175,10 @@ export async function runDecentralize(
         // pool. Falls back silently to pool if absent or resolution fails.
         if (mode === "phone" && userSigner) {
             try {
+                onEvent?.({
+                    kind: "signing",
+                    event: { label: "Approve Bulletin storage allowance" },
+                } as any);
                 const slotSigner = await getBulletinAllowanceSigner({
                     env,
                     ownerAddress: userSigner.address,

--- a/src/utils/decentralize/run.ts
+++ b/src/utils/decentralize/run.ts
@@ -41,6 +41,8 @@ import {
 import { runStorageDeploy } from "../deploy/storage.js";
 import type { ResolvedSigner } from "../signer.js";
 import { mirrorSite } from "./mirror.js";
+import { getBulletinAllowanceSigner } from "../allowances/bulletin.js";
+import { getSlotAccountAddress, readSlotAccountKey } from "../allowances/slotKeys.js";
 
 export type DecentralizeLogEvent =
     | { kind: "mirror-start"; url: string }
@@ -167,6 +169,34 @@ export async function runDecentralize(
             fileCount: mirror.fileCount,
             directory: mirror.uploadRoot,
         });
+
+        // Phone mode: attempt to resolve a BulletIn slot-account signer so
+        // chunk uploads use the user's own allowance instead of the shared
+        // pool. Falls back silently to pool if absent or resolution fails.
+        if (mode === "phone" && userSigner) {
+            try {
+                const slotSigner = await getBulletinAllowanceSigner({
+                    env,
+                    ownerAddress: userSigner.address,
+                    publishSigner: userSigner,
+                });
+                const slotKey = await readSlotAccountKey(
+                    env,
+                    userSigner.address,
+                    "BulletInAllowance",
+                );
+                const slotSs58 = slotKey ? getSlotAccountAddress(slotKey) : undefined;
+                if (slotSs58) {
+                    setup.bulletinDeployAuthOptions = {
+                        ...setup.bulletinDeployAuthOptions,
+                        storageSigner: slotSigner,
+                        storageSignerAddress: slotSs58,
+                    };
+                }
+            } catch {
+                // Slot signer resolution failed — pool fallback handled by bulletin-deploy.
+            }
+        }
 
         onEvent?.({ kind: "storage-start", fullDomain });
         const result = await runStorageDeploy({

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -25,6 +25,9 @@ const {
     detectBuildConfigMock,
     loadDetectInputMock,
     withSpanMock,
+    getBulletinAllowanceSignerMock,
+    readSlotAccountKeyMock,
+    getSlotAccountAddressMock,
 } = vi.hoisted(() => ({
     runStorageDeploy: vi.fn<
         (arg: any) => Promise<{
@@ -57,9 +60,23 @@ const {
         configFiles: new Set<string>(),
     })),
     withSpanMock: vi.fn(async (_op: string, _name: string, _attrs: any, fn: any) => fn()),
+    getBulletinAllowanceSignerMock: vi.fn(async () => ({
+        publicKey: new Uint8Array(32),
+        signTx: async () => new Uint8Array(64),
+        signBytes: async () => new Uint8Array(64),
+    })),
+    readSlotAccountKeyMock: vi.fn(async () => new Uint8Array(32).fill(0x42)),
+    getSlotAccountAddressMock: vi.fn(() => "5SlotAddress"),
 }));
 
 vi.mock("./storage.js", () => ({ runStorageDeploy }));
+vi.mock("../allowances/bulletin.js", () => ({
+    getBulletinAllowanceSigner: getBulletinAllowanceSignerMock,
+}));
+vi.mock("../allowances/slotKeys.js", () => ({
+    readSlotAccountKey: readSlotAccountKeyMock,
+    getSlotAccountAddress: getSlotAccountAddressMock,
+}));
 vi.mock("./playground.js", () => ({
     publishToPlayground: publishToPlaygroundMock,
     normalizeDomain: (d: string) => {
@@ -111,6 +128,9 @@ beforeEach(() => {
     publishToPlaygroundMock.mockClear();
     runBuildMock.mockClear();
     withSpanMock.mockClear();
+    getBulletinAllowanceSignerMock.mockClear();
+    readSlotAccountKeyMock.mockClear();
+    getSlotAccountAddressMock.mockClear();
 });
 
 describe("runDeploy", () => {
@@ -379,5 +399,65 @@ describe("runDeploy", () => {
         expect(ops).toContain("cli.deploy.build");
         expect(ops).toContain("cli.deploy.storage-dotns");
         expect(ops).toContain("cli.deploy.playground");
+    });
+
+    it("phone mode: slot signer injected into storage auth when resolution succeeds", async () => {
+        // getBulletinAllowanceSigner succeeds → storageSigner + storageSignerAddress
+        // must appear in the auth object passed to runStorageDeploy.
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            skipBuild: true,
+            domain: "my-app",
+            mode: "phone",
+            publishToPlayground: false,
+            userSigner: fakeUserSigner,
+            onEvent: push,
+        });
+
+        expect(getBulletinAllowanceSignerMock).toHaveBeenCalledTimes(1);
+        const arg = runStorageDeploy.mock.calls[0][0];
+        // The wrapped signer (from maybeWrapAuthForSigning) carries storageSignerAddress through.
+        expect(arg.auth.storageSignerAddress).toBe("5SlotAddress");
+        expect(arg.auth.storageSigner).toBeDefined();
+    });
+
+    it("dev mode: getBulletinAllowanceSigner is NOT called", async () => {
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            skipBuild: true,
+            domain: "my-app",
+            mode: "dev",
+            publishToPlayground: false,
+            userSigner: null,
+            onEvent: push,
+        });
+
+        expect(getBulletinAllowanceSignerMock).not.toHaveBeenCalled();
+    });
+
+    it("phone mode: slot resolution failure does not abort deploy (pool fallback)", async () => {
+        getBulletinAllowanceSignerMock.mockRejectedValueOnce(new Error("allocation failed"));
+        const { push } = collectEvents();
+        // Should resolve normally — error is swallowed, pool is used.
+        await expect(
+            runDeploy({
+                projectDir: "/tmp/proj",
+                buildDir: "/tmp/proj/dist",
+                skipBuild: true,
+                domain: "my-app",
+                mode: "phone",
+                publishToPlayground: false,
+                userSigner: fakeUserSigner,
+                onEvent: push,
+            }),
+        ).resolves.toBeDefined();
+
+        // auth must NOT contain storageSigner (slot resolution failed).
+        const arg = runStorageDeploy.mock.calls[0][0];
+        expect(arg.auth.storageSignerAddress).toBeUndefined();
     });
 });

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -404,7 +404,7 @@ describe("runDeploy", () => {
     it("phone mode: slot signer injected into storage auth when resolution succeeds", async () => {
         // getBulletinAllowanceSigner succeeds → storageSigner + storageSignerAddress
         // must appear in the auth object passed to runStorageDeploy.
-        const { push } = collectEvents();
+        const { events, push } = collectEvents();
         await runDeploy({
             projectDir: "/tmp/proj",
             buildDir: "/tmp/proj/dist",
@@ -421,6 +421,16 @@ describe("runDeploy", () => {
         // The wrapped signer (from maybeWrapAuthForSigning) carries storageSignerAddress through.
         expect(arg.auth.storageSignerAddress).toBe("5SlotAddress");
         expect(arg.auth.storageSigner).toBeDefined();
+
+        // A signing event must be emitted BEFORE getBulletinAllowanceSigner is
+        // called so the TUI can show "check your phone" while the allocator runs.
+        const signingEvents = events.filter((e) => e.kind === "signing") as Array<{
+            kind: "signing";
+            event: any;
+        }>;
+        expect(
+            signingEvents.some((e) => e.event?.label === "Approve Bulletin storage allowance"),
+        ).toBe(true);
     });
 
     it("dev mode: getBulletinAllowanceSigner is NOT called", async () => {

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -26,6 +26,10 @@ import { runBuild, loadDetectInput, detectBuildConfig, type BuildConfig } from "
 import { publishToPlayground, normalizeDomain } from "./playground.js";
 import { resolveSignerSetup, type SignerMode, type DeployApproval } from "./signerMode.js";
 import {
+    getBulletinAllowanceSigner,
+} from "../allowances/bulletin.js";
+import { getSlotAccountAddress, readSlotAccountKey } from "../allowances/slotKeys.js";
+import {
     wrapSignerWithEvents,
     createSigningCounter,
     type SigningCounter,
@@ -34,7 +38,7 @@ import {
 import type { DeployLogEvent } from "./progress.js";
 import { withDeployPhase } from "./phase.js";
 import type { ResolvedSigner } from "../signer.js";
-import type { Env } from "../../config.js";
+import { DEFAULT_ENV, type Env } from "../../config.js";
 import type { DeployPlan } from "./availability.js";
 
 // ── Events ───────────────────────────────────────────────────────────────────
@@ -115,6 +119,36 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
     });
 
     options.onEvent({ kind: "plan", approvals: setup.approvals });
+
+    // Phone mode: attempt to resolve a BulletIn slot-account signer so chunk
+    // uploads use the user's own allowance instead of the shared pool. Falls
+    // back silently to pool if the key is absent or resolution fails for any
+    // reason — bulletin-deploy handles the pool path internally.
+    if (options.mode === "phone" && options.userSigner) {
+        const resolvedEnv = options.env ?? DEFAULT_ENV;
+        try {
+            const slotSigner = await getBulletinAllowanceSigner({
+                env: resolvedEnv,
+                ownerAddress: options.userSigner.address,
+                publishSigner: options.userSigner,
+            });
+            const slotKey = await readSlotAccountKey(
+                resolvedEnv,
+                options.userSigner.address,
+                "BulletInAllowance",
+            );
+            const slotSs58 = slotKey ? getSlotAccountAddress(slotKey) : undefined;
+            if (slotSs58) {
+                setup.bulletinDeployAuthOptions = {
+                    ...setup.bulletinDeployAuthOptions,
+                    storageSigner: slotSigner,
+                    storageSignerAddress: slotSs58,
+                };
+            }
+        } catch {
+            // Slot signer resolution failed — pool fallback handled by bulletin-deploy.
+        }
+    }
 
     const counter = createSigningCounter(setup.approvals.length);
 

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -127,6 +127,10 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
     if (options.mode === "phone" && options.userSigner) {
         const resolvedEnv = options.env ?? DEFAULT_ENV;
         try {
+            options.onEvent({
+                kind: "signing",
+                event: { label: "Approve Bulletin storage allowance" },
+            } as any);
             const slotSigner = await getBulletinAllowanceSigner({
                 env: resolvedEnv,
                 ownerAddress: options.userSigner.address,

--- a/src/utils/deploy/signerMode.ts
+++ b/src/utils/deploy/signerMode.ts
@@ -37,6 +37,7 @@
  */
 
 import { DEFAULT_MNEMONIC, type DeployOptions } from "bulletin-deploy";
+import type { PolkadotSigner } from "polkadot-api";
 import { ss58Encode } from "@parity/product-sdk-address";
 import { seedToAccount } from "@parity/product-sdk-keys";
 import type { ResolvedSigner } from "../signer.js";
@@ -95,7 +96,23 @@ export interface DeploySignerSetup {
      * phone mode we inject the user's signer so DotNS registration is paid
      * for by — and recorded against — their account.
      */
-    bulletinDeployAuthOptions: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic">;
+    bulletinDeployAuthOptions: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic"> & {
+        /**
+         * Slot-account signer for Bulletin storage writes. When present,
+         * bulletin-deploy routes chunk uploads through this signer's
+         * allowance instead of the pool. Only populated in phone mode when
+         * `getBulletinAllowanceSigner` succeeds; pool fallback otherwise.
+         *
+         * NOTE: `storageSigner` / `storageSignerAddress` are present in
+         * `DeployOptions` only from bulletin-deploy v0.8.x onward. The
+         * intersection is used here because the npm-published 0.7.x types
+         * don't carry these fields yet; the spread in storage.ts passes them
+         * through silently to the runtime where they become effective once
+         * bulletin-deploy is updated.
+         */
+        storageSigner?: PolkadotSigner;
+        storageSignerAddress?: string;
+    };
 
     /**
      * Signer used to call `registry.publish()` for the playground step.

--- a/src/utils/deploy/storage.ts
+++ b/src/utils/deploy/storage.ts
@@ -35,6 +35,7 @@ import {
     type DeployOptions,
     type DeployResult,
 } from "bulletin-deploy";
+import type { PolkadotSigner } from "polkadot-api";
 import { DeployLogParser, type DeployLogEvent } from "./progress.js";
 import { getChainConfig, type Env } from "../../config.js";
 
@@ -53,7 +54,15 @@ export interface StorageDeployOptions {
      * Auth options forwarded to bulletin-deploy. Usually produced by
      * `resolveSignerSetup()`. May be `{}` for the dev path.
      */
-    auth: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic">;
+    auth: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic"> & {
+        /**
+         * Slot-account signer for Bulletin storage writes. Forwarded to
+         * bulletin-deploy unchanged; 0.7.x ignores it silently, 0.8.x routes
+         * chunk uploads through this signer's allowance instead of the pool.
+         */
+        storageSigner?: PolkadotSigner;
+        storageSignerAddress?: string;
+    };
     /** Emits progress events derived from bulletin-deploy's log output. */
     onLogEvent?: (event: DeployLogEvent) => void;
     /** Target environment — currently only `testnet` is supported. */

--- a/src/utils/sessionSigner.test.ts
+++ b/src/utils/sessionSigner.test.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { ss58Encode } from "@parity/product-sdk-address";
 import { seedToAccount } from "@parity/product-sdk-keys";
 import type { UserSession } from "@parity/product-sdk-terminal";
@@ -125,5 +125,80 @@ describe("init / deploy / playground-app account equivalence", () => {
         // The CLI must use the same productId so both derive the SAME account from
         // a given user mnemonic.
         expect(PLAYGROUND_PRODUCT_ID).toEqual("playground.dot");
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// signRaw(Payload) anti-regression — guards against accidental revert to the
+// signPayload path (which sends 2 MB calldata to mobile wallets).
+// ────────────────────────────────────────────────────────────────────────────
+describe("createPlaygroundSessionSigner — signRaw(Payload) routing", () => {
+    type OkResult<T> = { isErr(): false; isOk(): true; value: T };
+    type ErrResult<E> = { isErr(): true; isOk(): false; error: E };
+    function okResult<T>(value: T): OkResult<T> {
+        return { isErr: () => false as const, isOk: () => true as const, value };
+    }
+    function errResult<E>(error: E): ErrResult<E> {
+        return { isErr: () => true as const, isOk: () => false as const, error };
+    }
+
+    function makeSession(opts: {
+        signRaw?: (req: unknown) => Promise<unknown>;
+        signPayload?: (req: unknown) => Promise<unknown>;
+    } = {}) {
+        const root = seedToAccount("bottom drive obey lake curtain smoke basket hold race lonely fit walk", "");
+        return {
+            id: "test",
+            localAccount: { accountId: new Uint8Array(32), pin: undefined },
+            remoteAccount: { accountId: root.publicKey, publicKey: root.publicKey, pin: undefined },
+            rootAccountId: root.publicKey,
+            signRaw: vi.fn(opts.signRaw ?? (async () => { throw new Error("signRaw not stubbed"); })),
+            signPayload: vi.fn(opts.signPayload ?? (async () => { throw new Error("signPayload not stubbed"); })),
+        } as unknown as UserSession & { signRaw: ReturnType<typeof vi.fn>; signPayload: ReturnType<typeof vi.fn> };
+    }
+
+    test("signBytes never calls session.signPayload (anti-regression: message-too-big)", async () => {
+        const sig = new Uint8Array(64).fill(0xaa);
+        const session = makeSession({
+            signRaw: async () => okResult({ signature: sig }),
+        });
+        const signer = createPlaygroundSessionSigner(session, {
+            productId: PLAYGROUND_PRODUCT_ID,
+            derivationIndex: 0,
+        });
+        await signer.signBytes(new Uint8Array([1]));
+        expect(session.signPayload).not.toHaveBeenCalled();
+        expect(session.signRaw).toHaveBeenCalled();
+        const req = (session.signRaw.mock.calls[0] as [{ data: { tag: string } }])[0];
+        expect(req.data.tag).toBe("Bytes");
+    });
+
+    test("signBytes routes through signRaw with Bytes tag", async () => {
+        const sig = new Uint8Array(64).fill(0xbb);
+        const session = makeSession({
+            signRaw: async () => okResult({ signature: sig }),
+        });
+        const signer = createPlaygroundSessionSigner(session, {
+            productId: PLAYGROUND_PRODUCT_ID,
+            derivationIndex: 0,
+        });
+        const out = await signer.signBytes(new Uint8Array([1, 2, 3]));
+        expect(out).toEqual(sig);
+        expect(session.signPayload).not.toHaveBeenCalled();
+        const req = (session.signRaw.mock.calls[0] as [{ data: { tag: string } }])[0];
+        expect(req.data.tag).toBe("Bytes");
+    });
+
+    test("mobile rejection surfaces as 'Mobile signing rejected:' prefix", async () => {
+        const session = makeSession({
+            signRaw: async () => errResult({ message: "user declined" }),
+        });
+        const signer = createPlaygroundSessionSigner(session, {
+            productId: PLAYGROUND_PRODUCT_ID,
+            derivationIndex: 0,
+        });
+        await expect(signer.signBytes(new Uint8Array([1]))).rejects.toThrow(
+            "Mobile signing rejected: user declined",
+        );
     });
 });

--- a/src/utils/sessionSigner.ts
+++ b/src/utils/sessionSigner.ts
@@ -16,45 +16,25 @@
 /**
  * Session-backed `PolkadotSigner` for the playground product account.
  *
- * **Why a CLI-local builder and not `createSessionSignerForAccount` from
- * `@parity/product-sdk-terminal@0.2.1`?**
+ * **Why `getPolkadotSigner` with `signRaw(Payload)` instead of
+ * `getPolkadotSignerFromPjs` with `signPayload`?**
  *
- * The SDK's "PR #81 fix" routes tx signing through
- * `session.signRaw({ data: { tag: "Payload", value: hex(toSign) } })`. Android
- * v1198 (and earlier) ALWAYS applies the `<Bytes>...</Bytes>` anti-phishing
- * envelope inside `SignRawInteractor.sign()` — see
- * `polkadot-app-android-v2/chains/.../MessageSigningContext.kt::generalUntrustedMessage`
- * and `feature/products/impl/.../SignRawInteractor.kt` — so the resulting
- * signature is over `<Bytes>${utf8(hex)}</Bytes>`, NOT the bare extrinsic
- * payload. The chain reconstructs the bare payload, verifies, and rejects with
- * `{ type: "Invalid", value: { type: "BadProof" } }` on EVERY `Revive.map_account`
- * (and any other tx) on paseo-next-v2 with the AsPgas extension active.
+ * The PJS-based approach sent the full 2 MB chunk calldata as the `method`
+ * field of `signPayload`. Android rejects payloads exceeding a size limit with
+ * "message too big", causing every large-chunk deploy to fail on mobile wallets.
  *
- * The canonical workaround comes straight from the Android team's own sample
- * app at `polkadot-app-android-v2/feature/products/product-sample/src/scripts/products_demo.tsx:773-789`:
- *
- *   1. Build a PJS-style signer with `getPolkadotSignerFromPjs(address, signPayload, signRaw)`.
- *   2. Provide a custom `signPayload` that maps PJS's `SignerPayloadJSON` onto
- *      host-papp's `SigningPayloadRequest` and forwards via `session.signPayload(...)`.
- *      Android's `signPayload` handler then reconstructs the full payload itself
- *      (including AsPgas sponsoring) and signs the bare bytes correctly.
- *   3. Wrap the resulting signer so that for `RELAXED_SIGNED_EXTENSIONS`
- *      (extensions PAPI sees but the PJS adapter can't recognize, e.g. `AsPgas`
- *      and `AsRingAlias`), we zero out `value` + `additionalSigned` BEFORE PJS
- *      walks them. That sidesteps PJS's "PJS does not support this
- *      signed-extension" throw at `@polkadot-api/pjs-signer/dist/from-pjs-account.js:30-32`
- *      WITHOUT dropping the identifier from `signedExtensions[]` — so android
- *      still knows to include them and fills in the correct encoding from its
- *      own runtime view.
+ * PAPI's `getPolkadotSigner` hashes payloads >256 bytes before calling the raw
+ * sign function, so the mobile wallet only ever receives ≤32 bytes. The
+ * `Payload` tag tells Android to sign without the `<Bytes>…</Bytes>`
+ * anti-phishing envelope (which would break the signature for extrinsic
+ * payloads).
  *
  * Replace this whole file with a `product-sdk-terminal` re-export once that
- * package's signer uses `session.signPayload` and ships the relaxed-extensions
- * wrapper natively.
+ * package's signer uses the same approach and ships natively.
  */
 
-import { getPolkadotSignerFromPjs, type SignerPayloadJSON } from "polkadot-api/pjs-signer";
-import { fromHex, toHex } from "polkadot-api/utils";
-import { ss58Encode } from "@parity/product-sdk-address";
+import { getPolkadotSigner } from "polkadot-api/signer";
+import { toHex } from "polkadot-api/utils";
 import type { UserSession } from "@parity/product-sdk-terminal";
 import type { PolkadotSigner } from "polkadot-api";
 import { deriveProductAccountPublicKey } from "@parity/product-sdk-keys";
@@ -99,117 +79,44 @@ export function derivePlaygroundProductPublicKey(
     return deriveProductAccountPublicKey(rootAccountId, ref.productId, ref.derivationIndex);
 }
 
-/**
- * Identifiers whose payload PAPI may populate but the PJS adapter doesn't
- * recognize. Mirrors `RELAXED_SIGNED_EXTENSIONS` in the polkadot-app sample.
- * Add to this set if a future runtime adds another v2-style extension PAPI
- * doesn't know about; android's host fills in the actual encoding.
- */
-const RELAXED_SIGNED_EXTENSIONS: ReadonlySet<string> = new Set(["AsPgas", "AsRingAlias"]);
-
-function asHexString(value: string | undefined): `0x${string}` | undefined {
-    if (value === undefined) return undefined;
-    // host-papp's SigningPayloadRequest types hex fields as `0x${string}`.
-    // PJS adapter populates them via toPjsHex / toHex which produce hex strings;
-    // cast through since the runtime values are guaranteed-prefixed.
-    return value as `0x${string}`;
-}
-
-/**
- * Coerce PJS's `assetId: number | object | undefined` to host-papp's hex shape.
- *
- * For `ChargeAssetTxPayment` and `AsPgas`, the PJS mapper produces a `0x…`
- * string when the asset is set. Other shapes (number / nested object) shouldn't
- * surface in paseo-next-v2 today; we coerce defensively.
- */
-function coerceAssetId(value: unknown): `0x${string}` | undefined {
-    if (value === undefined || value === null) return undefined;
-    if (typeof value === "string" && value.startsWith("0x")) return value as `0x${string}`;
-    // Defensive fallback: stringify and warn upstream.
-    return undefined;
-}
-
 export function createPlaygroundSessionSigner(
     session: UserSession,
     ref: ProductAccountRef,
 ): PolkadotSigner {
-    // `session.remoteAccount.accountId` is the wallet's currently-selected
-    // substrate account (`walletAccount.defaultAccountId()` on Android), NOT
-    // the product-derived account that actually signs on-chain. Using it as
-    // `signer.publicKey` would cause every funding / balance lookup / allowance
-    // marker / display address in this CLI to point at the wallet, while the
-    // mobile-constructed `signedTransaction` carries a different `From`
-    // (the product account derived at `/product/{productId}/{idx}`).
-    //
     // `session.rootAccountId` is the handshake-time `rootUserAccountId` —
     // the user's bare-mnemonic keypair public key on current mobile builds
     // (`deriveRootAccount()` = `derivationPath = null`). See the "Accounts"
     // section in CLAUDE.md for the host-vs-mobile derivation map.
     const publicKey = derivePlaygroundProductPublicKey(sessionRootPublicKey(session), ref);
-    const address = ss58Encode(publicKey);
 
-    // Wire-shape identifier passed to host-papp's `signPayload` / `signRaw`.
+    // Wire-shape identifier passed to host-papp's `signRaw`.
     // Has to be assembled here (not in derive) because the host-papp message
     // codec wants the productId/derivationIndex as a separate tuple field.
     const productAccountId: [string, number] = [ref.productId, ref.derivationIndex];
 
-    const signPayload = async (pjs: SignerPayloadJSON) => {
-        const result = await session.signPayload({
-            productAccountId,
-            blockHash: asHexString(pjs.blockHash) as `0x${string}`,
-            blockNumber: asHexString(pjs.blockNumber) as `0x${string}`,
-            era: asHexString(pjs.era) as `0x${string}`,
-            genesisHash: asHexString(pjs.genesisHash) as `0x${string}`,
-            method: asHexString(pjs.method) as `0x${string}`,
-            nonce: asHexString(pjs.nonce) as `0x${string}`,
-            specVersion: asHexString(pjs.specVersion) as `0x${string}`,
-            tip: asHexString(pjs.tip) as `0x${string}`,
-            transactionVersion: asHexString(pjs.transactionVersion) as `0x${string}`,
-            signedExtensions: pjs.signedExtensions,
-            version: pjs.version,
-            assetId: coerceAssetId(pjs.assetId),
-            metadataHash: asHexString(pjs.metadataHash),
-            mode: pjs.mode,
-            withSignedTransaction: pjs.withSignedTransaction,
-        });
-        if (result.isErr()) {
-            throw new Error(`Mobile signing failed: ${result.error.message}`);
-        }
-        const data = result.value;
-        return {
-            signature: toHex(data.signature),
-            signedTransaction: data.signedTransaction ? toHex(data.signedTransaction) : undefined,
-        };
-    };
-
-    const signRaw = async (payload: { address: string; data: string; type: "bytes" }) => {
-        if (!payload.data.startsWith("0x")) {
-            throw new Error("Raw signing payload must be 0x-prefixed hex");
-        }
+    const txSign = async (toSign: Uint8Array): Promise<Uint8Array> => {
+        // PAPI has already hashed toSign if >256 bytes — mobile receives ≤32 bytes.
         const result = await session.signRaw({
             productAccountId,
-            data: { tag: "Bytes", value: fromHex(payload.data as `0x${string}`) },
+            data: { tag: "Payload", value: toHex(toSign) },
         });
         if (result.isErr()) {
-            throw new Error(`Mobile signing failed: ${result.error.message}`);
+            throw new Error(`Mobile signing rejected: ${result.error.message}`);
         }
-        return { id: 0, signature: toHex(result.value.signature) };
+        return result.value.signature;
     };
 
-    const baseSigner = getPolkadotSignerFromPjs(address, signPayload, signRaw);
-
-    // Relaxed-extensions wrapper — see the file-level comment.
-    return {
-        publicKey: baseSigner.publicKey,
-        signBytes: baseSigner.signBytes,
-        signTx: (callData, signedExtensions, metadata, atBlockNumber, hasher) => {
-            const relaxed: typeof signedExtensions = {};
-            for (const [identifier, ext] of Object.entries(signedExtensions)) {
-                relaxed[identifier] = RELAXED_SIGNED_EXTENSIONS.has(identifier)
-                    ? { ...ext, value: new Uint8Array(0), additionalSigned: new Uint8Array(0) }
-                    : ext;
-            }
-            return baseSigner.signTx(callData, relaxed, metadata, atBlockNumber, hasher);
-        },
+    const bytesSign = async (data: Uint8Array): Promise<Uint8Array> => {
+        const result = await session.signRaw({
+            productAccountId,
+            data: { tag: "Bytes", value: data },
+        });
+        if (result.isErr()) {
+            throw new Error(`Mobile signing rejected: ${result.error.message}`);
+        }
+        return result.value.signature;
     };
+
+    const base = getPolkadotSigner(publicKey, "Sr25519", txSign);
+    return { ...base, signBytes: bytesSign };
 }


### PR DESCRIPTION
## Summary

- Replaces `getPolkadotSignerFromPjs` + `session.signPayload` in `src/utils/sessionSigner.ts` with PAPI-native `getPolkadotSigner` + `session.signRaw({ tag: "Payload" })`.
- Wires `getBulletinAllowanceSigner` into phone-mode deploy and decentralize runners. Emits `"Approve Bulletin storage allowance"` signing event before allocation.
- Widens `StorageDeployOptions.auth` and `bulletinDeployAuthOptions` to carry `storageSigner`/`storageSignerAddress`.

Depends on: paritytech/bulletin-deploy#806 (must merge first).

---

# Bulletin Storage Slot-Account Signer

**Date:** 2026-06-02  
**Repos:** `paritytech/bulletin-deploy` (PR #791 branch) + `paritytech/playground-cli`  
**Status:** Design — awaiting implementation

---

## Problem

`src/auth/vendor/sessionSigner.ts` (bulletin-deploy) and `src/utils/sessionSigner.ts`
(playground-cli) both use `getPolkadotSignerFromPjs` + `session.signPayload`. The PJS
adapter puts the full call data (~2 MB for a storage chunk) in the `method` field and
sends it to the mobile wallet. Android rejects it: `"Mobile signing failed: message too big"`.

Confirmed in Sentry (7-day window): 2 live events from `paritytech/dApp-factory`, domain
`paseo-tip-jar01`, `chunk(nonce:0) subscription error: Mobile signing failed: message too
big`.

Even with a patched signer, routing 30+ storage chunks through an interactive mobile
session is architecturally wrong. The slot-account model — one wallet dialog at login
(or lazily at first deploy), then local sr25519 signing for all uploads — is the correct
design for bulk Bulletin submissions. playground-cli already implements this in
`src/utils/allowances/bulletin.ts` for its metadata-upload path; this design extends it
to the main `runStorageDeploy` path and mirrors the pattern in bulletin-deploy.

---

## Scope

Two repos change in lock-step because `DeployOptions` in bulletin-deploy is a breaking
interface for playground-cli.

### bulletin-deploy

| Unit | Files |
|------|-------|
| A. Session signer vendor update | `src/auth/vendor/sessionSigner.ts` |
| B. New `storageSigner` parameter | `src/deploy.ts` (`DeployOptions`, `selectStorageReconnect`) |
| C. Slot signer reader | `src/storage-signer.ts` (new) |
| D. CLI wiring | `src/commands/deploy.ts` |
| E. Classifier widening | `src/telemetry.ts` (PR #803 follow-up) |

### playground-cli

| Unit | Files |
|------|-------|
| A. Session signer vendor update | `src/utils/sessionSigner.ts` |
| B. Slot signer in deploy runners | `src/utils/deploy/run.ts`, `src/utils/decentralize/run.ts` |
| C. `StorageDeployOptions` widening | `src/utils/deploy/storage.ts` |

---

## Architecture

### A — Session signer vendor update (both repos)

The upstream product-sdk `signer.ts` has been rewritten. The old path:

```
getPolkadotSignerFromPjs → pjs.method = toHex(callData)  // ~4 MB hex for 2 MB chunk
→ session.signPayload({ method: "0x<4MB>" })              // Android: "message too big"
```

New path (mirrors current product-sdk `signer.ts` exactly):

```
getPolkadotSigner(publicKey, "Sr25519", signCallback)
  → PAPI: toSign.length > 256 ? blake2(toSign) : toSign   // 32 bytes for large tx
  → signCallback(32 bytes)
  → session.signRaw({ tag: "Payload", value: hex(32bytes) })  // no size problem
```

The `Payload` tag tells Android to sign the bytes as-is (no `<Bytes>…</Bytes>`
anti-phishing envelope), which avoids the `BadProof` failure that broke the previous
`signRaw` attempt on old Android builds.

The error string changes: `"Mobile signing failed:"` → `"Mobile signing rejected:"`.  
The `signer.message_too_large` classifier in `src/telemetry.ts` (PR #803) must be
widened:

```ts
// Before
[/Mobile signing failed.*message too big/i, 'signer.message_too_large'],

// After
[/Mobile signing (?:failed|rejected).*message too big/i, 'signer.message_too_large'],
```

### B — `DeployOptions.storageSigner` (bulletin-deploy)

Add to `DeployOptions`:

```ts
/** Local slot-account signer for Bulletin chunk uploads. When present, used instead of
 *  pool or mnemonic for storage. DotNS still uses `signer`/`signerAddress`. */
storageSigner?: PolkadotSigner;
storageSignerAddress?: string;
```

Update `selectStorageReconnect` — new priority: `storageSigner > mnemonic > pool`.
The `signer` field is **removed from storage routing entirely**; it routes to DotNS only.
This restores the architectural invariant documented at `deploy.ts:2309` that the sign-in
lift inadvertently broke.

The slot signer is Bulletin-only — it has nothing to do with the `ensureAuthorized` /
DotNS authorization machinery in `getSignerProvider`. A new `getSlotSignerProvider`
creates a Bulletin WS connection and returns `{ client, unsafeApi, signer, ss58 }` with
no authorization checks. Pool is always the final fallback; no deploy should fail because
of the Bulletin allowance path.

The reconnect thunk uses a committed `useSlot` flag: once the slot signer fails on the
first connection attempt, every subsequent reconnect uses pool. This prevents signer
drift across chunk uploads (nonce attribution would break if storage switched signers
mid-upload).

```ts
function selectStorageReconnect(options: DeployOptions): () => Promise<ProviderResult> {
  if (options.storageSigner && options.storageSignerAddress) {
    let useSlot = true;
    return async () => {
      if (!useSlot) return getProvider();
      try {
        return await getSlotSignerProvider(options.storageSigner!, options.storageSignerAddress!);
      } catch {
        useSlot = false;
        setDeployAttribute("deploy.signer.mode", "pool-fallback");
        return getProvider();
      }
    };
  }
  if (options.mnemonic)
    return () => getDirectProvider(options.mnemonic!, options.derivationPath);
  return () => getProvider();  // pool
  // options.signer intentionally absent — DotNS only
}

Export `__selectStorageProviderModeForTest` is updated to match:

```ts
export function __selectStorageProviderModeForTest(
  options: Pick<DeployOptions, "storageSigner" | "storageSignerAddress" | "mnemonic">
): "storageSigner" | "direct" | "pool"
```

### C — Slot signer reader + writer (bulletin-deploy `src/storage-signer.ts`)

Reads the product-sdk terminal allowance cache at
`~/.polkadot-apps/{sanitize(DOT_DAPP_ID)}_AllowanceKeys.json`
(same format as `@parity/product-sdk-terminal`'s `host-signer.ts`).

```ts
// src/storage-signer.ts
import { readFile } from "node:fs/promises";
import { homedir } from "node:os";
import { join } from "node:path";
import { fromHex } from "@polkadot-api/utils";
import { sr25519CreateDerive } from "@polkadot-labs/hdkd";
import { sr25519, ss58Address } from "@polkadot-labs/hdkd-helpers";
import { getPolkadotSigner } from "polkadot-api/signer";
import type { PolkadotSigner } from "polkadot-api";

// Mirrors product-sdk's sanitizeAppId.
function cacheFilePath(appId: string): string {
  return join(
    homedir(), ".polkadot-apps",
    `${appId.replace(/[^a-zA-Z0-9_.-]/g, "_")}_AllowanceKeys.json`,
  );
}

function signerFromSecret(secret: Uint8Array): PolkadotSigner {
  if (secret.length === 32) {
    const kp = sr25519CreateDerive(secret)("");
    return getPolkadotSigner(kp.publicKey, "Sr25519", async d => kp.sign(d));
  }
  if (secret.length === 64) {
    const publicKey = sr25519.getPublicKey(secret);
    return getPolkadotSigner(publicKey, "Sr25519", async d => sr25519.sign(d, secret));
  }
  throw new Error(`BulletInAllowance: unexpected key length ${secret.length}`);
}

/**
 * Read the BulletInAllowance slot account from the product-sdk terminal cache.
 * Returns null when not cached — caller should trigger requestResourceAllocation.
 *
 * Cache format: @parity/product-sdk-terminal host-cache.ts v1.
 */
export async function readBulletinSlotSigner(
  appId: string,
): Promise<{ signer: PolkadotSigner; ss58: string } | null> {
  let raw: string;
  try { raw = await readFile(cacheFilePath(appId), "utf-8"); }
  catch (e: any) { if (e?.code === "ENOENT") return null; throw e; }
  let cache: any;
  try { cache = JSON.parse(raw); } catch { return null; }
  const entry = cache?.entries?.BulletInAllowance;
  if (!entry?.slotAccountKey) return null;
  const secret = fromHex(entry.slotAccountKey);
  const signer = signerFromSecret(secret);
  return { signer, ss58: ss58Address(signer.publicKey) };
}
```

All imports (`@polkadot-labs/hdkd`, `@polkadot-labs/hdkd-helpers`, `@polkadot-api/utils`,
`polkadot-api/signer`) are already direct dependencies on the `feat/411-signin-impl`
branch. No new deps.

`src/storage-signer.ts` also needs a **writer**, because the vendored `allocations.ts`
intentionally does not persist slot keys ("the host stores them and uses them
transparently on subsequent calls" — its `AllocationOutcome.value` is typed `unknown`
and never read). The CLI path must extract the key from the outcome and write it to the
product-sdk terminal cache format itself.

Add to `src/storage-signer.ts`:

```ts
import { writeFile, mkdir } from "node:fs/promises";

/**
 * Extract the BulletInAllowance slot account key from a requestResourceAllocation
 * outcome array. Same shape as playground-cli's extractSlotAccountKey.
 */
export function extractBulletinSlotKey(outcomes: { tag: string; value: unknown }[]): `0x${string}` | null {
  for (const outcome of outcomes) {
    if (outcome.tag !== "Allocated") continue;
    const allocated = outcome.value as { tag?: string; value?: { slotAccountKey?: Uint8Array } } | undefined;
    if (allocated?.tag !== "BulletInAllowance") continue;
    const key = allocated.value?.slotAccountKey;
    if (!(key instanceof Uint8Array)) continue;
    return toHex(key) as `0x${string}`;  // toHex from @polkadot-api/utils (already imported)
  }
  return null;
}

/**
 * Write a BulletInAllowance slot key to the product-sdk terminal cache.
 * Format: @parity/product-sdk-terminal host-cache.ts v1.
 */
export async function writeBulletinSlotKey(appId: string, hexKey: `0x${string}`): Promise<void> {
  const path = cacheFilePath(appId);
  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
  // Read-modify-write to preserve other entries in the cache file.
  let existing: any = { version: 1, entries: {} };
  try { existing = JSON.parse(await readFile(path, "utf-8")); } catch { /* start fresh */ }
  existing.entries ??= {};
  existing.entries.BulletInAllowance = { tag: "BulletInAllowance", slotAccountKey: hexKey };
  await writeFile(path, `${JSON.stringify(existing, null, 2)}\n`, { mode: 0o600 });
}
```

(`dirname` comes from `node:path`, already imported.)

### D — CLI wiring (bulletin-deploy `src/commands/deploy.ts`)

After `resolveSigner`, if a session exists:

```ts
// Resolve slot-account signer for Bulletin storage.
// Pool is always the final fallback — no failure here should abort the deploy.
let slotResult = await readBulletinSlotSigner(DOT_DAPP_ID);

if (!slotResult && resolvedSigner.source === "session") {
  console.log("Requesting Bulletin storage allowance — check your phone to approve");
  try {
    // Get the live session (needed for requestResourceAllocation's UserSession arg).
    const sessionHandle = await authClient.getSessionSigner();
    if (sessionHandle) {
      const outcomes = await requestResourceAllocation(
        sessionHandle.userSession,
        DOT_PRODUCT_ID,
        [{ tag: "BulletInAllowance", value: undefined }],
      );
      // The vendored allocations.ts intentionally does not persist slot keys —
      // extract and write to the product-sdk terminal cache ourselves.
      const hexKey = extractBulletinSlotKey(outcomes);
      if (hexKey) {
        await writeBulletinSlotKey(DOT_DAPP_ID, hexKey);
        slotResult = await readBulletinSlotSigner(DOT_DAPP_ID);
      }
    }
  } catch {
    // Allocation failed or declined — fall back to pool silently.
  }
}

if (slotResult) {
  deployOptions.storageSigner = slotResult.signer;
  deployOptions.storageSignerAddress = slotResult.ss58;
}
// If slotResult is null for any reason (no session, declined, allocation error,
// key not extractable), selectStorageReconnect falls through to pool.
```

Imports added to the deploy command:
- `requestResourceAllocation` from `src/auth/index.ts` (already exported, signature is `(session: UserSession, productId: string, resources, onExisting) => Promise<AllocationOutcome[]>`)
- `extractBulletinSlotKey`, `writeBulletinSlotKey` from `src/storage-signer.ts` (new)
- `DOT_PRODUCT_ID` from `src/auth-config.ts` (already exported)

Pool is always the final fallback. Any failure — declined, timeout, key not in outcome,
write error — is caught and swallowed; deploy continues with pool storage.

### E — Slot signer resolution in playground-cli runners

`resolveSignerSetup` stays synchronous — no signature change. The slot signer resolution
happens in the async deploy runners, which already have `env`, `ownerAddress`
(`userSigner.address`), and `userSigner` in scope.

**`src/utils/deploy/run.ts` and `src/utils/decentralize/run.ts`** (phone mode):

```ts
// After resolveSignerSetup, before runStorageDeploy:
if (opts.mode === "phone" && opts.userSigner) {
  onEvent?.({ kind: "signing", event: { label: "Approve Bulletin storage allowance" } });
  const slotSigner = await getBulletinAllowanceSigner({
    env: opts.env,
    ownerAddress: opts.userSigner.address,
    publishSigner: opts.userSigner,
  });
  setup.bulletinDeployAuthOptions = {
    ...setup.bulletinDeployAuthOptions,
    storageSigner: slotSigner,
    storageSignerAddress: getSlotAccountAddress(
      await readSlotAccountKey(opts.env, opts.userSigner.address, "BulletInAllowance")!
    ),
  };
}
```

`getBulletinAllowanceSigner` handles: cache miss → `requestResourceAllocation` (phone
dialog) → `storeSlotAccountKeysFromOutcomes` → authorization check → re-allocate with
`Ignore` if not authorized. The `onEvent` signing emission before the call drives the
TUI's "check your phone" callout; it fires only when allocation is needed (the function
returns immediately from cache when the key exists).

Note: the `Increase` re-allocation branch inside `getBulletinAllowanceSigner` fires when
`authorized && remainingTransactions == 0`. In practice Bulletin grants a large
`transactions_allowance`, so remaining stays positive for any authorized account — the
`Increase` path is dead in practice. Leave the function unchanged; aligning the check
to `status.authorized` only is a separate cleanup.

**`src/utils/deploy/storage.ts`** — `StorageDeployOptions.auth` widened:

```ts
auth: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic" | "storageSigner" | "storageSignerAddress">;
```

`DeploySignerSetup.bulletinDeployAuthOptions` in `signerMode.ts` similarly widens its
`Pick` to include the two new fields.

---

## Data flow summary

### bulletin-deploy CLI

```
login  → requestResourceAllocation(BulletInAllowance)
         → ~/.polkadot-apps/dot-cli_AllowanceKeys.json

deploy → resolveSigner()                    // session signer → DotNS only
       → readBulletinSlotSigner(DOT_DAPP_ID)
           null → "check your phone to approve"
                → requestResourceAllocation()
                → read again
       → deploy({ signer,           // DotNS (phone taps)
                  storageSigner })  // Bulletin storage (local sr25519, no taps)
```

### playground-cli phone mode

```
runDeploy/runDecentralize
  → resolveSignerSetup()              // bulletinDeployAuthOptions: signer only
  → emit "Approve Bulletin storage allowance" signing event (if allocation needed)
  → getBulletinAllowanceSigner()      // reads ~/.polkadot/allowance-keys.json
      null → requestResourceAllocation() → store → checkAuth → (re-allocate if not authorized)
      → createSlotAccountSigner(key)  // local sr25519
  → runStorageDeploy({ auth: { signer, signerAddress,         // DotNS
                                storageSigner, storageSignerAddress } })  // storage
      → bulletinDeploy() → storeChunk ×N (local, no phone)
                         → DotNS flow  (phone taps as before)
```

**Fallback chain** (both paths): `storageSigner` → `mnemonic` → pool.  
`signer` never enters storage routing.

---

## Error handling

Pool is always the final fallback. No deploy should fail because of the Bulletin
allowance path.

| Condition | Behaviour |
|-----------|-----------|
| Cache file absent or corrupt | `readBulletinSlotSigner` returns null → pool |
| User declines phone dialog (bulletin-deploy) | allocation error caught → pool |
| Allocation fails for any reason | error caught → pool |
| `getSlotSignerProvider` throws (connection, not authorized, anything) | caught in `selectStorageReconnect` → pool |
| Slot account not authorized on Bulletin (playground-cli) | `getBulletinAllowanceSigner` re-allocates with `Ignore`; if still fails → propagates to runner, which should catch and fall back to pool |

---

## Testing

### bulletin-deploy

- **`src/storage-signer.ts`**: unit tests — (1) cache absent → null, (2) valid 32-byte
  key → correct SS58, (3) valid 64-byte key → correct SS58, (4) corrupt JSON → null,
  (5) missing `BulletInAllowance` entry → null.
- **`src/deploy.ts` `__selectStorageProviderModeForTest`**: update existing tests; add
  cases for `storageSigner` present → `"storageSigner"`, absent → existing `"direct"`/
  `"pool"` behaviour unchanged.
- **`src/auth/vendor/sessionSigner.ts`**: mirror the product-sdk `host-signer.ts` tests —
  (1) `signTx` routes through `signRaw` with `Payload` tag, never `signPayload`; (2)
  `signBytes` routes through `signRaw` with `Bytes` tag; (3) error → `"Mobile signing
  rejected:"` prefix.

### playground-cli

- **`src/utils/sessionSigner.ts`**: same three tests as bulletin-deploy vendor above.
- **`src/utils/deploy/signerMode.ts`**: existing snapshot tests unchanged (function stays
  sync, output shape unchanged for DotNS fields).
- **`src/utils/deploy/run.ts`**: new test — phone mode with a pre-cached slot key calls
  `getBulletinAllowanceSigner` and passes `storageSigner` to `runStorageDeploy`; dev mode
  does not call `getBulletinAllowanceSigner`.

---

## Open items

1. **product-sdk `signer.ts` version pin**: confirm `@parity/product-sdk-terminal` on
   both branches is at or above the version containing the `Payload`-tag rewrite before
   merging. The old `signPayload` path is removed in that version.

2. **`storageSignerAddress` derivation** in playground-cli runner:
   `getBulletinAllowanceSigner` returns a `PolkadotSigner` but not the SS58. Use
   `getSlotAccountAddress(key)` from `slotKeys.ts` immediately after reading the key.
   To avoid a double read, add a thin wrapper that returns both `{ signer, ss58 }`, or
   call `readSlotAccountKey` again (cheap, no WS).

3. **`AuthClient.getSessionSigner` creates its own adapter**: the `getSessionSigner()`
   call in the CLI wiring tears down and recreates a terminal adapter. If `resolveSigner`
   already called it (to produce the DotNS signer), confirm whether a second call is
   safe or whether the session handle from the first call can be threaded through instead.