### PR TITLE
fix(init): grace delay before allowance request after fresh pairing

### DIFF
--- a/.changeset/init-allowance-pairing-grace.md
+++ b/.changeset/init-allowance-pairing-grace.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix `playground init` losing the resource-allowance approval after a fresh QR pairing. The CLI fired the allowance request the instant pairing completed, but the phone is still showing its (non-cancellable) "Connecting device" modal at that point, so the approval dialog was obscured and then dismissed when the pairing modal closed — leaving the CLI stuck on "approve on your phone". The CLI now waits a short grace period after a fresh pairing before sending the request, so it lands once the phone has dismissed its modal. Re-runs with an existing session are unaffected.

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -60,11 +60,32 @@ interface PhonePrompt {
     label: string;
 }
 
+// Grace period to wait after a fresh QR pairing before sending the RFC-0010
+// resource-allocation request to the phone. The mobile app sends the
+// host-facing `HandshakeResponse.Success` (which resolves our login) PART-WAY
+// through its pairing flow — during the "Registering" step — then runs a
+// "Syncing data" step before it dismisses its non-cancellable "Connecting
+// device" modal. As of polkadot-app-android-v2 that sync step is a stubbed
+// `delay(800ms)` (RealSyncDeviceUseCase). If we fire the allowance request in
+// that window, the phone opens the approval dialog on the SAME NavController
+// that still holds the pairing modal: the approval sheet is obscured, and the
+// pairing flow's `router.back()` (top-of-stack pop) then dismisses the
+// approval sheet instead of the pairing modal — so the request is silently
+// lost and our `requestResourceAllocation` hangs to its queue timeout.
+// Waiting comfortably past the 800ms stub lets the phone dismiss its modal
+// first, so our request lands on a clean navigation stack. This is a stopgap
+// keyed to that stub delay; the durable fix is phone-side (send Success only
+// after pairing completes / pop a specific destination). See the android
+// issue tracked for this race.
+const PHONE_PAIRING_MODAL_GRACE_MS = 2000;
+
 export function AccountSetup({
     address,
+    freshlyPaired,
     onDone,
 }: {
     address: string;
+    freshlyPaired: boolean;
     onDone: (success: boolean) => void;
 }) {
     const [steps, setSteps] = useState<StepState[]>([
@@ -76,6 +97,7 @@ export function AccountSetup({
     useEffect(() => {
         let cancelled = false;
         let session: SessionHandle | null = null;
+        let graceTimer: ReturnType<typeof setTimeout> | undefined;
 
         const update = (idx: number, patch: Partial<StepState>) => {
             if (cancelled) return;
@@ -149,6 +171,20 @@ export function AccountSetup({
                         valueTone: "muted",
                     });
                 } else {
+                    // Only a fresh QR pairing puts the phone's "Connecting
+                    // device" modal up; on a re-run with an existing session
+                    // there is nothing to wait for, so skip the grace.
+                    if (freshlyPaired) {
+                        update(0, {
+                            status: "active",
+                            value: "finishing pairing on your phone…",
+                            valueTone: "muted",
+                        });
+                        await new Promise((resolve) => {
+                            graceTimer = setTimeout(resolve, PHONE_PAIRING_MODAL_GRACE_MS);
+                        });
+                        if (cancelled) return;
+                    }
                     update(0, {
                         status: "active",
                         value: "approve on your Polkadot mobile app…",
@@ -265,9 +301,13 @@ export function AccountSetup({
         // Ink's cursor anchor and the whole screen re-renders stacked).
         return () => {
             cancelled = true;
+            // Clear a pending grace timer so an unmount mid-wait doesn't keep
+            // the Node event loop alive — `init` runs `hardExit: false` and
+            // relies on the loop draining naturally after teardown.
+            if (graceTimer) clearTimeout(graceTimer);
             session?.destroy();
         };
-    }, [address, onDone]);
+    }, [address, freshlyPaired, onDone]);
 
     return (
         <Box flexDirection="column">

--- a/src/commands/init/InitScreen.tsx
+++ b/src/commands/init/InitScreen.tsx
@@ -99,7 +99,11 @@ export function InitScreen({
             <DependencyList onDone={handleDepsDone} />
 
             {addresses && depsComplete && (
-                <AccountSetup address={addresses.productAddress} onDone={handleAccountDone} />
+                <AccountSetup
+                    address={addresses.productAddress}
+                    freshlyPaired={needsQr}
+                    onDone={handleAccountDone}
+                />
             )}
 
             {addresses && accountComplete && accountOk && (


### PR DESCRIPTION
## Problem

On a fresh `playground init` QR pairing, the resource-allowance approval is silently lost and the CLI hangs on "approve on your phone". Re-running doesn't help.

**Root cause is a timing race between the CLI and the mobile app.** The phone sends the host-facing `HandshakeResponse.Success` (which resolves our login) *part-way* through its pairing flow — during its "Registering" step — then runs an ~800ms "Syncing data" step before it dismisses its non-cancellable "Connecting device" modal. The CLI, seeing login resolve, immediately fires `requestResourceAllocation` (`AccountSetup.tsx`). That request reaches the phone while the pairing modal is still up. Because the phone opens the approval sheet on the *same* `NavController` that still holds the pairing modal, the sheet is obscured, and the pairing flow's top-of-stack `router.back()` then pops the approval sheet instead of the pairing modal — so the request is dropped and our `requestResourceAllocation` blocks until its queue timeout.

## Fix (CLI-side stopgap)

Wait a short grace period (2s, comfortably past the phone's 800ms sync stub) after a **fresh** QR pairing before sending the allowance request, so it lands once the phone has dismissed its modal.

- Threads `freshlyPaired={needsQr}` from `InitScreen` to `AccountSetup`.
- The delay runs **only** when a fresh pairing actually needs to request allowances — skipped on existing-session re-runs and when allowances are already granted.
- The pending grace timer is cleared on unmount so it can't keep the event loop alive (`init` runs `hardExit: false` and relies on the loop draining naturally); `cancelled` is re-checked after the wait.

This is a stopgap keyed to the phone's current 800ms sync stub. The **durable fix is phone-side** (send `Success` only after the pairing flow completes, and/or pop a specific destination instead of top-of-stack on dismiss) — tracked separately with the Android team. It also can't recover the re-run case where a stuck modal is already lingering on the phone.

## Verification

- `pnpm format:check` ✓
- `pnpm lint:license` ✓
- `pnpm test` → 635 passed ✓
- `tsc --noEmit` error count unchanged at 11 (within the documented baseline)

Reviewed via code-review subagent; two hygiene findings (deps-array honesty, grace-timer cleanup) addressed.