### PR TITLE
fix(deploy): surface allowance approvals in the TUI, drop guessed step totals

### DIFF
--- a/.changeset/phone-approval-visibility.md
+++ b/.changeset/phone-approval-visibility.md
@@ -1,0 +1,8 @@
+---
+"playground-cli": patch
+---
+
+Surface Bulletin allowance approvals in the deploy TUI and drop the guessed step total from phone-approval prompts.
+
+- `playground deploy` and `playground decentralise` now show a "check your phone" callout when an RFC-0010 Bulletin allowance request (first-use grant or quota top-up) is waiting on the phone. Previously these requests rode the statement store outside the signing proxy, so the phone showed an approval dialog while the terminal sat silent.
+- Phone approval prompts now read "approve step 1", "approve step 2", … instead of "step N of M". The predicted total regularly drifted from what actually ran (e.g. a planned PoP upgrade the runtime skipped left users on "step 4 of 5" with no fifth step), and allowance taps are demand-driven so they can never be counted up front. The pre-deploy summary now labels its count as "expected" and notes that an extra Bulletin allowance approval may appear.

--- a/src/commands/contractDeployUi.tsx
+++ b/src/commands/contractDeployUi.tsx
@@ -85,7 +85,7 @@ export async function runContractDeployWithUI(
             ipfsGatewayUrl={ipfsGatewayUrl}
         />,
     );
-    const signingCounter = createSigningCounter(1);
+    const signingCounter = createSigningCounter();
     const signer = signerRequiresApproval
         ? wrapSignerWithEvents(deployOpts.signer, {
               label: "Deploy and register contracts",
@@ -166,7 +166,6 @@ function ContractDeployScreen({
                 {adapter.signingPrompt && (
                     <PhoneApprovalCallout
                         step={adapter.signingPrompt.step}
-                        total={adapter.signingPrompt.total}
                         label={adapter.signingPrompt.label}
                     />
                 )}

--- a/src/commands/contractPipelineStatus.test.ts
+++ b/src/commands/contractPipelineStatus.test.ts
@@ -128,7 +128,6 @@ describe("ContractPipelineStatusAdapter", () => {
             kind: "sign-request",
             label: "Deploy and register contracts",
             step: 1,
-            total: 1,
         });
         expect(adapter.signingPrompt?.label).toBe("Deploy and register contracts");
 
@@ -136,7 +135,6 @@ describe("ContractPipelineStatusAdapter", () => {
             kind: "sign-error",
             label: "Deploy and register contracts",
             step: 1,
-            total: 1,
             message: "Mobile signing failed: unsupported payload",
         });
         adapter.handleDeployEvent({

--- a/src/commands/decentralize/DecentralizeScreen.tsx
+++ b/src/commands/decentralize/DecentralizeScreen.tsx
@@ -586,11 +586,7 @@ function RunningStage({
             </Section>
 
             {signingPrompt && signingPrompt.kind === "sign-request" && (
-                <PhoneApprovalCallout
-                    step={signingPrompt.step}
-                    total={signingPrompt.total}
-                    label={signingPrompt.label}
-                />
+                <PhoneApprovalCallout step={signingPrompt.step} label={signingPrompt.label} />
             )}
         </Box>
     );

--- a/src/commands/decentralize/index.ts
+++ b/src/commands/decentralize/index.ts
@@ -159,7 +159,7 @@ async function runHeadless({
                     case "signing":
                         if (ev.event.kind === "sign-request") {
                             process.stdout.write(
-                                `\n  ▸ Check your phone — approve step ${ev.event.step}/${ev.event.total}: ${ev.event.label}\n`,
+                                `\n  ▸ Check your phone — approve step ${ev.event.step}: ${ev.event.label}\n`,
                             );
                         } else if (ev.event.kind === "sign-error") {
                             process.stdout.write(`  ✖ signing failed: ${ev.event.message}\n`);

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -647,7 +647,7 @@ function ConfirmStage({
                     <>
                         <Row
                             label="phone approvals"
-                            value={String(view.totalApprovals)}
+                            value={`${view.totalApprovals} expected`}
                             tone="accent"
                         />
                         {view.approvalLines.map((line) => (
@@ -655,6 +655,7 @@ function ConfirmStage({
                                 {line}
                             </Hint>
                         ))}
+                        {view.approvalHint && <Hint indent={2}>({view.approvalHint})</Hint>}
                     </>
                 )}
             </Section>
@@ -845,11 +846,7 @@ function RunningStage({
             )}
 
             {signingPrompt && signingPrompt.kind === "sign-request" && (
-                <PhoneApprovalCallout
-                    step={signingPrompt.step}
-                    total={signingPrompt.total}
-                    label={signingPrompt.label}
-                />
+                <PhoneApprovalCallout step={signingPrompt.step} label={signingPrompt.label} />
             )}
         </Box>
     );

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -505,7 +505,7 @@ function logHeadlessEvent(event: DeployEvent) {
         process.stdout.write(`  chunk ${event.event.current}/${event.event.total}\n`);
     } else if (event.kind === "signing" && event.event.kind === "sign-request") {
         process.stdout.write(
-            `  📱 Approve on your phone: ${event.event.label} (${event.event.step}/${event.event.total})\n`,
+            `  📱 Approve on your phone (step ${event.event.step}): ${event.event.label}\n`,
         );
     } else if (event.kind === "error") {
         process.stderr.write(`  ✖ ${event.phase}: ${event.message}\n`);

--- a/src/commands/deploy/runningState.test.ts
+++ b/src/commands/deploy/runningState.test.ts
@@ -168,7 +168,7 @@ describe("runningReducer — log/signing/plan events are no-ops", () => {
     it("signing sign-request -> state unchanged", () => {
         const s = runningReducer(s0, {
             kind: "signing",
-            event: { kind: "sign-request", step: 1, total: 3, label: "DotNS register" },
+            event: { kind: "sign-request", step: 1, label: "DotNS register" },
         });
         expect(s).toBe(s0);
     });

--- a/src/commands/deploy/summary.test.ts
+++ b/src/commands/deploy/summary.test.ts
@@ -177,9 +177,24 @@ describe("renderSummaryText", () => {
                 ],
             }),
         );
-        expect(text).toContain("Phone approvals required: 3");
+        expect(text).toContain("Phone approvals expected: 3");
         expect(text).toContain("1. Reserve domain");
         expect(text).toContain("3. Link content");
+        // Phone mode flags the demand-driven allowance tap the plan can't count.
+        expect(text).toContain("Bulletin storage allowance");
+    });
+
+    it("omits the allowance hint in dev mode — no phone taps ever happen there", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "x.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: true,
+            approvals: [{ phase: "playground", label: "Publish to Playground registry" }],
+        });
+        expect(view.approvalHint).toBeNull();
+        expect(renderSummaryText(view)).not.toContain("Bulletin storage allowance");
     });
 
     it("appends signerAddress to the Signer row when provided", () => {

--- a/src/commands/deploy/summary.ts
+++ b/src/commands/deploy/summary.ts
@@ -51,7 +51,15 @@ export interface SummaryView {
     headline: string;
     rows: Array<{ label: string; value: string }>;
     approvalLines: string[];
+    /**
+     * Expected tap count from the pre-deploy plan. An estimate, not a
+     * promise: the DotNS plan can drift from what bulletin-deploy actually
+     * submits, and RFC-0010 allowance taps are demand-driven. The runtime
+     * counter therefore shows bare sequential steps with no total.
+     */
     totalApprovals: number;
+    /** Extra line shown under the approvals list for demand-driven taps the plan can't count. */
+    approvalHint: string | null;
 }
 
 const MODE_LABEL: Record<SignerMode, string> = {
@@ -94,6 +102,10 @@ export function buildSummaryView(input: SummaryInputs): SummaryView {
         rows,
         approvalLines: input.approvals.map((a, i) => `${i + 1}. ${a.label}`),
         totalApprovals: input.approvals.length,
+        approvalHint:
+            input.mode === "phone"
+                ? "your phone may also ask to grant or top up the Bulletin storage allowance"
+                : null,
     };
 }
 
@@ -104,8 +116,9 @@ export function renderSummaryText(view: SummaryView): string {
         view.totalApprovals === 0
             ? "  No phone approvals required."
             : [
-                  `  Phone approvals required: ${view.totalApprovals}`,
+                  `  Phone approvals expected: ${view.totalApprovals}`,
                   ...view.approvalLines.map((a) => `    ${a}`),
+                  ...(view.approvalHint ? [`    (${view.approvalHint})`] : []),
               ].join("\n");
     return `${view.headline}\n\n${rows}\n\n${approvals}\n`;
 }

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -22,12 +22,14 @@ const {
     checkAuthorizationMock,
     createSlotAccountSignerMock,
     ensureSlotAccountSignerMock,
+    getCachedAllocationMock,
     requestResourceAllocationMock,
     readCachedBulletinSlotSignerMock,
 } = vi.hoisted(() => ({
     checkAuthorizationMock: vi.fn(),
     createSlotAccountSignerMock: vi.fn(),
     ensureSlotAccountSignerMock: vi.fn(),
+    getCachedAllocationMock: vi.fn(),
     requestResourceAllocationMock: vi.fn(),
     readCachedBulletinSlotSignerMock: vi.fn(),
 }));
@@ -39,6 +41,7 @@ vi.mock("@parity/product-sdk-cloud-storage", () => ({
 vi.mock("@parity/product-sdk-terminal/host", () => ({
     createSlotAccountSigner: createSlotAccountSignerMock,
     ensureSlotAccountSigner: ensureSlotAccountSignerMock,
+    getCachedAllocation: getCachedAllocationMock,
     requestResourceAllocation: requestResourceAllocationMock,
 }));
 
@@ -83,11 +86,15 @@ beforeEach(() => {
     checkAuthorizationMock.mockReset();
     createSlotAccountSignerMock.mockReset();
     ensureSlotAccountSignerMock.mockReset();
+    getCachedAllocationMock.mockReset();
     requestResourceAllocationMock.mockReset();
     readCachedBulletinSlotSignerMock.mockReset();
     // Default: no local cache read available — every existing test exercises
     // the SDK-signer fallback path unchanged.
     readCachedBulletinSlotSignerMock.mockResolvedValue(null);
+    // Default: slot key already in the SDK cache, so ensureSlotAccountSigner
+    // resolves silently and no grant prompt fires.
+    getCachedAllocationMock.mockResolvedValue({ tag: "BulletInAllowance" });
 });
 
 describe("getBulletinAllowanceSigner", () => {
@@ -210,6 +217,124 @@ describe("getBulletinAllowanceSigner", () => {
         ).rejects.toThrow(/not authorized on-chain yet/);
         // Never authorized → no Increase attempt (Increase only fires when authorized).
         expect(requestResourceAllocationMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("getBulletinAllowanceSigner — phone approval prompts", () => {
+    // Allocation requests travel over the statement store outside any
+    // PolkadotSigner, so the deploy TUI's signing proxy can't see them. The
+    // onPrompt hook is the only "check your phone" surface for these taps —
+    // these tests pin when it fires and when it must stay silent.
+    function recordingPrompt() {
+        const calls: Array<{ label: string; closed: "complete" | "fail" | null }> = [];
+        const prompt = (label: string) => {
+            const entry = { label, closed: null as "complete" | "fail" | null };
+            calls.push(entry);
+            return {
+                complete: () => {
+                    entry.closed = "complete";
+                },
+                fail: () => {
+                    entry.closed = "fail";
+                },
+            };
+        };
+        return { calls, prompt };
+    }
+
+    it("stays silent when the slot key is cached and quota is fine", async () => {
+        ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        checkAuthorizationMock.mockResolvedValue({
+            authorized: true,
+            remainingTransactions: 1,
+            remainingBytes: 100n,
+            expiration: 1,
+        });
+        const { calls, prompt } = recordingPrompt();
+
+        await getBulletinAllowanceSigner({
+            publishSigner: sessionSigner(),
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+            onPrompt: prompt,
+        });
+
+        expect(calls).toEqual([]);
+    });
+
+    it("prompts for the grant on a slot-key cache miss and completes it", async () => {
+        getCachedAllocationMock.mockResolvedValue(null);
+        ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        const { calls, prompt } = recordingPrompt();
+
+        await getBulletinAllowanceSigner({ publishSigner: sessionSigner(), onPrompt: prompt });
+
+        expect(calls).toEqual([{ label: "Grant Bulletin storage allowance", closed: "complete" }]);
+    });
+
+    it("fails the grant prompt when the allocation request throws", async () => {
+        getCachedAllocationMock.mockResolvedValue(null);
+        ensureSlotAccountSignerMock.mockRejectedValue(new Error("Rejected on phone"));
+        const { calls, prompt } = recordingPrompt();
+
+        await expect(
+            getBulletinAllowanceSigner({ publishSigner: sessionSigner(), onPrompt: prompt }),
+        ).rejects.toThrow("Rejected on phone");
+
+        expect(calls).toEqual([{ label: "Grant Bulletin storage allowance", closed: "fail" }]);
+    });
+
+    it("prompts for the Increase when the slot is authorized but out of quota", async () => {
+        ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        requestResourceAllocationMock.mockResolvedValue([]);
+        checkAuthorizationMock
+            .mockResolvedValueOnce({
+                authorized: true,
+                remainingTransactions: 0,
+                remainingBytes: 100n,
+                expiration: 1,
+            })
+            .mockResolvedValueOnce({
+                authorized: true,
+                remainingTransactions: 1,
+                remainingBytes: 100n,
+                expiration: 1,
+            });
+        const { calls, prompt } = recordingPrompt();
+
+        await getBulletinAllowanceSigner({
+            publishSigner: sessionSigner(),
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+            onPrompt: prompt,
+        });
+
+        expect(calls).toEqual([
+            { label: "Increase Bulletin storage allowance", closed: "complete" },
+        ]);
+    });
+
+    it("fails the Increase prompt when the allocation request throws", async () => {
+        ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        requestResourceAllocationMock.mockRejectedValue(new Error("declined"));
+        checkAuthorizationMock.mockResolvedValue({
+            authorized: true,
+            remainingTransactions: 0,
+            remainingBytes: 100n,
+            expiration: 1,
+        });
+        const { calls, prompt } = recordingPrompt();
+
+        await expect(
+            getBulletinAllowanceSigner({
+                publishSigner: sessionSigner(),
+                bulletinApi: {} as any,
+                requiredBytes: 50,
+                onPrompt: prompt,
+            }),
+        ).rejects.toThrow("declined");
+
+        expect(calls).toEqual([{ label: "Increase Bulletin storage allowance", closed: "fail" }]);
     });
 });
 

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -23,6 +23,7 @@ import {
 import {
     createSlotAccountSigner,
     ensureSlotAccountSigner,
+    getCachedAllocation,
     requestResourceAllocation,
     type AllocatableResource,
 } from "@parity/product-sdk-terminal/host";
@@ -36,10 +37,33 @@ export const BULLETIN_RESOURCE: AllocatableResource = {
 
 const INIT_HINT = 'Run "playground init" to grant allowances.';
 
+/**
+ * Live handle for one in-flight phone approval. Close it exactly once: with
+ * `complete()` when the wallet answered, or `fail(message)` when the request
+ * threw / was declined.
+ */
+export interface AllowancePromptHandle {
+    complete(): void;
+    fail(message: string): void;
+}
+
+/**
+ * Called right before a step that needs a tap on the phone (slot grant on
+ * first use, quota Increase). RFC-0010 allocation requests travel over the
+ * statement store outside any `PolkadotSigner`, so the deploy TUI's signing
+ * proxy cannot see them — without this hook the phone shows an approval
+ * dialog while the terminal sits silent.
+ * `deploy/signingProxy.ts::createApprovalPrompt` builds a compatible
+ * implementation backed by the deploy's shared step counter.
+ */
+export type AllowancePrompt = (label: string) => AllowancePromptHandle;
+
 export interface BulletinAllowanceSignerOptions {
     publishSigner: ResolvedSigner;
     bulletinApi?: CloudStorageApi;
     requiredBytes?: number;
+    /** Surfaces "check your phone" UI for allocation requests. Optional: headless callers omit it. */
+    onPrompt?: AllowancePrompt;
 }
 
 function hasUsableAuthorization(status: AuthorizationStatus, requiredBytes = 0): boolean {
@@ -125,6 +149,7 @@ export async function getBulletinAllowanceSigner({
     publishSigner,
     bulletinApi,
     requiredBytes,
+    onPrompt,
 }: BulletinAllowanceSignerOptions): Promise<PolkadotSigner> {
     // Local dev/SURI deploys are the explicit CI escape hatch: the caller
     // supplied a local key and owns making sure it has Bulletin allowance.
@@ -134,20 +159,40 @@ export async function getBulletinAllowanceSigner({
 
     // Cache hit → local sr25519 signer; miss → one phone approval. The SDK
     // call owns allocation + caching; the signer itself is rebuilt from the
-    // cached key with the correct derivation (see correctedSlotSigner).
-    let slotSigner = await correctedSlotSigner(
-        await ensureSlotAccountSigner(userSession, adapter, BULLETIN_RESOURCE),
-        adapter,
-    );
+    // cached key with the correct derivation (see correctedSlotSigner). The
+    // cache probe mirrors ensureSlotAccountSigner's own hit/miss decision so
+    // the prompt fires only when the phone will actually be asked.
+    const cachedSlot = await getCachedAllocation(adapter, BULLETIN_RESOURCE);
+    const grantPrompt = cachedSlot
+        ? null
+        : (onPrompt?.("Grant Bulletin storage allowance") ?? null);
+    let slotSigner: PolkadotSigner;
+    try {
+        slotSigner = await correctedSlotSigner(
+            await ensureSlotAccountSigner(userSession, adapter, BULLETIN_RESOURCE),
+            adapter,
+        );
+        grantPrompt?.complete();
+    } catch (err) {
+        grantPrompt?.fail(err instanceof Error ? err.message : String(err));
+        throw err;
+    }
     if (!bulletinApi) return slotSigner;
 
     let authorization = await getBulletinSlotAuthorization(bulletinApi, slotSigner, requiredBytes);
 
     if (!authorization.usable && authorization.status.authorized) {
         // Slot exists on-chain but quota is exhausted: ask for one more slot.
-        await requestResourceAllocation(userSession, adapter, [BULLETIN_RESOURCE], {
-            onExisting: "Increase",
-        });
+        const increasePrompt = onPrompt?.("Increase Bulletin storage allowance") ?? null;
+        try {
+            await requestResourceAllocation(userSession, adapter, [BULLETIN_RESOURCE], {
+                onExisting: "Increase",
+            });
+            increasePrompt?.complete();
+        } catch (err) {
+            increasePrompt?.fail(err instanceof Error ? err.message : String(err));
+            throw err;
+        }
         slotSigner = await correctedSlotSigner(
             await ensureSlotAccountSigner(userSession, adapter, BULLETIN_RESOURCE),
             adapter,

--- a/src/utils/decentralize/run.test.ts
+++ b/src/utils/decentralize/run.test.ts
@@ -47,6 +47,9 @@ vi.mock("./mirror.js", () => ({ mirrorSite: mirrorSiteMock }));
 vi.mock("@parity/product-sdk-terminal/host", () => ({
     createSlotAccountSigner: vi.fn(),
     ensureSlotAccountSigner: ensureSlotAccountSignerMock,
+    // Slot key reported as cached so no grant prompt fires — these tests
+    // exercise storage-signer routing, not the approval UI.
+    getCachedAllocation: vi.fn(async () => ({ tag: "BulletInAllowance" })),
     requestResourceAllocation: vi.fn(),
 }));
 // Hermeticity: the corrected-derivation path reads the REAL allowance cache

--- a/src/utils/decentralize/run.ts
+++ b/src/utils/decentralize/run.ts
@@ -39,6 +39,7 @@ import {
 } from "../deploy/signerMode.js";
 import {
     createSigningCounter,
+    createApprovalPrompt,
     type SigningCounter,
     type SigningEvent,
     wrapSignerWithEvents,
@@ -153,10 +154,17 @@ export async function runDecentralize(
     // registry-level `claimedOwnerH160`).
     const storageSignerSource: ResolvedSigner["source"] = mode === "phone" ? "session" : "dev";
 
-    // Shared counter across every phone tap (DotNS commitment/finalize/link
-    // + the optional playground publish) so the callout reads "step N of M".
-    const counter = createSigningCounter(setup.approvals.length);
+    // Shared counter across every phone tap (DotNS commitment/finalize/link,
+    // RFC-0010 allowance grants, the optional playground publish) so the
+    // callout reads "step 1", "step 2", … — bare sequential numbers, no
+    // predicted total (plans drifted from runtime and stranded users on
+    // "step 4 of 5").
+    const counter = createSigningCounter();
     const emitSigning = (event: SigningEvent) => onEvent?.({ kind: "signing", event });
+    // "Check your phone" surface for allocation taps (Bulletin slot grant /
+    // quota Increase) — they happen outside any PolkadotSigner, so the
+    // signer wrap below can't see them.
+    const allowancePrompt = createApprovalPrompt(counter, emitSigning);
 
     let mirrorDir: string | null = null;
 
@@ -176,7 +184,12 @@ export async function runDecentralize(
         // Bulletin storage chunks must sign with the local BulletInAllowance
         // slot key, never the phone signer — chunk txs blow the phone's
         // statement-store message cap. See resolveStorageSignerOptions.
-        const storageSignerOptions = await resolveStorageSignerOptions(mode, userSigner);
+        const storageSignerOptions = await resolveStorageSignerOptions(
+            mode,
+            userSigner,
+            undefined,
+            allowancePrompt,
+        );
 
         onEvent?.({ kind: "storage-start", fullDomain });
         const result = await runStorageDeploy({
@@ -240,6 +253,7 @@ export async function runDecentralize(
                 isModdable: false,
                 isDevSigner: setup.publishSigner.source === "dev",
                 onLogEvent: (event) => onEvent?.({ kind: "playground-event", event }),
+                onAllowancePrompt: allowancePrompt,
             });
             metadataCid = publishResult.metadataCid;
             onEvent?.({ kind: "playground-done", metadataCid });

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -43,7 +43,11 @@ import { getRegistryContract } from "../registry.js";
 import { getConnection } from "../connection.js";
 import { getChainConfig, type Env } from "../../config.js";
 import { captureWarning, withSpan, errorMessage } from "../../telemetry.js";
-import { getBulletinAllowanceSigner, isInvalidPaymentError } from "../allowances/bulletin.js";
+import {
+    getBulletinAllowanceSigner,
+    isInvalidPaymentError,
+    type AllowancePrompt,
+} from "../allowances/bulletin.js";
 import { BULLETIN_WS_HEARTBEAT_MS } from "../bulletinWs.js";
 import type { ResolvedSigner } from "../signer.js";
 import type { DeployLogEvent } from "./progress.js";
@@ -76,6 +80,12 @@ export interface PublishToPlaygroundOptions {
     cwd?: string;
     /** Progress sink for the metadata-upload sub-step. */
     onLogEvent?: (event: DeployLogEvent) => void;
+    /**
+     * Surfaces "check your phone" UI when the metadata upload needs an
+     * RFC-0010 allocation tap (slot grant on first use, quota Increase).
+     * Without it the phone shows an approval dialog the TUI never mentions.
+     */
+    onAllowancePrompt?: AllowancePrompt;
     /** Target environment. */
     env?: Env;
     /**
@@ -299,6 +309,7 @@ export async function publishToPlayground(
                     publishSigner: options.publishSigner,
                     bulletinApi,
                     requiredBytes: metadataBytes.length,
+                    onPrompt: options.onAllowancePrompt,
                 });
                 try {
                     await withRetry(() => submitAndWatch(storeTx, storageSigner));
@@ -314,6 +325,7 @@ export async function publishToPlayground(
                         publishSigner: options.publishSigner,
                         bulletinApi,
                         requiredBytes: metadataBytes.length,
+                        onPrompt: options.onAllowancePrompt,
                     });
                     await withRetry(() => submitAndWatch(storeTx, storageSigner));
                 }

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -286,6 +286,10 @@ describe("runDeploy", () => {
             publishSigner: fakeUserSigner,
             bulletinApi: quotaApi,
             requiredBytes: 1234,
+            // The deploy threads a "check your phone" prompt into the
+            // allowance resolution — allocation taps happen outside any
+            // PolkadotSigner, so this hook is their only TUI surface.
+            onPrompt: expect.any(Function),
         });
         expect(quotaDestroyMock).toHaveBeenCalledTimes(1);
 

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -33,6 +33,7 @@ import {
 import {
     wrapSignerWithEvents,
     createSigningCounter,
+    createApprovalPrompt,
     type SigningCounter,
     type SigningEvent,
 } from "./signingProxy.js";
@@ -122,7 +123,14 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
 
     options.onEvent({ kind: "plan", approvals: setup.approvals });
 
-    const counter = createSigningCounter(setup.approvals.length);
+    const counter = createSigningCounter();
+    // "Check your phone" surface for RFC-0010 allocation taps (Bulletin slot
+    // grant / quota Increase). These ride the statement store outside any
+    // PolkadotSigner, so the signing proxy below can't see them — without
+    // this the phone shows an approval dialog the TUI never mentions.
+    const allowancePrompt = createApprovalPrompt(counter, (event) =>
+        options.onEvent({ kind: "signing", event }),
+    );
 
     const buildAbs = options.buildDir;
 
@@ -175,6 +183,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                               }),
                       }
                     : undefined,
+                allowancePrompt,
             );
         } finally {
             quota?.destroy();
@@ -231,6 +240,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     repositoryUrl: options.repositoryUrl ?? null,
                     cwd: options.projectDir,
                     onLogEvent: (event) => options.onEvent({ kind: "storage-event", event }),
+                    onAllowancePrompt: allowancePrompt,
                     env: options.env,
                     isPrivate: options.playgroundPrivate,
                     isModdable: options.moddable ?? false,
@@ -265,8 +275,9 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
  * at the start when a PoP upgrade is needed), so `seen === N` → phone shows
  * the Nth entry. If bulletin-deploy ever fires *more* sigs than approvals
  * anticipated, we fall back to the last known label — better than emitting
- * a bogus index — and `createSigningCounter` simultaneously extends `total`
- * so the TUI shows "step N of N" instead of "N of N-1".
+ * a bogus index. The step counter itself is plan-independent (bare
+ * sequential numbers, no predicted total), so extra or skipped sigs can't
+ * desync the displayed count.
  */
 function maybeWrapAuthForSigning(
     auth: ReturnType<typeof resolveSignerSetup>["bulletinDeployAuthOptions"],

--- a/src/utils/deploy/signerMode.ts
+++ b/src/utils/deploy/signerMode.ts
@@ -41,7 +41,7 @@ import { DEFAULT_MNEMONIC, type DeployOptions } from "bulletin-deploy";
 import { ss58Encode } from "@parity/product-sdk-address";
 import type { CloudStorageApi } from "@parity/product-sdk-cloud-storage";
 import { seedToAccount } from "@parity/product-sdk-keys";
-import { getBulletinAllowanceSigner } from "../allowances/bulletin.js";
+import { getBulletinAllowanceSigner, type AllowancePrompt } from "../allowances/bulletin.js";
 import type { ResolvedSigner } from "../signer.js";
 import type { DeployPlan } from "./availability.js";
 
@@ -144,8 +144,10 @@ export interface ResolveOptions {
      * Known DotNS plan from the availability check. Shapes the approvals list
      * to match what bulletin-deploy will actually submit. Absent = we haven't
      * run the check yet, so assume the most common path (new register, no
-     * PoP upgrade, 3 DotNS taps). The signing counter clamps up at runtime if
-     * we under-estimated, so users never see "step 5 of 4" even on this path.
+     * PoP upgrade, 3 DotNS taps). The list drives the pre-deploy summary and
+     * the per-tap labels only — the runtime counter shows bare sequential
+     * step numbers (no predicted total), so a wrong guess here can't strand
+     * the user on "step 4 of 5" with no fifth step.
      */
     plan?: DeployPlan;
 }
@@ -302,6 +304,7 @@ export async function resolveStorageSignerOptions(
         requiredBytes?: number;
         onWarning?: (message: string) => void;
     },
+    onPrompt?: AllowancePrompt,
 ): Promise<Pick<DeployOptions, "storageSigner" | "storageSignerAddress">> {
     if (mode !== "phone" || userSigner?.source !== "session") return {};
 
@@ -310,6 +313,7 @@ export async function resolveStorageSignerOptions(
             publishSigner: userSigner,
             bulletinApi: withQuota ? quota?.bulletinApi : undefined,
             requiredBytes: withQuota ? quota?.requiredBytes : undefined,
+            onPrompt,
         });
         return { storageSigner, storageSignerAddress: ss58Encode(storageSigner.publicKey) };
     };

--- a/src/utils/deploy/signingProxy.test.ts
+++ b/src/utils/deploy/signingProxy.test.ts
@@ -14,36 +14,55 @@
 // limitations under the License.
 
 import { describe, it, expect } from "vitest";
-import { createSigningCounter } from "./signingProxy.js";
+import { createSigningCounter, createApprovalPrompt, type SigningEvent } from "./signingProxy.js";
 
 describe("createSigningCounter", () => {
-    it("returns sequential step numbers against the configured total", () => {
-        const c = createSigningCounter(3);
-        expect(c.next()).toEqual({ step: 1, total: 3 });
-        expect(c.next()).toEqual({ step: 2, total: 3 });
-        expect(c.next()).toEqual({ step: 3, total: 3 });
+    it("returns bare sequential step numbers with no predicted total", () => {
+        // Regression: the counter used to carry a plan-derived total, and a
+        // plan that over-predicted (e.g. a `setUserPopStatus` tx that runtime
+        // skipped) stranded users on "step 4 of 5" with no fifth step. The
+        // counter now just numbers taps as they happen.
+        const c = createSigningCounter();
+        expect(c.next()).toEqual({ step: 1 });
+        expect(c.next()).toEqual({ step: 2 });
+        expect(c.next()).toEqual({ step: 3 });
         expect(c.count()).toBe(3);
     });
+});
 
-    it("clamps total upward when step exceeds the predicted count", () => {
-        // Regression: TUI used to print "approve step 5 of 4" whenever
-        // bulletin-deploy fired an extra `setUserPopStatus` tx that the
-        // predicted plan missed. Clamping the total up to the current step
-        // keeps the display coherent even when the prediction under-shoots.
-        const c = createSigningCounter(2);
-        expect(c.next()).toEqual({ step: 1, total: 2 });
-        expect(c.next()).toEqual({ step: 2, total: 2 });
-        // Predicted 2 taps, but a third fires:
-        expect(c.next()).toEqual({ step: 3, total: 3 });
-        // And a fourth:
-        expect(c.next()).toEqual({ step: 4, total: 4 });
+describe("createApprovalPrompt", () => {
+    it("emits sign-request on open and sign-complete on complete(), sharing the counter", () => {
+        const events: SigningEvent[] = [];
+        const counter = createSigningCounter();
+        const prompt = createApprovalPrompt(counter, (e) => events.push(e));
+
+        // A signing tap reserves step 1 elsewhere…
+        counter.next();
+        // …so the allowance tap continues the same sequence at step 2.
+        const handle = prompt("Grant Bulletin storage allowance");
+        handle.complete();
+
+        expect(events).toEqual([
+            { kind: "sign-request", label: "Grant Bulletin storage allowance", step: 2 },
+            { kind: "sign-complete", label: "Grant Bulletin storage allowance", step: 2 },
+        ]);
     });
 
-    it("count() reflects every reserved step regardless of clamping", () => {
-        const c = createSigningCounter(1);
-        c.next();
-        c.next();
-        c.next();
-        expect(c.count()).toBe(3);
+    it("emits sign-error with the failure message on fail()", () => {
+        const events: SigningEvent[] = [];
+        const prompt = createApprovalPrompt(createSigningCounter(), (e) => events.push(e));
+
+        const handle = prompt("Increase Bulletin storage allowance");
+        handle.fail("declined on phone");
+
+        expect(events).toEqual([
+            { kind: "sign-request", label: "Increase Bulletin storage allowance", step: 1 },
+            {
+                kind: "sign-error",
+                label: "Increase Bulletin storage allowance",
+                step: 1,
+                message: "declined on phone",
+            },
+        ]);
     });
 });

--- a/src/utils/deploy/signingProxy.ts
+++ b/src/utils/deploy/signingProxy.ts
@@ -21,33 +21,34 @@
  */
 
 import type { PolkadotSigner } from "polkadot-api";
+import type { AllowancePrompt } from "../allowances/bulletin.js";
 
 export type SigningEvent =
-    | { kind: "sign-request"; label: string; step: number; total: number }
-    | { kind: "sign-complete"; label: string; step: number; total: number }
-    | { kind: "sign-error"; label: string; step: number; total: number; message: string };
+    | { kind: "sign-request"; label: string; step: number }
+    | { kind: "sign-complete"; label: string; step: number }
+    | { kind: "sign-error"; label: string; step: number; message: string };
 
 export interface SigningCounter {
-    /** Reserve the next step number. Returns { step, total } for the event payload. */
-    next(): { step: number; total: number };
+    /** Reserve the next step number. */
+    next(): { step: number };
     /** How many steps were reserved so far — useful for a final tally. */
     count(): number;
 }
 
-export function createSigningCounter(total: number): SigningCounter {
+/**
+ * Sequential tap counter shared across a whole deploy run. Deliberately has
+ * NO predicted total: the pre-deploy approvals plan regularly diverged from
+ * what bulletin-deploy actually submitted (e.g. a predicted `setUserPopStatus`
+ * that runtime skipped left users on "step 4 of 5" with no fifth step), and
+ * RFC-0010 allowance taps are demand-driven so they can't be counted up
+ * front. The UI shows "step 1", "step 2", … and never has to guess.
+ */
+export function createSigningCounter(): SigningCounter {
     let step = 0;
-    // Treat the caller's `total` as a *minimum* — if the real deploy fires
-    // more sigs than we predicted (e.g. bulletin-deploy adds a new DotNS tx
-    // in a future version, or our PoP upgrade detection missed a case), the
-    // UI shows "step N of N" rather than the obviously-wrong "step N of N-1".
-    // Summary card's pre-deploy count can still be stale; this only fixes
-    // the runtime counter.
-    let runningTotal = total;
     return {
         next() {
             step += 1;
-            if (step > runningTotal) runningTotal = step;
-            return { step, total: runningTotal };
+            return { step };
         },
         count() {
             return step;
@@ -72,15 +73,15 @@ export interface WrapOptions {
  */
 export function wrapSignerWithEvents(inner: PolkadotSigner, options: WrapOptions): PolkadotSigner {
     const announce = async <T>(fn: () => Promise<T>): Promise<T> => {
-        const { step, total } = options.counter.next();
-        options.onEvent({ kind: "sign-request", label: options.label, step, total });
+        const { step } = options.counter.next();
+        options.onEvent({ kind: "sign-request", label: options.label, step });
         try {
             const value = await fn();
-            options.onEvent({ kind: "sign-complete", label: options.label, step, total });
+            options.onEvent({ kind: "sign-complete", label: options.label, step });
             return value;
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            options.onEvent({ kind: "sign-error", label: options.label, step, total, message });
+            options.onEvent({ kind: "sign-error", label: options.label, step, message });
             throw err;
         }
     };
@@ -92,5 +93,32 @@ export function wrapSignerWithEvents(inner: PolkadotSigner, options: WrapOptions
                 inner.signTx(callData, signedExtensions, metadata, atBlockNumber, hasher),
             ),
         signBytes: (data) => announce(() => inner.signBytes(data)),
+    };
+}
+
+/**
+ * Prompt factory for phone taps that are NOT signer calls: RFC-0010
+ * resource-allocation requests (Bulletin allowance grant on first use, quota
+ * Increase). They ride the statement store outside any `PolkadotSigner`, so
+ * `wrapSignerWithEvents` never sees them — until this existed the phone
+ * showed an approval dialog while the deploy TUI sat silent.
+ *
+ * The returned function implements
+ * `allowances/bulletin.ts::AllowancePrompt`: call it right before sending the
+ * request, then close the handle when the request resolves. Steps come from
+ * the same shared counter as signing taps, so the user sees one continuous
+ * "step 1, step 2, …" sequence across both kinds of approval.
+ */
+export function createApprovalPrompt(
+    counter: SigningCounter,
+    onEvent: (event: SigningEvent) => void,
+): AllowancePrompt {
+    return (label) => {
+        const { step } = counter.next();
+        onEvent({ kind: "sign-request", label, step });
+        return {
+            complete: () => onEvent({ kind: "sign-complete", label, step }),
+            fail: (message) => onEvent({ kind: "sign-error", label, step, message }),
+        };
     };
 }

--- a/src/utils/ui/theme/PhoneApprovalCallout.tsx
+++ b/src/utils/ui/theme/PhoneApprovalCallout.tsx
@@ -18,7 +18,14 @@ import { Callout } from "./Callout.js";
 
 export interface PhoneApprovalCalloutProps {
     step: number;
-    total: number;
+    /**
+     * Optional: only pass when the total is exactly known (e.g. a fixed
+     * single-tap flow like the init allowance grant). Deploy flows omit it —
+     * taps are demand-driven (allowance grants, DotNS plan drift), so a
+     * predicted total regularly turned out wrong ("step 4 of 5" with no
+     * fifth step).
+     */
+    total?: number;
     label: string;
 }
 
@@ -26,7 +33,8 @@ export function PhoneApprovalCallout({ step, total, label }: PhoneApprovalCallou
     return (
         <Callout tone="warning" title="check your phone">
             <Text>
-                approve step {step} of {total}: <Text bold>{label}</Text>
+                approve step {step}
+                {total !== undefined ? ` of ${total}` : ""}: <Text bold>{label}</Text>
             </Text>
         </Callout>
     );


### PR DESCRIPTION
## Problem

Two related UX failures in phone-mode `playground deploy` / `playground decentralise` (observed in field testing, 4 June):

1. **Invisible phone prompts.** RFC-0010 Bulletin allowance requests (first-use slot grant, quota `Increase` top-up) travel over the statement store outside any `PolkadotSigner`, so the signing proxy never saw them. The phone showed "Product dot-cli requests resource allocation" while the terminal sat silent — users had no idea a tap was being waited on. With slot grants observed at ~10 txs / 4 MiB and chunks at 2 MiB, the Increase tap recurs on most deploys.
2. **Wrong step totals.** The "step N of M" total came from a pre-deploy plan that regularly drifted from what bulletin-deploy actually submitted (e.g. a predicted `setUserPopStatus` the runtime skipped), stranding users on "step 4 of 5" with no fifth step. Allowance taps additionally were never counted, so phone taps and the counter disagreed.

## Changes

- `signingProxy.ts`: new `createApprovalPrompt(counter, onEvent)` emits the existing `sign-request` / `sign-complete` / `sign-error` events around non-signer phone taps, sharing the deploy's step counter — one continuous sequence across signing and allowance approvals.
- `allowances/bulletin.ts`: `getBulletinAllowanceSigner` takes an optional `onPrompt` (`AllowancePrompt`). Fires "Grant Bulletin storage allowance" only on a real slot-key cache miss (probe mirrors `ensureSlotAccountSigner`'s own hit/miss decision) and "Increase Bulletin storage allowance" around the quota top-up. Errors fail the prompt and rethrow; handles close exactly once on every path.
- Threaded through every resolution site: `resolveStorageSignerOptions` (chunk-upload slot key), `publishToPlayground` (metadata upload incl. the Payment-error retry), in both `deploy` and `decentralise`, interactive TUI and headless output.
- `createSigningCounter()` no longer takes a predicted total; `SigningEvent` carries only `step`. Prompts read "approve step 1", "approve step 2", … `PhoneApprovalCallout`'s `total` is now optional — init's fixed 1-of-1 flows keep passing it.
- Pre-deploy summary says "Phone approvals expected: N" and, in phone mode, notes the possible extra Bulletin allowance approval.

## Not in scope

- The phantom "all three allowances" dialog mid-deploy is a stale `pg init` request redelivered by the statement store — needs an upstream mobile/host-papp fix.
- `pg init` re-requesting all three resources when only the bulletin quota is exhausted (`AccountSetup.tsx`) — candidate follow-up.

## Verification

- `pnpm test`: 643/643 (7 new tests: prompt fires on cache miss / Increase, stays silent on cache hit, fail paths, counter continuity, dev-mode hint gating)
- `pnpm format:check`, `pnpm lint:license`: clean
- `tsc --noEmit`: 13 errors — exactly the pre-existing baseline
- No React/Ink imports added under `src/utils/deploy/` (RevX surface intact); no e2e consumers of the removed `total` field
- Changeset included (patch)