### PR TITLE
chore: burn tsc baseline to zero and add typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
                       exit 1
                   fi
 
+    typecheck:
+        name: Typecheck
+        runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+            - run: pnpm install
+            - run: pnpm typecheck
+
     unit-tests:
         name: Unit Tests
         runs-on: ${{ github.repository_owner == 'paritytech' && 'parity-default' || 'ubuntu-latest' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,16 @@ Refer to the **Contributing** and **Architecture Highlights** sections of [READM
 
 ## Verification before committing
 
-Before claiming a task complete, opening a PR, or merging, run all three. The first two are enforced by CI; the third catches regressions:
+Before claiming a task complete, opening a PR, or merging, run all four. The first three are enforced by CI; `pnpm test` also catches regressions:
 
 ```bash
 pnpm format:check
 pnpm lint:license
+pnpm typecheck
 pnpm test
 ```
 
-`pnpm build` compiles with bun, which STRIPS types without checking them — it is NOT a type signal, and there is no tsc step in CI. The tree carries a known baseline of pre-existing `tsc --noEmit` errors (11 as of June 2026, including the `TypedApi<Paseo_bulletin>` vs `BulletinTypedApi` mismatches in `playground.ts`/`AccountSetup.tsx` and a possibly-null access in `deploy/run.ts`). Before claiming a change complete, run `pnpm exec tsc --noEmit 2>&1 | grep -c "error TS"` and confirm the count did not grow — new errors hide silently otherwise. Burning the baseline down to zero and adding a tsc CI step is an open follow-up. If `lint:license` flags a file you authored, run `./scripts/check-license-headers.sh --fix` to prepend the standard Parity Apache-2.0 header (`SPDX-License-Identifier: Apache-2.0` + `Copyright (C) Parity Technologies (UK) Ltd.`, both lines required). The check script keeps shebangs on line 1 and places the header below them.
+`pnpm build` compiles with bun, which STRIPS types without checking them — it is NOT a type signal. The tsc baseline was burned to zero in June 2026 and `pnpm typecheck` (`tsc --noEmit`) now runs as a CI job, so any new type error fails the build — keep it at zero. The old `TypedApi<Paseo_bulletin>` vs `BulletinTypedApi` skew is bridged through the single `asCloudStorageApi` helper in `src/utils/allowances/bulletin.ts` (see the dependency-pins note on the cdm-builder version skew). If `lint:license` flags a file you authored, run `./scripts/check-license-headers.sh --fix` to prepend the standard Parity Apache-2.0 header (`SPDX-License-Identifier: Apache-2.0` + `Copyright (C) Parity Technologies (UK) Ltd.`, both lines required). The check script keeps shebangs on line 1 and places the header below them.
 
 ## Non-obvious invariants
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "format": "biome format --write .",
         "format:check": "biome format .",
         "lint:license": "./scripts/check-license-headers.sh",
+        "typecheck": "tsc --noEmit",
         "build": "bun build --compile src/index.ts --outfile ./dist/playground",
         "cli:install": "bun build --compile src/index.ts --outfile ~/.polkadot/bin/playground && ln -sf ~/.polkadot/bin/playground ~/.polkadot/bin/pg",
         "test": "vitest run",

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -35,7 +35,6 @@ import {
     getChainPreset,
     getRegistryAddress,
 } from "@parity/cdm-env";
-import type { CloudStorageApi } from "@parity/product-sdk-cloud-storage";
 import { createContractFromClient } from "@parity/product-sdk-contracts";
 import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
 import { paseo_bulletin } from "@parity/product-sdk-descriptors/paseo-bulletin";
@@ -45,7 +44,7 @@ import { createClient, type HexString, type SS58String } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
 import { runCliCommand } from "../cli-runtime.js";
 import { getChainConfig } from "../config.js";
-import { getBulletinAllowanceSigner } from "../utils/allowances/bulletin.js";
+import { asCloudStorageApi, getBulletinAllowanceSigner } from "../utils/allowances/bulletin.js";
 import { ensureSmartContractAllowance } from "../utils/allowances/smartContracts.js";
 import { BULLETIN_WS_HEARTBEAT_MS } from "../utils/bulletinWs.js";
 import { suppressReviveTraceNoise } from "../utils/contractManifest.js";
@@ -261,10 +260,9 @@ async function runContractDeploy(opts: ContractDeployOpts): Promise<void> {
         client = await createContractChainClient(target);
         const metadataSigner = await getBulletinAllowanceSigner({
             publishSigner: signer,
-            // client.bulletin is the same runtime bulletin API, but it's nominally
-            // typed as @parity/cdm-env's CdmBulletinApi (built against an older
-            // product-sdk-cloud-storage than the CLI's). Bridge the version skew.
-            bulletinApi: client.bulletin as unknown as CloudStorageApi,
+            // client.bulletin is the same runtime bulletin API but nominally a
+            // different descriptor instance; asCloudStorageApi bridges the skew.
+            bulletinApi: asCloudStorageApi(client.bulletin),
         });
 
         const result = await runContractDeployWithUI({

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -26,7 +26,10 @@ import {
     describeResource,
     summarizeOutcomes,
 } from "../../utils/allowances/resources.js";
-import { cachedBulletinSlotAuthorization } from "../../utils/allowances/bulletin.js";
+import {
+    asCloudStorageApi,
+    cachedBulletinSlotAuthorization,
+} from "../../utils/allowances/bulletin.js";
 
 type Status = "pending" | "active" | "ok" | "failed" | "skipped";
 
@@ -157,7 +160,7 @@ export function AccountSetup({
                 );
                 const bulletinAuth = await cachedBulletinSlotAuthorization(
                     adapter,
-                    client.bulletin,
+                    asCloudStorageApi(client.bulletin),
                     1,
                 ).catch(() => null);
 

--- a/src/commands/init/UsernamePrompt.tsx
+++ b/src/commands/init/UsernamePrompt.tsx
@@ -221,7 +221,10 @@ function SubmitUsername({
                 return;
             }
             try {
-                await setRegistryUsername(session, name);
+                // `setRegistryUsername` takes a `ResolvedSigner`; a session
+                // handle is one once tagged with its source (same shape
+                // `resolveSigner` produces for QR/mobile sessions).
+                await setRegistryUsername({ ...session, source: "session" }, name);
                 if (!cancelled) setPhase({ kind: "complete", username: name });
             } catch (err) {
                 if (cancelled) return;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -128,8 +128,11 @@ export async function initTelemetry(options: TelemetryInitOptions = {}): Promise
         return;
     }
 
+    // Capture a non-null local so the integrations callback below (a closure
+    // over the mutable module-level `Sentry`) type-checks without a null guard.
+    const sentry = Sentry;
     try {
-        Sentry.init({
+        sentry.init({
             dsn: process.env.SENTRY_DSN || PLAYGROUND_SENTRY_DSN,
             release: `playground-cli@${VERSION}`,
             tracesSampleRate: 1,
@@ -154,10 +157,11 @@ export async function initTelemetry(options: TelemetryInitOptions = {}): Promise
                 ...defaultIntegrations.filter(
                     (integration) => integration.name !== "OnUnhandledRejection",
                 ),
-                Sentry.onUnhandledRejectionIntegration({ mode: "none" }),
+                sentry.onUnhandledRejectionIntegration({ mode: "none" }),
             ],
             beforeSend(event) {
-                if (isBenignDestroyedErrorEvent(event)) return null;
+                if (isBenignDestroyedErrorEvent(event as unknown as Record<string, unknown>))
+                    return null;
                 return sanitizeSentryEvent(
                     event as unknown as Record<string, unknown>,
                 ) as unknown as typeof event;
@@ -169,8 +173,8 @@ export async function initTelemetry(options: TelemetryInitOptions = {}): Promise
             },
             transport: options.transport as never,
         });
-        Sentry.setTag("cli.tool_version", VERSION);
-        Sentry.setContext("playground-cli", {
+        sentry.setTag("cli.tool_version", VERSION);
+        sentry.setContext("playground-cli", {
             version: VERSION,
             release: `playground-cli@${VERSION}`,
             node: process.version,

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -29,6 +29,28 @@ import {
 } from "@parity/product-sdk-terminal/host";
 import type { ResolvedSigner } from "../signer.js";
 
+/**
+ * Bridge the one nominal type skew between our bulletin chain API and
+ * product-sdk's. We build the API from `@parity/product-sdk-descriptors`'
+ * `bulletin` descriptor (`TypedApi<Paseo_bulletin>`); product-sdk's
+ * `CloudStorageApi` is `@parity/bulletin-sdk`'s `BulletinTypedApi`, generated
+ * from a different descriptor instance pinned at a slightly older product-sdk
+ * version (the cdm-builder version skew documented in CLAUDE.md). The two are
+ * structurally identical at runtime but nominally distinct to `tsc`. Cast
+ * through this single seam so the skew lives in one deletable place — drop
+ * this helper and inline its callers once the descriptor versions realign.
+ *
+ * The param is `unknown` on purpose: callers pass mutually-incompatible
+ * nominal types (the descriptor `TypedApi<Paseo_bulletin>` from
+ * `getConnection()`/`getTypedApi`, and cdm-env's `CdmBulletinApi` from the
+ * contract chain client in `commands/contract.ts`). Narrowing the param to one
+ * of them would re-couple the bridge to a single descriptor's structural shape
+ * — the exact skew this seam exists to absorb — so leave it `unknown`.
+ */
+export function asCloudStorageApi(api: unknown): CloudStorageApi {
+    return api as CloudStorageApi;
+}
+
 export const BULLETIN_RESOURCE: AllocatableResource = {
     tag: "BulletInAllowance",
     value: undefined,

--- a/src/utils/auth.connect.test.ts
+++ b/src/utils/auth.connect.test.ts
@@ -72,7 +72,11 @@ function fakeAdapter() {
         destroy: vi.fn().mockResolvedValue(undefined),
         sso: {
             authenticate: vi.fn(() => new Promise(() => {})),
-            pairingStatus: { subscribe: vi.fn(() => () => {}) },
+            pairingStatus: {
+                subscribe: vi.fn(
+                    (_cb: (status: { step: string; payload: string }) => void) => () => {},
+                ),
+            },
         },
     };
 }

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -23,7 +23,9 @@ const { captureWarningMock, withSpanMock, bulletinStorageSigner, getBulletinAllo
         captureWarningMock: vi.fn(),
         withSpanMock: vi.fn(async (_op: string, _name: string, _attrs: any, fn: any) => fn()),
         bulletinStorageSigner: { __signer: "bulletin-allowance" },
-        getBulletinAllowanceSignerMock: vi.fn(async () => ({ __signer: "bulletin-allowance" })),
+        getBulletinAllowanceSignerMock: vi.fn(async (_options: unknown) => ({
+            __signer: "bulletin-allowance",
+        })),
     }));
 
 // Mock the metadata upload path so we never actually touch the network.
@@ -37,6 +39,7 @@ vi.mock("@parity/product-sdk-tx", () => ({
     withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
 }));
 vi.mock("../allowances/bulletin.js", () => ({
+    asCloudStorageApi: (api: unknown) => api,
     getBulletinAllowanceSigner: (options: unknown) => getBulletinAllowanceSignerMock(options),
     isInvalidPaymentError: (err: unknown) => String(err).includes("Payment"),
 }));
@@ -106,7 +109,9 @@ beforeEach(() => {
     vi.mocked(submitAndWatch).mockClear();
     vi.mocked(submitAndWatch).mockResolvedValue({
         ok: true,
+        txHash: "0x0",
         block: { hash: "0x0", number: 0, index: 0 },
+        events: [],
     });
 });
 
@@ -647,7 +652,12 @@ describe("publishToPlayground", () => {
     it("re-checks Bulletin allowance once when metadata upload fails with Invalid Payment", async () => {
         vi.mocked(submitAndWatch)
             .mockRejectedValueOnce(new Error('{"type":"Invalid","value":{"type":"Payment"}}'))
-            .mockResolvedValueOnce({ ok: true, block: { hash: "0x1", number: 1, index: 0 } });
+            .mockResolvedValueOnce({
+                ok: true,
+                txHash: "0x1",
+                block: { hash: "0x1", number: 1, index: 0 },
+                events: [],
+            });
 
         await publishToPlayground({
             domain: "my-app.dot",

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -44,6 +44,7 @@ import { getConnection } from "../connection.js";
 import { getChainConfig, type Env } from "../../config.js";
 import { captureWarning, withSpan, errorMessage } from "../../telemetry.js";
 import {
+    asCloudStorageApi,
     getBulletinAllowanceSigner,
     isInvalidPaymentError,
     type AllowancePrompt,
@@ -307,7 +308,7 @@ export async function publishToPlayground(
                 const storeTx = bulletinApi.tx.TransactionStorage.store({ data: metadataBytes });
                 let storageSigner = await getBulletinAllowanceSigner({
                     publishSigner: options.publishSigner,
-                    bulletinApi,
+                    bulletinApi: asCloudStorageApi(bulletinApi),
                     requiredBytes: metadataBytes.length,
                     onPrompt: options.onAllowancePrompt,
                 });
@@ -323,7 +324,7 @@ export async function publishToPlayground(
                     });
                     storageSigner = await getBulletinAllowanceSigner({
                         publishSigner: options.publishSigner,
-                        bulletinApi,
+                        bulletinApi: asCloudStorageApi(bulletinApi),
                         requiredBytes: metadataBytes.length,
                         onPrompt: options.onAllowancePrompt,
                     });

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -211,21 +211,25 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
     // ── Playground publish ───────────────────────────────────────────────
     let metadataCid: string | undefined;
     if (setup.publishSigner) {
+        // Capture the non-null signer so its narrowing survives into the
+        // `publishToPlayground` closure below — TS drops property narrowing
+        // across closure boundaries.
+        const publishSigner = setup.publishSigner;
         // Only emit sign-request / sign-complete events for signers that
         // need user interaction (real phone sessions). When dev-mode
         // synthesises an in-process Alice signer there's no human in the
         // loop — wrapping with the signing proxy would flash a "check
         // your phone" UI callout between the synchronous request and
         // completion, contradicting the 0-approvals summary.
-        const isInteractiveSigner = setup.publishSigner.source === "session";
+        const isInteractiveSigner = publishSigner.source === "session";
         const wrappedPublishSigner = isInteractiveSigner
             ? wrapResolvedSigner(
-                  setup.publishSigner,
+                  publishSigner,
                   "Publish to Playground registry",
                   counter,
                   (event) => options.onEvent({ kind: "signing", event }),
               )
-            : setup.publishSigner;
+            : publishSigner;
 
         const pub = await withDeployPhase(
             "playground",
@@ -244,7 +248,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     env: options.env,
                     isPrivate: options.playgroundPrivate,
                     isModdable: options.moddable ?? false,
-                    isDevSigner: setup.publishSigner.source === "dev",
+                    isDevSigner: publishSigner.source === "dev",
                 }),
         );
         metadataCid = pub.metadataCid;

--- a/src/utils/deploy/storageQuota.ts
+++ b/src/utils/deploy/storageQuota.ts
@@ -37,6 +37,7 @@ import { createClient } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
 import { paseo_bulletin as bulletin } from "@parity/product-sdk-descriptors/paseo-bulletin";
 import type { CloudStorageApi } from "@parity/product-sdk-cloud-storage";
+import { asCloudStorageApi } from "../allowances/bulletin.js";
 import { getChainConfig, type Env } from "../../config.js";
 import { BULLETIN_WS_HEARTBEAT_MS } from "../bulletinWs.js";
 
@@ -108,7 +109,7 @@ export function createStorageQuotaContext(
             }),
         );
         return {
-            bulletinApi: client.getTypedApi(bulletin) as unknown as CloudStorageApi,
+            bulletinApi: asCloudStorageApi(client.getTypedApi(bulletin)),
             requiredBytes,
             destroy: () => client.destroy(),
         };


### PR DESCRIPTION
## What

The repo carried **11 pre-existing `tsc --noEmit` errors** with no CI step to catch new ones (`bun build` strips types without checking, and there was no `tsc` step in CI). This fixes all 11 idiomatically and adds a `typecheck` CI job so the baseline cannot silently regrow.

## The 11 errors, by cluster

- **Bulletin descriptor/SDK type skew (3):** `getBulletinAllowanceSigner` / `cachedBulletinSlotAuthorization` want product-sdk's `CloudStorageApi` (= `@parity/bulletin-sdk`'s `BulletinTypedApi`), but the code builds the API from `@parity/product-sdk-descriptors` (`TypedApi<Paseo_bulletin>`). Same runtime shape, distinct nominal type (the documented cdm-builder version skew). Bridged through a single `asCloudStorageApi()` helper in `src/utils/allowances/bulletin.ts`, replacing the scattered inline `as unknown as CloudStorageApi` casts (including a fifth pre-existing site in `storageQuota.ts`).
- **Test mock mismatches (4):** mock-arg arity + two partial `TxResult` objects missing `txHash`/`events` in `playground.test.ts`; a 0-arg `pairingStatus.subscribe` mock called with a callback in `auth.connect.test.ts`.
- **telemetry.ts (2):** `Sentry` (mutable `let`, nulled in a catch) seen as possibly-null inside the integrations closure → capture a non-null local; plus a `beforeSend` event cast matching its siblings.
- **Closure narrowing (1):** `run.ts` read `setup.publishSigner.source` inside a closure where the guard's narrowing didn't survive → hoisted a non-null local.
- **SessionHandle vs ResolvedSigner (1):** `UsernamePrompt.tsx` passed a `SessionHandle` (lacks required `source`) where a `ResolvedSigner` is expected → `{ ...session, source: "session" }`, matching `resolveSigner`'s own pattern.

## CI guard

Adds a `pnpm typecheck` (`tsc --noEmit`) script and a `Typecheck` CI job alongside Format/Unit Tests. Verified it gates: `pnpm typecheck` exits non-zero on an injected type error, 0 when clean.

## Verification

- `pnpm typecheck`: 0 errors
- `pnpm test`: 635/635 pass
- `pnpm format:check` / `pnpm lint:license`: clean

CLAUDE.md's "11 errors as of June 2026" baseline note is updated to reflect zero + the new CI job.

No changeset: type-only / test / CI change with no user-visible behavior, per repo convention.