### PR TITLE
docs: add prototype/PoC disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # playground-cli
 
+> [!WARNING]
+> The following is a prototype, reference implementation, and proof-of-concept. This open source code is provided for research, experimentation, and developer education only. This code has not been audited, is actively experimental, and may contain bugs, vulnerabilities, or incomplete features. Use at your own risk.
+
 CLI tooling for Polkadot Playground. Installed as the `playground` command, with `pg` as a short alias — both invoke the same binary, so `playground init` and `pg init` are interchangeable.
 
 ## Quick Start


### PR DESCRIPTION
Adds the standard Parity prototype/proof-of-concept disclaimer to the top of the README, as a GitHub `> [!WARNING]` callout so it renders as the styled alert.

This is the reference-only boilerplate ("prototype, reference implementation, and proof-of-concept... use at your own risk") that open-source-bound product-engineering repos are expected to carry. Requested by leadership as part of open-sourcing the CLI.

Docs-only, no behaviour change, so no changeset.