### PR TITLE
deps: migrate to pnpm 11.5.2; settings move to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "Apache-2.0",
     "type": "module",
-    "packageManager": "pnpm@10.32.1",
+    "packageManager": "pnpm@11.5.2",
     "bin": {
         "playground": "./src/index.ts",
         "pg": "./src/index.ts"
@@ -57,18 +57,5 @@
         "execa": "^9.6.1",
         "typescript": "^5.9.3",
         "vitest": "^3.2.1"
-    },
-    "pnpm": {
-        "onlyBuiltDependencies": [
-            "@biomejs/biome"
-        ],
-        "overrides": {
-            "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub",
-            "@polkadot-api/json-rpc-provider": "^0.2.0"
-        },
-        "patchedDependencies": {
-            "@novasamatech/statement-store@0.8.6": "patches/@novasamatech__statement-store@0.8.6.patch",
-            "@novasamatech/sdk-statement@0.6.0": "patches/@novasamatech__sdk-statement@0.6.0.patch"
-        }
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,27 @@
+# pnpm settings (moved here from package.json#pnpm — pnpm 11 no longer reads
+# that field). This is NOT a multi-package workspace; pnpm-workspace.yaml is
+# simply where pnpm >= 11 keeps its settings, single-package repos included.
+
+# pnpm 11 renamed onlyBuiltDependencies to an allowBuilds map. Only biome's
+# postinstall runs (same as the old onlyBuiltDependencies allowlist); the
+# explicit `false` entries were implicitly denied under pnpm 10 and the tree
+# works without their build scripts.
+allowBuilds:
+  "@biomejs/biome": true
+  "@parity/product-sdk-terminal": false
+  esbuild: false
+  node-datachannel: false
+
+overrides:
+  # dotns-cli 0.6.1 ships a broken publish manifest (file:.papi/descriptors
+  # missing from the tarball); redirect to a local empty stub. See CLAUDE.md.
+  "@parity/dotns-cli>@polkadot-api/descriptors": "file:./stubs/papi-descriptors-stub"
+  # Load-bearing: collapses three transitive json-rpc-provider versions onto
+  # one to avoid wire-shape divergence. See CLAUDE.md.
+  "@polkadot-api/json-rpc-provider": "^0.2.0"
+
+patchedDependencies:
+  # PATCH(playground-cli) — local-only fixes pending upstream. See CLAUDE.md
+  # "Two local pnpm patches remain" for what each one does.
+  "@novasamatech/statement-store@0.8.6": "patches/@novasamatech__statement-store@0.8.6.patch"
+  "@novasamatech/sdk-statement@0.6.0": "patches/@novasamatech__sdk-statement@0.6.0.patch"


### PR DESCRIPTION
## Why

pnpm 11 stopped reading the `pnpm` field in `package.json`. Upgrading without migrating would silently drop three load-bearing settings: the statement-store/sdk-statement patches, the `json-rpc-provider` override + dotns descriptor stub, and the biome build allowlist. (Anyone whose local pnpm self-updated to 11 already sees the `The "pnpm" field in package.json is no longer read` warning on install.)

## What

- **New `pnpm-workspace.yaml`** (pnpm 11's settings home, single-package repos included):
  - `overrides` and `patchedDependencies` move verbatim, with comments pointing at the CLAUDE.md invariants
  - `onlyBuiltDependencies` becomes the renamed `allowBuilds` map: biome `true`; `@parity/product-sdk-terminal`/`esbuild`/`node-datachannel` explicitly `false` (they were implicitly denied under pnpm 10 and the tree works without their build scripts)
- **`package.json`**: `pnpm` field removed; `packageManager` bumped to `pnpm@11.5.2`

The `packageManager` bump propagates automatically: every CI workflow uses `pnpm/action-setup@v4` with no version input (reads the field), and pnpm 10 installs auto-switch to 11.5.2 in this repo. No action needed from anyone.

`pnpm-lock.yaml` is **untouched**: lockfileVersion 9.0 is shared between pnpm 10 and 11, so there is zero dependency drift in this PR.

## Verification

| Check | Result |
|---|---|
| Patches applied under 11 | `PATCH(playground-cli)` markers + patch hashes confirmed in `node_modules` for both packages |
| Overrides effective | single `json-rpc-provider@0.2.0` in the store; dotns stub resolves to `0.0.0-stub` |
| `pnpm format:check` | pass (proves biome's postinstall ran under `allowBuilds`) |
| `pnpm lint:license` | pass (196 files) |
| `pnpm test` | 61 files, 635 tests passed |
| `tsc --noEmit` | 13 errors, exactly the documented baseline |
| `pnpm build` | compiles clean |

No changeset: tooling-only, no user-visible behavior change.

Note for future dep bumps: when pnpm 11 meets a new package with build scripts, it appends `set this to true or false` placeholder lines to `allowBuilds` in the yaml. Set them explicitly rather than leaving the placeholders.