### PR TITLE
chore(cdm): sync playground-registry manifest to v3 (sorted-index reads)

### DIFF
--- a/.changeset/cdm-registry-v3-sync.md
+++ b/.changeset/cdm-registry-v3-sync.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Sync the `@w3s/playground-registry` CDM snapshot to v3 (`0x9938255f40485B25641C9bc263aa8E0bAE8c202d`), picking up the registry's new on-chain sorted-index read methods (`getTopStarred` / `getTopModded`) added for the most-starred and most-modded Apps-tab sorts.

--- a/cdm.json
+++ b/cdm.json
@@ -1,1017 +1,1139 @@
 {
-    "registry": "0xf62c2ece29cd8df2e10040ecfa5a894a5c5d9cb0",
-    "dependencies": {
-        "@w3s/playground-registry": "latest"
-    },
-    "contracts": {
-        "@w3s/playground-registry": {
-            "version": 0,
-            "address": "0x1C12456f461aBd82C276436d3136F9Df4E8f3E08",
-            "abi": [
+  "registry": "0xf62c2ece29cd8df2e10040ecfa5a894a5c5d9cb0",
+  "dependencies": {
+    "@w3s/playground-registry": "latest"
+  },
+  "contracts": {
+    "@w3s/playground-registry": {
+      "version": 3,
+      "address": "0x9938255f40485B25641C9bc263aa8E0bAE8c202d",
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "publish",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "metadata_uri",
+              "type": "string"
+            },
+            {
+              "name": "visibility",
+              "type": "uint8"
+            },
+            {
+              "name": "owner",
+              "type": "tuple",
+              "components": [
                 {
-                    "type": "constructor",
-                    "inputs": [],
-                    "stateMutability": "nonpayable"
+                  "name": "isSome",
+                  "type": "bool"
                 },
                 {
-                    "type": "function",
-                    "name": "publish",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        },
-                        {
-                            "name": "metadata_uri",
-                            "type": "string"
-                        },
-                        {
-                            "name": "visibility",
-                            "type": "uint8"
-                        },
-                        {
-                            "name": "owner",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "isSome",
-                                    "type": "bool"
-                                },
-                                {
-                                    "name": "value",
-                                    "type": "address"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "modded_from",
-                            "type": "string"
-                        },
-                        {
-                            "name": "is_moddable",
-                            "type": "bool"
-                        },
-                        {
-                            "name": "is_dev_signer",
-                            "type": "bool"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "unpublish",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "rateApp",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        },
-                        {
-                            "name": "rating",
-                            "type": "uint8"
-                        },
-                        {
-                            "name": "comment_uri",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "removeRating",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        },
-                        {
-                            "name": "reviewer",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "star",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "unstar",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "getContextId",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getAppCount",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getDomainAt",
-                    "inputs": [
-                        {
-                            "name": "index",
-                            "type": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "isSome",
-                                    "type": "bool"
-                                },
-                                {
-                                    "name": "value",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getOwnerAppCount",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getOwnerDomainAt",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address"
-                        },
-                        {
-                            "name": "index",
-                            "type": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "isSome",
-                                    "type": "bool"
-                                },
-                                {
-                                    "name": "value",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getSudo",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "addAdmin",
-                    "inputs": [
-                        {
-                            "name": "admin",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "removeAdmin",
-                    "inputs": [
-                        {
-                            "name": "admin",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "isAdmin",
-                    "inputs": [
-                        {
-                            "name": "addr",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "setBlacklisted",
-                    "inputs": [
-                        {
-                            "name": "accounts",
-                            "type": "address[]"
-                        },
-                        {
-                            "name": "value",
-                            "type": "bool"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "isBlacklisted",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "setVisibility",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        },
-                        {
-                            "name": "visibility",
-                            "type": "uint8"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "getVisibility",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "pin",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "unpin",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "isPinned",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getPinnedApps",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "index",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "name": "domain",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "metadata_uri",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "owner",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "visibility",
-                                    "type": "uint8"
-                                },
-                                {
-                                    "name": "publisher",
-                                    "type": "address"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getApps",
-                    "inputs": [
-                        {
-                            "name": "start",
-                            "type": "uint32"
-                        },
-                        {
-                            "name": "count",
-                            "type": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "total",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "name": "scanned",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "name": "entries",
-                                    "type": "tuple[]",
-                                    "components": [
-                                        {
-                                            "name": "index",
-                                            "type": "uint32"
-                                        },
-                                        {
-                                            "name": "domain",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "name": "metadata_uri",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "name": "owner",
-                                            "type": "address"
-                                        },
-                                        {
-                                            "name": "visibility",
-                                            "type": "uint8"
-                                        },
-                                        {
-                                            "name": "publisher",
-                                            "type": "address"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getLineageCount",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getLineage",
-                    "inputs": [
-                        {
-                            "name": "start",
-                            "type": "uint32"
-                        },
-                        {
-                            "name": "count",
-                            "type": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "child",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "source",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getMetadataUri",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "isSome",
-                                    "type": "bool"
-                                },
-                                {
-                                    "name": "value",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getOwner",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getPoints",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint128"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getTopBuilders",
-                    "inputs": [
-                        {
-                            "name": "start",
-                            "type": "uint32"
-                        },
-                        {
-                            "name": "count",
-                            "type": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "account",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "score",
-                                    "type": "uint128"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getModCount",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getStarCount",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "hasStarred",
-                    "inputs": [
-                        {
-                            "name": "voter",
-                            "type": "address"
-                        },
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getPointBreakdown",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "launch_points",
-                                    "type": "uint128"
-                                },
-                                {
-                                    "name": "mod_points",
-                                    "type": "uint128"
-                                },
-                                {
-                                    "name": "star_points",
-                                    "type": "uint128"
-                                },
-                                {
-                                    "name": "total",
-                                    "type": "uint128"
-                                }
-                            ]
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "setFrozen",
-                    "inputs": [
-                        {
-                            "name": "value",
-                            "type": "bool"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "isFrozen",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "refreshReputationReference",
-                    "inputs": [],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importApp",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        },
-                        {
-                            "name": "owner",
-                            "type": "address"
-                        },
-                        {
-                            "name": "publisher",
-                            "type": "address"
-                        },
-                        {
-                            "name": "visibility",
-                            "type": "uint8"
-                        },
-                        {
-                            "name": "metadata_uri",
-                            "type": "string"
-                        },
-                        {
-                            "name": "is_moddable",
-                            "type": "bool"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importApps",
-                    "inputs": [
-                        {
-                            "name": "apps",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "domain",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "owner",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "publisher",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "visibility",
-                                    "type": "uint8"
-                                },
-                                {
-                                    "name": "metadata_uri",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "is_moddable",
-                                    "type": "bool"
-                                }
-                            ]
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importPinned",
-                    "inputs": [
-                        {
-                            "name": "domain",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importLineage",
-                    "inputs": [
-                        {
-                            "name": "entries",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "child",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "source",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importPoints",
-                    "inputs": [
-                        {
-                            "name": "entries",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "account",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "total",
-                                    "type": "uint128"
-                                }
-                            ]
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importSocialCounts",
-                    "inputs": [
-                        {
-                            "name": "entries",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "domain",
-                                    "type": "string"
-                                },
-                                {
-                                    "name": "star_count",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "name": "mod_count",
-                                    "type": "uint32"
-                                }
-                            ]
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "importUsernames",
-                    "inputs": [
-                        {
-                            "name": "entries",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "account",
-                                    "type": "address"
-                                },
-                                {
-                                    "name": "name",
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "setUsername",
-                    "inputs": [
-                        {
-                            "name": "name",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "clearUsername",
-                    "inputs": [],
-                    "outputs": [],
-                    "stateMutability": "nonpayable"
-                },
-                {
-                    "type": "function",
-                    "name": "getUsername",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getUsernames",
-                    "inputs": [
-                        {
-                            "name": "accounts",
-                            "type": "address[]"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string[]"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "getUsernameOwner",
-                    "inputs": [
-                        {
-                            "name": "name",
-                            "type": "string"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address"
-                        }
-                    ],
-                    "stateMutability": "view"
-                },
-                {
-                    "type": "function",
-                    "name": "isUsernameAvailable",
-                    "inputs": [
-                        {
-                            "name": "name",
-                            "type": "string"
-                        },
-                        {
-                            "name": "prospective_caller",
-                            "type": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view"
+                  "name": "value",
+                  "type": "address"
                 }
-            ],
-            "metadataCid": "bafk2bzaceduyvqkzgyfafjcy77v3t3ypvkruwvt6zq3uaw37zvzelalfpkfty"
+              ]
+            },
+            {
+              "name": "modded_from",
+              "type": "string"
+            },
+            {
+              "name": "is_moddable",
+              "type": "bool"
+            },
+            {
+              "name": "is_dev_signer",
+              "type": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpublish",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "rateApp",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "rating",
+              "type": "uint8"
+            },
+            {
+              "name": "comment_uri",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "removeRating",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "reviewer",
+              "type": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "star",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unstar",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "getContextId",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getAppCount",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getDomainAt",
+          "inputs": [
+            {
+              "name": "index",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "isSome",
+                  "type": "bool"
+                },
+                {
+                  "name": "value",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getOwnerAppCount",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getOwnerDomainAt",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "index",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "isSome",
+                  "type": "bool"
+                },
+                {
+                  "name": "value",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getSudo",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "addAdmin",
+          "inputs": [
+            {
+              "name": "admin",
+              "type": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "removeAdmin",
+          "inputs": [
+            {
+              "name": "admin",
+              "type": "address"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isAdmin",
+          "inputs": [
+            {
+              "name": "addr",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setBlacklisted",
+          "inputs": [
+            {
+              "name": "accounts",
+              "type": "address[]"
+            },
+            {
+              "name": "value",
+              "type": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isBlacklisted",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setVisibility",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "visibility",
+              "type": "uint8"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "getVisibility",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "pin",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "unpin",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isPinned",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getPinnedApps",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "index",
+                  "type": "uint32"
+                },
+                {
+                  "name": "domain",
+                  "type": "string"
+                },
+                {
+                  "name": "metadata_uri",
+                  "type": "string"
+                },
+                {
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "name": "visibility",
+                  "type": "uint8"
+                },
+                {
+                  "name": "publisher",
+                  "type": "address"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getApps",
+          "inputs": [
+            {
+              "name": "start",
+              "type": "uint32"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "total",
+                  "type": "uint32"
+                },
+                {
+                  "name": "scanned",
+                  "type": "uint32"
+                },
+                {
+                  "name": "entries",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "name": "index",
+                      "type": "uint32"
+                    },
+                    {
+                      "name": "domain",
+                      "type": "string"
+                    },
+                    {
+                      "name": "metadata_uri",
+                      "type": "string"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address"
+                    },
+                    {
+                      "name": "visibility",
+                      "type": "uint8"
+                    },
+                    {
+                      "name": "publisher",
+                      "type": "address"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getTopStarred",
+          "inputs": [
+            {
+              "name": "start",
+              "type": "uint32"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "total",
+                  "type": "uint32"
+                },
+                {
+                  "name": "scanned",
+                  "type": "uint32"
+                },
+                {
+                  "name": "entries",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "name": "index",
+                      "type": "uint32"
+                    },
+                    {
+                      "name": "domain",
+                      "type": "string"
+                    },
+                    {
+                      "name": "metadata_uri",
+                      "type": "string"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address"
+                    },
+                    {
+                      "name": "visibility",
+                      "type": "uint8"
+                    },
+                    {
+                      "name": "publisher",
+                      "type": "address"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getTopModded",
+          "inputs": [
+            {
+              "name": "start",
+              "type": "uint32"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "total",
+                  "type": "uint32"
+                },
+                {
+                  "name": "scanned",
+                  "type": "uint32"
+                },
+                {
+                  "name": "entries",
+                  "type": "tuple[]",
+                  "components": [
+                    {
+                      "name": "index",
+                      "type": "uint32"
+                    },
+                    {
+                      "name": "domain",
+                      "type": "string"
+                    },
+                    {
+                      "name": "metadata_uri",
+                      "type": "string"
+                    },
+                    {
+                      "name": "owner",
+                      "type": "address"
+                    },
+                    {
+                      "name": "visibility",
+                      "type": "uint8"
+                    },
+                    {
+                      "name": "publisher",
+                      "type": "address"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getLineageCount",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getLineage",
+          "inputs": [
+            {
+              "name": "start",
+              "type": "uint32"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "child",
+                  "type": "string"
+                },
+                {
+                  "name": "source",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getMetadataUri",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "isSome",
+                  "type": "bool"
+                },
+                {
+                  "name": "value",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getOwner",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getPoints",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint128"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getTopBuilders",
+          "inputs": [
+            {
+              "name": "start",
+              "type": "uint32"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "account",
+                  "type": "address"
+                },
+                {
+                  "name": "score",
+                  "type": "uint128"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getModCount",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getStarCount",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint32"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "hasStarred",
+          "inputs": [
+            {
+              "name": "voter",
+              "type": "address"
+            },
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getPointBreakdown",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "launch_points",
+                  "type": "uint128"
+                },
+                {
+                  "name": "mod_points",
+                  "type": "uint128"
+                },
+                {
+                  "name": "star_points",
+                  "type": "uint128"
+                },
+                {
+                  "name": "total",
+                  "type": "uint128"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "setFrozen",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "isFrozen",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "refreshReputationReference",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importApp",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "name": "publisher",
+              "type": "address"
+            },
+            {
+              "name": "visibility",
+              "type": "uint8"
+            },
+            {
+              "name": "metadata_uri",
+              "type": "string"
+            },
+            {
+              "name": "is_moddable",
+              "type": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importApps",
+          "inputs": [
+            {
+              "name": "apps",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "domain",
+                  "type": "string"
+                },
+                {
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "name": "publisher",
+                  "type": "address"
+                },
+                {
+                  "name": "visibility",
+                  "type": "uint8"
+                },
+                {
+                  "name": "metadata_uri",
+                  "type": "string"
+                },
+                {
+                  "name": "is_moddable",
+                  "type": "bool"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importPinned",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importLineage",
+          "inputs": [
+            {
+              "name": "entries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "child",
+                  "type": "string"
+                },
+                {
+                  "name": "source",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importPoints",
+          "inputs": [
+            {
+              "name": "entries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "account",
+                  "type": "address"
+                },
+                {
+                  "name": "total",
+                  "type": "uint128"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importSocialCounts",
+          "inputs": [
+            {
+              "name": "entries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "domain",
+                  "type": "string"
+                },
+                {
+                  "name": "star_count",
+                  "type": "uint32"
+                },
+                {
+                  "name": "mod_count",
+                  "type": "uint32"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "importUsernames",
+          "inputs": [
+            {
+              "name": "entries",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "name": "account",
+                  "type": "address"
+                },
+                {
+                  "name": "name",
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "setUsername",
+          "inputs": [
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "clearUsername",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "getUsername",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getUsernames",
+          "inputs": [
+            {
+              "name": "accounts",
+              "type": "address[]"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string[]"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "getUsernameOwner",
+          "inputs": [
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "isUsernameAvailable",
+          "inputs": [
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "prospective_caller",
+              "type": "address"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
         }
+      ],
+      "metadataCid": "bafk2bzaceafacjrrftyijid6r3hvk54mhpdsoizrj6lxvmqfba5ufndlk2w6o"
     }
+  }
 }


### PR DESCRIPTION
## What

Regenerates the CDM snapshot with `cdm i -n paseo` (cdm 0.8.18) against the live meta-registry (`0xf62c2ece`), picking up the v3 redeploy of `@w3s/playground-registry` at `0x9938255f40485B25641C9bc263aa8E0bAE8c202d` from playground-app PR [#277](https://github.com/paritytech/playground-app/pull/277).

## Why

playground-app added on-chain sorted indexes for the Apps-tab sorts and redeployed the registry. The new ABI surface:

- `getTopStarred(start, count)` - apps ranked by star count
- `getTopModded(start, count)` - apps ranked by mod count

Both return the same `AppsPage` shape as `getApps`. No existing method signatures changed, so no CLI code changes are needed; the typed contract handle simply gains the two new read methods.

## Notes

- Addresses keep resolving live from the meta-registry (`ContractManager.fromLiveClient` + the `"latest"` pin), so the snapshot only refreshes the ABI surface and the recorded version/address/metadataCid. Verified the CLI snapshot is now byte-identical (ABI deep-equal) to playground-app's manifest.
- The whitespace churn is the generator's canonical 2-space JSON style (same as playground-app's `cdm.json`); future `cdm i` runs are zero-diff. Biome does not cover root JSON, so `format:check` is unaffected.
- `.cdm/*.d.ts` typings were regenerated too but are gitignored (local-only).

## Verification

- `pnpm format:check` pass
- `pnpm lint:license` pass
- `pnpm test` 579/579 pass
- `pnpm build` pass