### PR TITLE
Refresh contract deploy flow

### DIFF
--- a/.changeset/fresh-contract-deploy-flow.md
+++ b/.changeset/fresh-contract-deploy-flow.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Refresh contract deploy/install orchestration and add an optional `playground deploy` contracts pre-step (`--contracts` / `--no-contracts`, or an interactive prompt). Contract deploys now preflight CDM registry package ownership so users get a direct rename/use-owner-account error before a deploy batch reverts.
+Refresh contract deploy/install orchestration and add an optional `playground deploy` contracts pre-step (`--contracts` / `--no-contracts`, or an interactive prompt). Headless deploys now require an explicit `--contracts` or `--no-contracts` answer. Contract deploys now preflight CDM registry package ownership so users get a direct rename/use-owner-account error before a deploy batch reverts.

--- a/.changeset/fresh-contract-deploy-flow.md
+++ b/.changeset/fresh-contract-deploy-flow.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Refresh contract deploy/install orchestration and add an optional `playground deploy` contracts pre-step (`--contracts` / `--no-contracts`, or an interactive prompt).

--- a/.changeset/fresh-contract-deploy-flow.md
+++ b/.changeset/fresh-contract-deploy-flow.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-Refresh contract deploy/install orchestration and add an optional `playground deploy` contracts pre-step (`--contracts` / `--no-contracts`, or an interactive prompt).
+Refresh contract deploy/install orchestration and add an optional `playground deploy` contracts pre-step (`--contracts` / `--no-contracts`, or an interactive prompt). Contract deploys now preflight CDM registry package ownership so users get a direct rename/use-owner-account error before a deploy batch reverts.

--- a/e2e/cli/chaos.test.ts
+++ b/e2e/cli/chaos.test.ts
@@ -50,6 +50,7 @@ function chaosDeployArgs(domain: string, buildDir: string, dir: string): string[
 		"run",
 		CLI_ENTRY,
 		"deploy",
+		"--no-contracts",
 		"--signer",
 		"dev",
 		"--domain",

--- a/e2e/cli/deploy.test.ts
+++ b/e2e/cli/deploy.test.ts
@@ -19,7 +19,7 @@
  * These tests verify the deploy pipeline behavior. Tests that require
  * full network connectivity (Paseo testnet + IPFS) are marked accordingly.
  *
- * All headless deploys require: --signer, --domain, --buildDir, --playground
+ * All headless deploys require: --signer, --domain, --buildDir, --playground, --contracts/--no-contracts
  * to trigger the non-interactive path (see isFullySpecified() in deploy/index.ts).
  *
  */
@@ -64,6 +64,7 @@ describe("dot deploy — preflight and validation", () => {
 	test("reports mainnet not yet supported", async () => {
 		const result = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -88,6 +89,7 @@ describe("dot deploy — preflight and validation", () => {
 		const domain = E2E_DOMAINS.preflight;
 		const result = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -141,6 +143,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 		const wasAlreadyPublished = (await getApp(`${domain}.dot`)) !== null;
 		const result = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -226,6 +229,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 		const domain = E2E_DOMAINS.redeploy;
 		const first = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -241,6 +245,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 
 		const second = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -276,6 +281,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 		const domain = E2E_DOMAINS.collision;
 		const ownerDeploy = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -291,6 +297,7 @@ describe("dot deploy --playground — full pipeline (requires Paseo + IPFS)", ()
 
 		const bobDeploy = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", domain,
 			"--buildDir", absBuildDir(frontendOnly),
@@ -341,6 +348,7 @@ describe("dot deploy — moddable (requires Paseo + IPFS + GH)", () => {
 			const result = await dot(
 				[
 					"deploy",
+					"--no-contracts",
 					"--signer", "dev",
 					"--domain", domain,
 					"--buildDir", absBuildDir(workDir),

--- a/e2e/cli/diagnostic.test.ts
+++ b/e2e/cli/diagnostic.test.ts
@@ -40,6 +40,7 @@ describe("diagnostic mode", () => {
 			// to get there.
 			const result = await dot([
 				"deploy",
+				"--no-contracts",
 				"--signer", "dev",
 				"--domain", E2E_DOMAINS.preflight,
 				"--buildDir", resolve(frontendOnly, "dist"),
@@ -76,6 +77,7 @@ describe("diagnostic mode", () => {
 		// var is set (see src/utils/process-guard.ts startMemoryWatchdog).
 		const result = await dot([
 			"deploy",
+			"--no-contracts",
 			"--signer", "dev",
 			"--domain", E2E_DOMAINS.preflight,
 			"--buildDir", resolve(frontendOnly, "dist"),

--- a/e2e/cli/session.test.ts
+++ b/e2e/cli/session.test.ts
@@ -58,7 +58,17 @@ describe("session management", () => {
 		writeFileSync(sessionFile, "CORRUPT_DATA_HERE");
 
 		const result = await dot(
-			["deploy", "--signer", "phone", "--domain", "test", "--playground", "--buildDir", "dist"],
+			[
+				"deploy",
+				"--no-contracts",
+				"--signer",
+				"phone",
+				"--domain",
+				"test",
+				"--playground",
+				"--buildDir",
+				"dist",
+			],
 			{ home: tempHome, timeout: 30_000 },
 		);
 		// Must fail with the deliberate no-session notice. `--signer phone`

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "test:e2e:nightly": "tools/e2e-local.sh nightly"
     },
     "dependencies": {
-        "@parity/cdm-builder": "3.1.4",
-        "@parity/cdm-codegen": "0.6.17",
-        "@parity/cdm-env": "^2.0.4",
+        "@parity/cdm-builder": "3.1.5",
+        "@parity/cdm-codegen": "0.6.18",
+        "@parity/cdm-env": "^2.0.5",
         "@parity/dotns-cli": "0.6.1",
         "@parity/product-sdk-address": "^0.1.1",
         "@parity/product-sdk-cloud-storage": "^0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
   .:
     dependencies:
       '@parity/cdm-builder':
-        specifier: 3.1.4
-        version: 3.1.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
+        specifier: 3.1.5
+        version: 3.1.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
       '@parity/cdm-codegen':
-        specifier: 0.6.17
-        version: 0.6.17(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot-api/ink-contracts@0.6.3)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
+        specifier: 0.6.18
+        version: 0.6.18(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot-api/ink-contracts@0.6.3)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
       '@parity/cdm-env':
-        specifier: ^2.0.4
-        version: 2.0.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
+        specifier: ^2.0.5
+        version: 2.0.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/dotns-cli':
         specifier: 0.6.1
         version: 0.6.1(@polkadot/util@14.0.3)(jiti@2.7.0)(postcss@8.5.10)(react-native@0.85.2(@babel/core@7.29.7)(@types/react@18.3.28)(react@18.3.1))(rxjs@7.8.2)(typescript@5.9.3)(yaml@2.9.0)
@@ -1149,14 +1149,14 @@ packages:
       multiformats: ^13.4.1
       polkadot-api: ^2.1.2
 
-  '@parity/cdm-builder@3.1.4':
-    resolution: {integrity: sha512-MS1aTAUThB0wr/NEc9V0VVKE9uRpWJtjpbSQHz0k0dy6glTIjt8ewz1gmer3RRb5N99CE+ein4NDUWzv99m+WQ==}
+  '@parity/cdm-builder@3.1.5':
+    resolution: {integrity: sha512-73EXF3KXJn+InLANhXSuz1ZXhiu3H5F9qn65FkSSzVSbu9hRY9fge0z79lSIU/f+PCmaLQPrYFpQZYm9jIGIgw==}
 
-  '@parity/cdm-codegen@0.6.17':
-    resolution: {integrity: sha512-EyQLj+ctgnEenrEkyLwhVgHWasq2SpHV8oXwDG6E+vnDPHUmfeUL4ECaaqucwZAvJi7JukBXmk0euQA0IO5SLA==}
+  '@parity/cdm-codegen@0.6.18':
+    resolution: {integrity: sha512-9UvgVVP4cOtPDZ88bGLDvtfBSu22e9xFWhLvcub2XzJQpLEvADpGSzcPd99qSQ3xip4tQTwOmGkXphtLrBT5pg==}
 
-  '@parity/cdm-env@2.0.4':
-    resolution: {integrity: sha512-sOg3zsQ4BquP/Qwu5y8h452xW21ggGUgP2BkrzZuu91DLaQjJY3bc/zJDooFCteQr+VtafpcT7wEhix9FszcWQ==}
+  '@parity/cdm-env@2.0.5':
+    resolution: {integrity: sha512-twNHpTsuRSyFnZXPmBu8sNXljr+w8Gt28KFUCxRJG2oBKH1GzIQymAjvoMhKtKr8te4Z+PerweTzj1OOc+XfWg==}
 
   '@parity/cdm-utils@0.4.1':
     resolution: {integrity: sha512-Da2hXGhGIvLpQoHtwjfFQ4hIG3ignf0Nf4vn4oML+JBUJ5I4KpjfLM4mt/wNwURGWa2CNCz7u7mzae1s0QuqMQ==}
@@ -6563,10 +6563,10 @@ snapshots:
       multiformats: 13.4.2
       polkadot-api: 2.1.6(esbuild@0.27.7)(rxjs@7.8.2)
 
-  '@parity/cdm-builder@3.1.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)':
+  '@parity/cdm-builder@3.1.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:
       '@noble/hashes': 2.2.0
-      '@parity/cdm-env': 2.0.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
+      '@parity/cdm-env': 2.0.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/cdm-utils': 0.4.1
       '@parity/product-sdk-cloud-storage': 0.5.3(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/product-sdk-contracts': 0.7.0(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
@@ -6587,10 +6587,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@parity/cdm-codegen@0.6.17(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot-api/ink-contracts@0.6.3)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)':
+  '@parity/cdm-codegen@0.6.18(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot-api/ink-contracts@0.6.3)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)':
     dependencies:
-      '@parity/cdm-builder': 3.1.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
-      '@parity/cdm-env': 2.0.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
+      '@parity/cdm-builder': 3.1.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2)(typescript@5.9.3)
+      '@parity/cdm-env': 2.0.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)
       '@parity/cdm-utils': 0.4.1
       '@polkadot-api/sdk-ink': 0.7.0(@polkadot-api/ink-contracts@0.6.3)(polkadot-api@2.1.6(esbuild@0.27.7)(rxjs@7.8.2))(rxjs@7.8.2)(typescript@5.9.3)
       polkadot-api: 2.1.6(esbuild@0.27.7)(rxjs@7.8.2)
@@ -6608,7 +6608,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@parity/cdm-env@2.0.4(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@parity/cdm-env@2.0.5(@novasamatech/host-api-wrapper@0.8.6(@polkadot/api@16.5.6)(@polkadot/util@14.0.3)(esbuild@0.27.7)(rxjs@7.8.2))(@novasamatech/host-api@0.8.6)(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@parity/cdm-utils': 0.4.1
       '@parity/product-sdk-descriptors': 0.5.2(esbuild@0.27.7)(rxjs@7.8.2)

--- a/src/commands/contract.test.ts
+++ b/src/commands/contract.test.ts
@@ -20,6 +20,8 @@ import { describe, expect, it } from "vitest";
 import { getChainConfig } from "../config.js";
 import {
     assertSupportedCdmJson,
+    findForeignOwnedCdmPackages,
+    formatCdmPackageOwnershipConflicts,
     parseContractInstallLibraryArg,
     resolveContractDeployTarget,
     resolveContractInstallTarget,
@@ -215,6 +217,89 @@ describe("resolveContractSignerOptions", () => {
     it("rejects SURI with phone mode to avoid silently using a local signer", () => {
         expect(() => resolveContractSignerOptions({ signer: "phone", suri: "//Alice" })).toThrow(
             "--suri cannot be used with --signer phone",
+        );
+    });
+});
+
+describe("CDM package ownership conflicts", () => {
+    const caller = "0x1111111111111111111111111111111111111111" as const;
+
+    it("ignores unregistered packages and packages owned by the caller", () => {
+        expect(
+            findForeignOwnedCdmPackages(
+                [
+                    {
+                        packageName: "@example/new",
+                        versionCount: 0,
+                        owner: "0x0000000000000000000000000000000000000000",
+                    },
+                    {
+                        packageName: "@example/mine",
+                        versionCount: 1,
+                        owner: caller,
+                    },
+                ],
+                caller,
+            ),
+        ).toEqual([]);
+    });
+
+    it("returns packages owned by another account", () => {
+        expect(
+            findForeignOwnedCdmPackages(
+                [
+                    {
+                        packageName: "@example/theirs",
+                        versionCount: 2,
+                        owner: "0x2222222222222222222222222222222222222222",
+                    },
+                ],
+                caller,
+            ),
+        ).toEqual([
+            {
+                packageName: "@example/theirs",
+                owner: "0x2222222222222222222222222222222222222222",
+                caller,
+            },
+        ]);
+    });
+
+    it("formats the rename-or-owner-account guidance", () => {
+        expect(
+            formatCdmPackageOwnershipConflicts([
+                {
+                    packageName: "@example/theirs",
+                    owner: "0x2222222222222222222222222222222222222222",
+                    caller,
+                },
+            ]),
+        ).toContain('Update the contract Cargo.toml [package.metadata.cdm] package = "..."');
+    });
+
+    it("formats multiple ownership conflicts with one selected signer", () => {
+        const message = formatCdmPackageOwnershipConflicts([
+            {
+                packageName: "@example/one",
+                owner: "0x2222222222222222222222222222222222222222",
+                caller,
+            },
+            {
+                packageName: "@example/two",
+                owner: "0x3333333333333333333333333333333333333333",
+                caller,
+            },
+        ]);
+
+        expect(message).toContain(`selected signer maps to ${caller}`);
+        expect(message).toContain(
+            "@example/one owned by 0x2222222222222222222222222222222222222222",
+        );
+        expect(message).toContain(
+            "@example/two owned by 0x3333333333333333333333333333333333333333",
+        );
+        expect(message).toContain(
+            'Update each contract Cargo.toml [package.metadata.cdm] package = "..."',
         );
     });
 });

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -52,13 +52,11 @@ import { createClient, type HexString, type SS58String } from "polkadot-api";
 import { getWsProvider } from "polkadot-api/ws";
 import { runCliCommand } from "../cli-runtime.js";
 import { getChainConfig } from "../config.js";
-import { asCloudStorageApi, getBulletinAllowanceSigner } from "../utils/allowances/bulletin.js";
-import { ensureSmartContractAllowance } from "../utils/allowances/smartContracts.js";
+import { getCachedBulletinAllowanceSigner } from "../utils/allowances/bulletin.js";
 import { BULLETIN_WS_HEARTBEAT_MS } from "../utils/bulletinWs.js";
 import { suppressReviveTraceNoise } from "../utils/contractManifest.js";
 import type { SignerMode } from "../utils/deploy/signerMode.js";
 import {
-    createApprovalPrompt,
     createSigningCounter,
     wrapSignerWithEvents,
     type SigningEvent,
@@ -394,9 +392,6 @@ export async function runContractDeploy(
     const features = resolveFeatures(opts.features, rootDir);
     const useUi = runOptions.useUi ?? true;
     const signingCounter = createSigningCounter();
-    const allowancePrompt = runOptions.onSigningEvent
-        ? createApprovalPrompt(signingCounter, runOptions.onSigningEvent)
-        : undefined;
 
     let signer: ResolvedSigner | null = runOptions.resolvedSigner ?? null;
     const ownsSigner = !signer;
@@ -420,22 +415,31 @@ export async function runContractDeploy(
 
     try {
         signer ??= await resolveSigner(resolveContractSignerOptions(opts));
+        runOptions.onDeployEvent?.({
+            type: "log",
+            line: "connecting contract chains",
+        });
         client = await createContractChainClient(target);
+        runOptions.onDeployEvent?.({
+            type: "log",
+            line: "checking cdm registry ownership",
+        });
         await assertCdmPackageOwnership({
             rootDir,
             client,
             registryAddress: target.registryAddress,
             origin: signer.address as SS58String,
         });
-        await ensureSmartContractAllowance({
-            deploySigner: signer,
+        runOptions.onDeployEvent?.({
+            type: "log",
+            line: "cdm registry ownership ok",
         });
-        const metadataSigner = await getBulletinAllowanceSigner({
+        runOptions.onDeployEvent?.({
+            type: "log",
+            line: "checking cached bulletin allowance",
+        });
+        const metadataSigner = await getCachedBulletinAllowanceSigner({
             publishSigner: signer,
-            // client.bulletin is the same runtime bulletin API but nominally a
-            // different descriptor instance; asCloudStorageApi bridges the skew.
-            bulletinApi: asCloudStorageApi(client.bulletin),
-            onPrompt: allowancePrompt,
         });
 
         if (useUi) {

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -18,13 +18,19 @@ import { dirname, resolve } from "node:path";
 import { generateContractTypes, generateContractsAugmentation } from "@parity/cdm-codegen";
 import {
     CONTRACTS_REGISTRY_ABI,
+    deployContracts,
     generateSolidityImport,
     hasBuildableSolidityProject,
+    installContracts,
     readCdmJson,
     resolveFeatures,
     type CdmJson,
+    type DeployEvent as ContractDeployEvent,
+    type DeploySummary,
     type InstallLibraryRequest,
+    type InstallEvent as ContractInstallEvent,
     type InstallResult,
+    type InstallSummary,
     type PipelineChainClient,
     type SolidityAbiEntry,
     writeCdmJson,
@@ -34,6 +40,7 @@ import {
     createCdmAssetHubClient,
     getChainPreset,
     getRegistryAddress,
+    resolveQueryOrigin,
 } from "@parity/cdm-env";
 import { createContractFromClient } from "@parity/product-sdk-contracts";
 import { paseo_asset_hub } from "@parity/product-sdk-descriptors/paseo-asset-hub";
@@ -49,17 +56,22 @@ import { ensureSmartContractAllowance } from "../utils/allowances/smartContracts
 import { BULLETIN_WS_HEARTBEAT_MS } from "../utils/bulletinWs.js";
 import { suppressReviveTraceNoise } from "../utils/contractManifest.js";
 import type { SignerMode } from "../utils/deploy/signerMode.js";
+import {
+    createApprovalPrompt,
+    createSigningCounter,
+    wrapSignerWithEvents,
+    type SigningEvent,
+} from "../utils/deploy/signingProxy.js";
 import { onProcessShutdown } from "../utils/process-guard.js";
 import { resolveSigner, type ResolvedSigner, type SignerOptions } from "../utils/signer.js";
 import { runContractDeployWithUI } from "./contractDeployUi.js";
 import { runContractInstallWithUI } from "./contractInstallUi.js";
 
 const CDM_INCLUDE = ".cdm/**/*";
-// CDM registry getters are read-only, but Revive dry-run queries still require
-// an origin that encodes on the target chain. This value is not a signer.
-const REGISTRY_QUERY_ORIGIN_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-interface ContractDeployOpts {
+export interface ContractDeployOpts {
+    /** Project root. Internal callers set this; the standalone command defaults to cwd. */
+    rootDir?: string;
     assethubUrl?: string;
     bulletinUrl?: string;
     registryAddress?: string;
@@ -68,11 +80,41 @@ interface ContractDeployOpts {
     features?: string;
 }
 
-interface ContractInstallOpts {
+export interface ContractInstallOpts {
+    /** Project root. Internal callers set this; the standalone command defaults to cwd. */
+    rootDir?: string;
     assethubUrl?: string;
     name?: string;
     ipfsGatewayUrl?: string;
     registryAddress?: string;
+}
+
+export interface ContractDeployRunOptions {
+    /** Render the standalone contract deploy Ink UI. Defaults to true for the direct command. */
+    useUi?: boolean;
+    /**
+     * Reuse a signer already resolved by another command. The caller retains
+     * ownership and must destroy it; this runner only destroys signers it opens.
+     */
+    resolvedSigner?: ResolvedSigner;
+    onDeployEvent?: (event: ContractDeployEvent) => void;
+    onSigningEvent?: (event: SigningEvent) => void;
+}
+
+export interface ContractDeployRunResult {
+    summary: DeploySummary;
+    success: boolean;
+}
+
+export interface ContractInstallRunOptions {
+    /** Render the standalone contract install Ink UI. Defaults to true for the direct command. */
+    useUi?: boolean;
+    onInstallEvent?: (event: ContractInstallEvent) => void;
+}
+
+export interface ContractInstallRunResult {
+    summary: InstallSummary;
+    success: boolean;
 }
 
 interface ContractDeployTarget {
@@ -229,22 +271,33 @@ async function createContractChainClient(
     };
 }
 
-async function runContractDeploy(opts: ContractDeployOpts): Promise<void> {
+export async function runContractDeploy(
+    opts: ContractDeployOpts,
+    runOptions: ContractDeployRunOptions = {},
+): Promise<ContractDeployRunResult> {
     const target = resolveContractDeployTarget(opts);
     const cfg = getChainConfig();
-    const rootDir = resolve(process.cwd());
+    const rootDir = resolve(opts.rootDir ?? process.cwd());
     const features = resolveFeatures(opts.features, rootDir);
+    const useUi = runOptions.useUi ?? true;
+    const signingCounter = createSigningCounter();
+    const allowancePrompt = runOptions.onSigningEvent
+        ? createApprovalPrompt(signingCounter, runOptions.onSigningEvent)
+        : undefined;
 
-    let signer: ResolvedSigner | null = null;
+    let signer: ResolvedSigner | null = runOptions.resolvedSigner ?? null;
+    const ownsSigner = !signer;
     let client: ContractChainClient | null = null;
     const cleanupOnce = (() => {
         let ran = false;
         return () => {
             if (ran) return;
             ran = true;
-            try {
-                signer?.destroy();
-            } catch {}
+            if (ownsSigner) {
+                try {
+                    signer?.destroy();
+                } catch {}
+            }
             try {
                 client?.destroy();
             } catch {}
@@ -253,7 +306,7 @@ async function runContractDeploy(opts: ContractDeployOpts): Promise<void> {
     onProcessShutdown(cleanupOnce);
 
     try {
-        signer = await resolveSigner(resolveContractSignerOptions(opts));
+        signer ??= await resolveSigner(resolveContractSignerOptions(opts));
         await ensureSmartContractAllowance({
             deploySigner: signer,
         });
@@ -263,23 +316,48 @@ async function runContractDeploy(opts: ContractDeployOpts): Promise<void> {
             // client.bulletin is the same runtime bulletin API but nominally a
             // different descriptor instance; asCloudStorageApi bridges the skew.
             bulletinApi: asCloudStorageApi(client.bulletin),
+            onPrompt: allowancePrompt,
         });
 
-        const result = await runContractDeployWithUI({
+        if (useUi) {
+            return await runContractDeployWithUI({
+                rootDir,
+                features,
+                client,
+                signer: signer.signer,
+                origin: signer.address as SS58String,
+                registryAddress: target.registryAddress,
+                metadataSigner,
+                assethubUrl: target.assethubUrl,
+                bulletinUrl: target.bulletinUrl,
+                ipfsGatewayUrl: cfg.bulletinGateway,
+                signerAddress: signer.address,
+                signerRequiresApproval: signer.source === "session",
+            });
+        }
+
+        const deploySigner =
+            signer.source === "session" && runOptions.onSigningEvent
+                ? wrapSignerWithEvents(signer.signer, {
+                      label: "Deploy and register contracts",
+                      counter: signingCounter,
+                      onEvent: runOptions.onSigningEvent,
+                  })
+                : signer.signer;
+        const summary = await deployContracts({
             rootDir,
             features,
             client,
-            signer: signer.signer,
+            signer: deploySigner,
             origin: signer.address as SS58String,
             registryAddress: target.registryAddress,
             metadataSigner,
-            assethubUrl: target.assethubUrl,
-            bulletinUrl: target.bulletinUrl,
-            ipfsGatewayUrl: cfg.bulletinGateway,
-            signerAddress: signer.address,
-            signerRequiresApproval: signer.source === "session",
+            onEvent: runOptions.onDeployEvent,
         });
-        if (!result.success) process.exitCode = 1;
+        return {
+            summary,
+            success: summary.contracts.every((contract) => contract.status !== "error"),
+        };
     } finally {
         cleanupOnce();
     }
@@ -399,13 +477,18 @@ function runPostInstallHooks(rootDir: string, cdmJson: CdmJson): void {
     if (projectType.hasTypeScript) postInstallTypeScript(rootDir, cdmJson);
 }
 
-async function runContractInstall(libraries: string[], opts: ContractInstallOpts): Promise<void> {
-    const rootDir = resolve(process.cwd());
+export async function runContractInstall(
+    libraries: string[],
+    opts: ContractInstallOpts,
+    runOptions: ContractInstallRunOptions = {},
+): Promise<ContractInstallRunResult> {
+    const rootDir = resolve(opts.rootDir ?? process.cwd());
     const cdmResult = readCdmJson(rootDir);
     const cdmJson = cdmResult?.cdmJson ?? { dependencies: {}, contracts: {} };
     assertSupportedCdmJson(cdmJson, cdmResult?.cdmJsonPath);
     const target = resolveContractInstallTarget(opts, cdmJson);
     const requests = installRequestsFromArgs(libraries, cdmJson);
+    const useUi = runOptions.useUi ?? true;
 
     let client: Awaited<ReturnType<typeof createCdmAssetHubClient>> | null = null;
     const cleanupOnce = (() => {
@@ -431,26 +514,38 @@ async function runContractInstall(libraries: string[], opts: ContractInstallOpts
                 client.descriptors.assetHub,
                 target.registryAddress,
                 CONTRACTS_REGISTRY_ABI,
-                { defaultOrigin: REGISTRY_QUERY_ORIGIN_SS58 },
+                {
+                    defaultOrigin: resolveQueryOrigin({
+                        chainName: target.chainName,
+                        assethubUrl: target.assethubUrl,
+                    }),
+                },
             ),
         );
         const ipfs = connectIpfsGateway(target.ipfsGatewayUrl);
 
-        const result = await runContractInstallWithUI({
-            libraries: requests,
-            registry,
-            ipfs,
-            registryAddress: target.registryAddress,
-            assethubUrl: target.assethubUrl,
-            ipfsGatewayUrl: target.ipfsGatewayUrl,
-        });
+        const result: ContractInstallRunResult = useUi
+            ? await runContractInstallWithUI({
+                  libraries: requests,
+                  registry,
+                  ipfs,
+                  registryAddress: target.registryAddress,
+                  assethubUrl: target.assethubUrl,
+                  ipfsGatewayUrl: target.ipfsGatewayUrl,
+              })
+            : await installContracts({
+                  libraries: requests,
+                  registry,
+                  ipfs,
+                  onEvent: runOptions.onInstallEvent,
+              }).then((summary) => ({ summary, success: summary.success }));
 
         updateCdmJsonAfterInstall(cdmJson, target, requests, result.summary.results);
         writeCdmJson(cdmJson, rootDir);
         if (result.summary.results.length > 0) {
             runPostInstallHooks(rootDir, cdmJson);
         }
-        if (!result.success) process.exitCode = 1;
+        return result;
     } finally {
         cleanupOnce();
     }
@@ -470,7 +565,9 @@ function makeDeployCommand(): Command {
         .option("--features <features>", "Cargo feature flags to pass to the build")
         .action(async (opts: ContractDeployOpts) =>
             runCliCommand("contract", { watchdog: true, hardExit: true }, () =>
-                runContractDeploy(opts),
+                runContractDeploy(opts).then((result) => {
+                    if (!result.success) process.exitCode = 1;
+                }),
             ),
         );
 }
@@ -489,7 +586,9 @@ function makeInstallCommand(): Command {
         .option("--registry-address <address>", "Registry contract address")
         .action(async (libraries: string[], opts: ContractInstallOpts) =>
             runCliCommand("contract", { watchdog: true, hardExit: true }, () =>
-                runContractInstall(libraries, opts),
+                runContractInstall(libraries, opts).then((result) => {
+                    if (!result.success) process.exitCode = 1;
+                }),
             ),
         );
 }

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -18,6 +18,7 @@ import { dirname, resolve } from "node:path";
 import { generateContractTypes, generateContractsAugmentation } from "@parity/cdm-codegen";
 import {
     CONTRACTS_REGISTRY_ABI,
+    detectBuildOrder,
     deployContracts,
     generateSolidityImport,
     hasBuildableSolidityProject,
@@ -68,6 +69,7 @@ import { runContractDeployWithUI } from "./contractDeployUi.js";
 import { runContractInstallWithUI } from "./contractInstallUi.js";
 
 const CDM_INCLUDE = ".cdm/**/*";
+const ZERO_H160 = "0x0000000000000000000000000000000000000000";
 
 export interface ContractDeployOpts {
     /** Project root. Internal callers set this; the standalone command defaults to cwd. */
@@ -132,6 +134,12 @@ interface ContractInstallTarget {
 }
 
 type ContractChainClient = PipelineChainClient & { destroy(): void };
+
+export interface CdmPackageOwnershipConflict {
+    packageName: string;
+    owner: HexString;
+    caller: HexString;
+}
 
 function assertHexAddress(value: string, label: string): HexString {
     if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
@@ -235,6 +243,111 @@ export function resolveContractInstallTarget(
     };
 }
 
+function normalizeH160(value: unknown): HexString | null {
+    if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(value)) return null;
+    return value.toLowerCase() as HexString;
+}
+
+export function findForeignOwnedCdmPackages(
+    packages: { packageName: string; versionCount: number; owner: HexString | null }[],
+    caller: HexString,
+): CdmPackageOwnershipConflict[] {
+    const callerLower = caller.toLowerCase();
+    return packages
+        .filter((pkg) => pkg.versionCount > 0)
+        .filter((pkg) => pkg.owner !== null && pkg.owner.toLowerCase() !== ZERO_H160)
+        .filter((pkg) => pkg.owner!.toLowerCase() !== callerLower)
+        .map((pkg) => ({
+            packageName: pkg.packageName,
+            owner: pkg.owner!,
+            caller,
+        }));
+}
+
+export function formatCdmPackageOwnershipConflicts(
+    conflicts: CdmPackageOwnershipConflict[],
+): string {
+    if (conflicts.length === 1) {
+        const conflict = conflicts[0];
+        return (
+            `CDM package "${conflict.packageName}" is already owned by ${conflict.owner}, ` +
+            `but the selected signer maps to ${conflict.caller}. Update the contract Cargo.toml ` +
+            `[package.metadata.cdm] package = "..." value to a package name you own, or ` +
+            `deploy with the owner account.`
+        );
+    }
+    return (
+        `Some CDM packages are already owned by another account, but the selected signer maps to ${conflicts[0]?.caller}: ` +
+        conflicts
+            .map((conflict) => `${conflict.packageName} owned by ${conflict.owner}`)
+            .join("; ") +
+        `. Update each contract Cargo.toml [package.metadata.cdm] package = "..." value to package names you own, ` +
+        `or deploy with the owner account.`
+    );
+}
+
+async function assertCdmPackageOwnership({
+    rootDir,
+    client,
+    registryAddress,
+    origin,
+}: {
+    rootDir: string;
+    client: ContractChainClient;
+    registryAddress: HexString;
+    origin: SS58String;
+}): Promise<void> {
+    const detected = detectBuildOrder(rootDir);
+    const packageNames = [
+        ...new Set(
+            detected.contracts
+                .map((contract) => contract.cdmPackage)
+                .filter((pkg): pkg is string => Boolean(pkg)),
+        ),
+    ];
+    if (packageNames.length === 0) return;
+
+    const caller = normalizeH160(await client.assetHub.apis.ReviveApi.address(origin));
+    if (!caller) {
+        throw new Error(`Could not resolve Revive H160 address for ${origin}`);
+    }
+
+    const registry = suppressReviveTraceNoise(
+        await createContractFromClient(
+            client.raw.assetHub,
+            client.descriptors.assetHub,
+            registryAddress,
+            CONTRACTS_REGISTRY_ABI,
+            { defaultOrigin: origin },
+        ),
+    );
+
+    const ownership = await Promise.all(
+        packageNames.map(async (packageName) => {
+            const [versionResult, ownerResult] = await Promise.all([
+                registry.getVersionCount.query(packageName),
+                registry.getOwner.query(packageName),
+            ]);
+            if (!versionResult.success || typeof versionResult.value !== "number") {
+                throw new Error(`Failed to query registry version count for "${packageName}"`);
+            }
+            if (!ownerResult.success) {
+                throw new Error(`Failed to query registry owner for "${packageName}"`);
+            }
+            return {
+                packageName,
+                versionCount: versionResult.value,
+                owner: normalizeH160(ownerResult.value),
+            };
+        }),
+    );
+
+    const conflicts = findForeignOwnedCdmPackages(ownership, caller);
+    if (conflicts.length > 0) {
+        throw new Error(formatCdmPackageOwnershipConflicts(conflicts));
+    }
+}
+
 async function createContractChainClient(
     target: ContractDeployTarget,
 ): Promise<ContractChainClient> {
@@ -307,10 +420,16 @@ export async function runContractDeploy(
 
     try {
         signer ??= await resolveSigner(resolveContractSignerOptions(opts));
+        client = await createContractChainClient(target);
+        await assertCdmPackageOwnership({
+            rootDir,
+            client,
+            registryAddress: target.registryAddress,
+            origin: signer.address as SS58String,
+        });
         await ensureSmartContractAllowance({
             deploySigner: signer,
         });
-        client = await createContractChainClient(target);
         const metadataSigner = await getBulletinAllowanceSigner({
             publishSigner: signer,
             // client.bulletin is the same runtime bulletin API but nominally a

--- a/src/commands/contractDeployUi.tsx
+++ b/src/commands/contractDeployUi.tsx
@@ -57,6 +57,11 @@ export interface ContractDeployUiResult {
     success: boolean;
 }
 
+export interface ContractDeployDisplay {
+    crates: string[];
+    displayNames: Map<string, string>;
+}
+
 export async function runContractDeployWithUI(
     opts: ContractDeployUiOptions,
 ): Promise<ContractDeployUiResult> {
@@ -68,7 +73,10 @@ export async function runContractDeployWithUI(
         signerRequiresApproval = false,
         ...deployOpts
     } = opts;
-    const { crates, displayNames } = precomputeDisplay(deployOpts.rootDir, deployOpts.contracts);
+    const { crates, displayNames } = precomputeContractDeployDisplay(
+        deployOpts.rootDir,
+        deployOpts.contracts,
+    );
     const adapter = new ContractPipelineStatusAdapter({
         onCdmPackageDetected: (crate, pkg) => displayNames.set(crate, pkg),
     });
@@ -112,7 +120,10 @@ export async function runContractDeployWithUI(
     };
 }
 
-function precomputeDisplay(rootDir: string, contracts: string[] | undefined) {
+export function precomputeContractDeployDisplay(
+    rootDir: string,
+    contracts: string[] | undefined,
+): ContractDeployDisplay {
     const order = detectBuildOrder(rootDir, contracts);
     const displayNames = new Map<string, string>();
     for (const contract of order.contracts) {
@@ -143,13 +154,6 @@ function ContractDeployScreen({
     bulletinUrl: string;
     ipfsGatewayUrl: string;
 }) {
-    const [tick, setTick] = useState(0);
-
-    useEffect(() => {
-        const timer = setInterval(() => setTick((current) => current + 1), TIMING.spinnerMs);
-        return () => clearInterval(timer);
-    }, []);
-
     return (
         <Box flexDirection="column">
             <Header
@@ -162,28 +166,59 @@ function ContractDeployScreen({
                 <Row label="signer" value={signerAddress} tone="muted" />
                 <Row label="registry" value={registryAddress} tone="muted" />
             </Section>
-            <Box flexDirection="column">
-                {adapter.signingPrompt && (
-                    <PhoneApprovalCallout
-                        step={adapter.signingPrompt.step}
-                        label={adapter.signingPrompt.label}
-                    />
-                )}
-                {adapter.signingError && (
-                    <Callout tone="danger" title="Signing Failed">
-                        <Text>{adapter.signingError}</Text>
-                    </Callout>
-                )}
-                <DeployTable
-                    statuses={adapter.statuses}
-                    displayNames={displayNames}
-                    crates={crates.length > 0 ? crates : adapter.crates}
-                    logLines={adapter.logLines}
-                    assethubUrl={assethubUrl}
-                    ipfsGatewayUrl={ipfsGatewayUrl}
-                    tick={tick}
+            <ContractDeployStatusView
+                adapter={adapter}
+                crates={crates}
+                displayNames={displayNames}
+                assethubUrl={assethubUrl}
+                ipfsGatewayUrl={ipfsGatewayUrl}
+            />
+        </Box>
+    );
+}
+
+export function ContractDeployStatusView({
+    adapter,
+    crates,
+    displayNames,
+    assethubUrl,
+    ipfsGatewayUrl,
+}: {
+    adapter: ContractPipelineStatusAdapter;
+    crates: string[];
+    displayNames: Map<string, string>;
+    assethubUrl: string;
+    ipfsGatewayUrl: string;
+}) {
+    const [tick, setTick] = useState(0);
+
+    useEffect(() => {
+        const timer = setInterval(() => setTick((current) => current + 1), TIMING.spinnerMs);
+        return () => clearInterval(timer);
+    }, []);
+
+    return (
+        <Box flexDirection="column">
+            {adapter.signingPrompt && (
+                <PhoneApprovalCallout
+                    step={adapter.signingPrompt.step}
+                    label={adapter.signingPrompt.label}
                 />
-            </Box>
+            )}
+            {adapter.signingError && (
+                <Callout tone="danger" title="Signing Failed">
+                    <Text>{adapter.signingError}</Text>
+                </Callout>
+            )}
+            <DeployTable
+                statuses={adapter.statuses}
+                displayNames={displayNames}
+                crates={crates.length > 0 ? crates : adapter.crates}
+                logLines={adapter.logLines}
+                assethubUrl={assethubUrl}
+                ipfsGatewayUrl={ipfsGatewayUrl}
+                tick={tick}
+            />
         </Box>
     );
 }

--- a/src/commands/contractInstallUi.tsx
+++ b/src/commands/contractInstallUi.tsx
@@ -33,7 +33,7 @@ const COL_ADDRESS = 14;
 
 type InstallState = "waiting" | "querying" | "fetching" | "done" | "error";
 
-interface InstallStatus {
+export interface InstallStatus {
     library: string;
     state: InstallState;
     error?: string;
@@ -54,10 +54,10 @@ export interface ContractInstallUiResult {
     success: boolean;
 }
 
-class ContractInstallStatusAdapter {
+export class ContractInstallStatusAdapter {
     readonly statuses = new Map<string, InstallStatus>();
 
-    constructor(libraries: string[]) {
+    constructor(libraries: string[] = []) {
         for (const library of libraries) {
             this.statuses.set(library, { library, state: "waiting" });
         }
@@ -148,13 +148,6 @@ function ContractInstallScreen({
     assethubUrl: string;
     ipfsGatewayUrl: string;
 }) {
-    const [tick, setTick] = useState(0);
-
-    useEffect(() => {
-        const timer = setInterval(() => setTick((current) => current + 1), TIMING.spinnerMs);
-        return () => clearInterval(timer);
-    }, []);
-
     return (
         <Box flexDirection="column">
             <Header
@@ -168,13 +161,38 @@ function ContractInstallScreen({
                 <Row label="registry" value={registryAddress} tone="muted" />
                 <Row label="gateway" value={ipfsGatewayUrl} tone="muted" />
             </Section>
-            <InstallTable
-                statuses={adapter.statuses}
+            <ContractInstallStatusView
+                adapter={adapter}
                 libraries={libraries}
                 ipfsGatewayUrl={ipfsGatewayUrl}
-                tick={tick}
             />
         </Box>
+    );
+}
+
+export function ContractInstallStatusView({
+    adapter,
+    libraries,
+    ipfsGatewayUrl,
+}: {
+    adapter: ContractInstallStatusAdapter;
+    libraries: string[];
+    ipfsGatewayUrl: string;
+}) {
+    const [tick, setTick] = useState(0);
+
+    useEffect(() => {
+        const timer = setInterval(() => setTick((current) => current + 1), TIMING.spinnerMs);
+        return () => clearInterval(timer);
+    }, []);
+
+    return (
+        <InstallTable
+            statuses={adapter.statuses}
+            libraries={libraries}
+            ipfsGatewayUrl={ipfsGatewayUrl}
+            tick={tick}
+        />
     );
 }
 
@@ -189,7 +207,11 @@ function InstallTable({
     ipfsGatewayUrl: string;
     tick: number;
 }) {
-    const errors = libraries
+    const rowLibraries = [
+        ...libraries,
+        ...Array.from(statuses.keys()).filter((library) => !libraries.includes(library)),
+    ];
+    const errors = rowLibraries
         .map((library) => statuses.get(library))
         .filter((status): status is InstallStatus & { error: string } =>
             Boolean(status?.state === "error" && status.error),
@@ -198,7 +220,7 @@ function InstallTable({
     return (
         <Box flexDirection="column" marginTop={1}>
             <HeaderRow />
-            {libraries.map((library) => (
+            {rowLibraries.map((library) => (
                 <InstallRow
                     key={library}
                     library={library}

--- a/src/commands/deploy/DeployScreen.test.ts
+++ b/src/commands/deploy/DeployScreen.test.ts
@@ -22,6 +22,7 @@ describe("pickNextStage", () => {
             pickNextStage(
                 false,
                 "phone",
+                true,
                 "dist",
                 "tw33d3r.dot",
                 true,
@@ -32,8 +33,14 @@ describe("pickNextStage", () => {
     });
 
     it("enters moddable preflight when moddable is true and no repository URL is resolved yet", () => {
-        expect(pickNextStage(false, "phone", "dist", "tw33d3r.dot", true, true, null)).toEqual({
-            kind: "moddable-preflight",
+        expect(
+            pickNextStage(false, "phone", true, "dist", "tw33d3r.dot", true, true, null),
+        ).toEqual({ kind: "moddable-preflight" });
+    });
+
+    it("asks whether to deploy contracts after signer selection", () => {
+        expect(pickNextStage(false, "phone", null, null, null, null, null, null)).toEqual({
+            kind: "prompt-contracts",
         });
     });
 });

--- a/src/commands/deploy/DeployScreen.test.ts
+++ b/src/commands/deploy/DeployScreen.test.ts
@@ -38,9 +38,15 @@ describe("pickNextStage", () => {
         ).toEqual({ kind: "moddable-preflight" });
     });
 
-    it("asks whether to deploy contracts after signer selection", () => {
-        expect(pickNextStage(false, "phone", null, null, null, null, null, null)).toEqual({
+    it("asks whether contracts changed before the frontend build choice", () => {
+        expect(pickNextStage(null, null, null, null, null, null, null, null)).toEqual({
             kind: "prompt-contracts",
+        });
+    });
+
+    it("skips the frontend build prompt when contracts will be deployed", () => {
+        expect(pickNextStage(null, null, true, null, null, null, null, null)).toEqual({
+            kind: "prompt-signer",
         });
     });
 });

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -55,11 +55,14 @@ import {
     type StepStatus,
 } from "./runningState.js";
 import type { ResolvedSigner } from "../../utils/signer.js";
-import { DEFAULT_BUILD_DIR, getNetworkLabel } from "../../config.js";
+import { DEFAULT_BUILD_DIR, getChainConfig, getNetworkLabel } from "../../config.js";
 import { VERSION_LABEL } from "../../utils/version.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
 import { validateDomainLabel } from "../../utils/deploy/dotnsRules.js";
 import { NO_SESSION_NOTICE_TITLE, NO_SESSION_NOTICE_BODY } from "./signerNotice.js";
+import { ContractPipelineStatusAdapter } from "../contractPipelineStatus.js";
+import { ContractDeployStatusView, precomputeContractDeployDisplay } from "../contractDeployUi.js";
+import { ContractInstallStatusAdapter, ContractInstallStatusView } from "../contractInstallUi.js";
 
 export interface DeployScreenInputs {
     projectDir: string;
@@ -809,21 +812,6 @@ function stepMark(status: StepStatus): MarkKind {
     }
 }
 
-interface ContractSectionState {
-    deployStatus: StepStatus;
-    installStatus: StepStatus;
-    latestLog: string | null;
-    error?: string;
-}
-
-function initialContractState(enabled: boolean): ContractSectionState {
-    return {
-        deployStatus: enabled ? "pending" : "skipped",
-        installStatus: enabled ? "pending" : "skipped",
-        latestLog: null,
-    };
-}
-
 function RunningStage({
     projectDir,
     inputs,
@@ -851,9 +839,27 @@ function RunningStage({
     );
     const frontendState = runningState.frontend;
     const playgroundState = runningState.playground;
-    const [contractState, setContractState] = useState<ContractSectionState>(() =>
-        initialContractState(inputs.deployContracts),
+    const [activeView, setActiveView] = useState<"contracts" | "frontend">(
+        inputs.deployContracts ? "contracts" : "frontend",
     );
+    const chainConfig = useMemo(() => getChainConfig(), []);
+    const contractDeployDisplay = useMemo(() => {
+        if (!inputs.deployContracts) return { crates: [], displayNames: new Map<string, string>() };
+        try {
+            return precomputeContractDeployDisplay(projectDir, undefined);
+        } catch {
+            return { crates: [], displayNames: new Map<string, string>() };
+        }
+    }, [inputs.deployContracts, projectDir]);
+    const [contractDeployAdapter] = useState(
+        () =>
+            new ContractPipelineStatusAdapter({
+                onCdmPackageDetected: (crate, pkg) =>
+                    contractDeployDisplay.displayNames.set(crate, pkg),
+            }),
+    );
+    const [contractInstallAdapter] = useState(() => new ContractInstallStatusAdapter());
+    const [contractInstallLibraries, setContractInstallLibraries] = useState<string[]>([]);
     const [signingPrompt, setSigningPrompt] = useState<SigningEvent | null>(null);
     // Heads-up rendered from the moment the run starts until the first real
     // sign-request arrives — once the PhoneApprovalCallout takes over, the
@@ -871,8 +877,6 @@ function RunningStage({
     const INFO_MAX_LEN = 160;
     const frontendPendingRef = useRef<string | null>(null);
     const frontendTimerRef = useRef<NodeJS.Timeout | null>(null);
-    const contractPendingRef = useRef<string | null>(null);
-    const contractTimerRef = useRef<NodeJS.Timeout | null>(null);
     const queueFrontendLog = (line: string) => {
         const truncated = line.length > INFO_MAX_LEN ? `${line.slice(0, INFO_MAX_LEN - 1)}…` : line;
         frontendPendingRef.current = truncated;
@@ -887,20 +891,6 @@ function RunningStage({
                     }));
                 }
                 frontendTimerRef.current = null;
-            }, INFO_THROTTLE_MS);
-        }
-    };
-    const queueContractLog = (line: string) => {
-        const truncated = line.length > INFO_MAX_LEN ? `${line.slice(0, INFO_MAX_LEN - 1)}…` : line;
-        contractPendingRef.current = truncated;
-        if (contractTimerRef.current === null) {
-            contractTimerRef.current = setTimeout(() => {
-                if (contractPendingRef.current !== null) {
-                    const v = contractPendingRef.current;
-                    contractPendingRef.current = null;
-                    setContractState((s) => ({ ...s, latestLog: v }));
-                }
-                contractTimerRef.current = null;
             }, INFO_THROTTLE_MS);
         }
     };
@@ -920,13 +910,9 @@ function RunningStage({
             try {
                 if (inputs.deployContracts) {
                     runningContracts = true;
-                    setContractState({
-                        deployStatus: "running",
-                        installStatus: "pending",
-                        latestLog: "starting contract deploy",
-                    });
+                    setActiveView("contracts");
                     const { runContractsBeforeFrontend } = await import("./contracts.js");
-                    const result = await runContractsBeforeFrontend({
+                    await runContractsBeforeFrontend({
                         projectDir,
                         mode: inputs.mode,
                         suri,
@@ -937,14 +923,7 @@ function RunningStage({
                     });
                     runningContracts = false;
                     if (cancelled) return;
-                    setContractState({
-                        deployStatus: "complete",
-                        installStatus: "complete",
-                        latestLog:
-                            result.installedLibraries.length > 0
-                                ? `installed ${result.installedLibraries.join(", ")}`
-                                : "installed cdm dependencies",
-                    });
+                    setActiveView("frontend");
                 }
 
                 const { runDeploy } = await import("../../utils/deploy/run.js");
@@ -971,18 +950,7 @@ function RunningStage({
             } catch (err) {
                 if (!cancelled) {
                     const message = err instanceof Error ? err.message : String(err);
-                    if (runningContracts) {
-                        setContractState((s) => {
-                            const installFailed = s.deployStatus === "complete";
-                            return {
-                                ...s,
-                                deployStatus: installFailed ? s.deployStatus : "error",
-                                installStatus: installFailed ? "error" : "skipped",
-                                error: message,
-                                latestLog: message,
-                            };
-                        });
-                    }
+                    if (runningContracts) contractDeployAdapter.signingError ??= message;
                     setShowPhoneNotice(false);
                     onError(message);
                 }
@@ -990,6 +958,11 @@ function RunningStage({
         })();
 
         function handleSigningEvent(event: SigningEvent) {
+            if (runningContracts) {
+                if (event.kind === "sign-request") setShowPhoneNotice(false);
+                contractDeployAdapter.handleSigningEvent(event);
+                return;
+            }
             if (event.kind === "sign-request") {
                 setShowPhoneNotice(false);
                 setSigningPrompt(event);
@@ -1001,88 +974,15 @@ function RunningStage({
         }
 
         function handleContractDeployEvent(event: ContractDeployEvent) {
-            if (event.type === "detect") {
-                setContractState((s) => ({ ...s, deployStatus: "running" }));
-                queueContractLog(
-                    event.contracts.length === 1
-                        ? "1 contract detected"
-                        : `${event.contracts.length} contracts detected`,
-                );
-            } else if (event.type === "log") {
-                queueContractLog(event.line);
-            } else if (event.type === "build-start") {
-                queueContractLog(`building ${event.crate}`);
-            } else if (event.type === "build-done") {
-                queueContractLog(`built ${event.crate}`);
-            } else if (event.type === "phase") {
-                queueContractLog(event.description);
-            } else if (event.type === "deploy-register-start") {
-                queueContractLog(`registering ${event.crates.join(", ")}`);
-            } else if (event.type === "deploy-register-done") {
-                queueContractLog(`registered ${Object.keys(event.addresses).join(", ")}`);
-            } else if (event.type === "publish-done") {
-                queueContractLog(`published metadata for ${Object.keys(event.cids).join(", ")}`);
-            } else if (event.type === "pipeline-done") {
-                const failed = event.summary.contracts.find(
-                    (contract) => contract.status === "error",
-                );
-                if (failed) {
-                    const message = `${failed.cdmPackage ?? failed.crate}: ${failed.error ?? "error"}`;
-                    setContractState((s) => ({
-                        ...s,
-                        deployStatus: "error",
-                        installStatus: "skipped",
-                        error: message,
-                        latestLog: message,
-                    }));
-                } else {
-                    setContractState((s) => ({ ...s, deployStatus: "complete" }));
-                    queueContractLog("contract deploy complete");
-                }
-            } else if (
-                event.type === "build-error" ||
-                event.type === "deploy-register-error" ||
-                event.type === "pipeline-error"
-            ) {
-                const message = event.error;
-                setContractState((s) => ({
-                    ...s,
-                    deployStatus: "error",
-                    installStatus: "skipped",
-                    error: message,
-                    latestLog: message,
-                }));
-            }
+            contractDeployAdapter.handleDeployEvent(event);
         }
 
         function handleContractInstallEvent(event: ContractInstallEvent) {
-            if (event.type === "install-start") {
-                setContractState((s) => ({
-                    ...s,
-                    deployStatus: "complete",
-                    installStatus: "running",
-                }));
-                queueContractLog(`installing ${event.library}`);
-            } else if (event.type === "query-start") {
-                queueContractLog(`querying ${event.library}`);
-            } else if (event.type === "fetch-start") {
-                queueContractLog(`fetching metadata for ${event.library}`);
-            } else if (event.type === "install-done") {
-                queueContractLog(`installed ${event.library} v${event.result.version}`);
-            } else if (event.type === "pipeline-done") {
-                setContractState((s) => ({
-                    ...s,
-                    installStatus: event.summary.success ? "complete" : "error",
-                    error: event.summary.success ? undefined : "contract install failed",
-                }));
-            } else if (event.type === "install-error" || event.type === "pipeline-error") {
-                const message = event.error;
-                setContractState((s) => ({
-                    ...s,
-                    installStatus: "error",
-                    error: message,
-                    latestLog: message,
-                }));
+            contractInstallAdapter.handleEvent(event);
+            if ("library" in event) {
+                setContractInstallLibraries((libraries) =>
+                    libraries.includes(event.library) ? libraries : [...libraries, event.library],
+                );
             }
         }
 
@@ -1126,13 +1026,11 @@ function RunningStage({
                 clearTimeout(frontendTimerRef.current);
                 frontendTimerRef.current = null;
             }
-            if (contractTimerRef.current !== null) {
-                clearTimeout(contractTimerRef.current);
-                contractTimerRef.current = null;
-            }
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    const showContractView = inputs.deployContracts && activeView === "contracts";
 
     return (
         <Box flexDirection="column">
@@ -1141,42 +1039,52 @@ function RunningStage({
                     <Text>This deploy may ask you to approve transactions in your mobile app.</Text>
                 </Callout>
             )}
-            {inputs.deployContracts && <ContractSectionView state={contractState} />}
-            <FrontendSectionView state={frontendState} />
-            {playgroundState.status !== "skipped" && (
-                <Box marginTop={1}>
-                    <Row
-                        mark={stepMark(playgroundState.status)}
-                        label="publish to playground"
-                        tone={playgroundState.status === "error" ? "danger" : "muted"}
-                    />
+            {showContractView ? (
+                <Box flexDirection="column">
+                    <Section
+                        title="contract deploy"
+                        gapBelow={contractInstallLibraries.length === 0}
+                    >
+                        <ContractDeployStatusView
+                            adapter={contractDeployAdapter}
+                            crates={contractDeployDisplay.crates}
+                            displayNames={contractDeployDisplay.displayNames}
+                            assethubUrl={chainConfig.assetHubRpc}
+                            ipfsGatewayUrl={chainConfig.bulletinGateway}
+                        />
+                    </Section>
+                    {contractInstallLibraries.length > 0 && (
+                        <Section title="contract install" gapBelow={false}>
+                            <ContractInstallStatusView
+                                adapter={contractInstallAdapter}
+                                libraries={contractInstallLibraries}
+                                ipfsGatewayUrl={chainConfig.bulletinGateway}
+                            />
+                        </Section>
+                    )}
                 </Box>
-            )}
+            ) : (
+                <>
+                    <FrontendSectionView state={frontendState} />
+                    {playgroundState.status !== "skipped" && (
+                        <Box marginTop={1}>
+                            <Row
+                                mark={stepMark(playgroundState.status)}
+                                label="publish to playground"
+                                tone={playgroundState.status === "error" ? "danger" : "muted"}
+                            />
+                        </Box>
+                    )}
 
-            {signingPrompt && signingPrompt.kind === "sign-request" && (
-                <PhoneApprovalCallout step={signingPrompt.step} label={signingPrompt.label} />
+                    {signingPrompt && signingPrompt.kind === "sign-request" && (
+                        <PhoneApprovalCallout
+                            step={signingPrompt.step}
+                            label={signingPrompt.label}
+                        />
+                    )}
+                </>
             )}
         </Box>
-    );
-}
-
-function ContractSectionView({ state }: { state: ContractSectionState }) {
-    const running = state.deployStatus === "running" || state.installStatus === "running";
-    return (
-        <Section title="contracts" gapBelow={false}>
-            <Row
-                mark={stepMark(state.deployStatus)}
-                label="deploy"
-                tone={state.deployStatus === "error" ? "danger" : "muted"}
-            />
-            <Row
-                mark={stepMark(state.installStatus)}
-                label="install"
-                tone={state.installStatus === "error" ? "danger" : "muted"}
-            />
-            {running && state.latestLog && <Hint indent={2}>{truncate(state.latestLog, 120)}</Hint>}
-            {!running && state.error && <Hint indent={2}>{truncate(state.error, 120)}</Hint>}
-        </Section>
     );
 }
 

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -15,6 +15,10 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useInput } from "ink";
+import type {
+    DeployEvent as ContractDeployEvent,
+    InstallEvent as ContractInstallEvent,
+} from "@parity/cdm-builder";
 import {
     Header,
     Row,
@@ -62,6 +66,10 @@ export interface DeployScreenInputs {
     domain: string | null;
     buildDir: string | null;
     mode: SignerMode | null;
+    /** Secret URI forwarded to the contract pre-step when deploy was invoked with --suri. */
+    suri?: string;
+    /** Pre-set from --contracts / --no-contracts. null = ask. */
+    deployContracts: boolean | null;
     publishToPlayground: boolean | null;
     /** Publish to the playground with private visibility. Not interactively prompted — set via `--private`. */
     playgroundPrivate: boolean;
@@ -75,6 +83,7 @@ export interface DeployScreenInputs {
 export type Stage =
     | { kind: "prompt-build" }
     | { kind: "prompt-signer" }
+    | { kind: "prompt-contracts" }
     | { kind: "prompt-buildDir" }
     | { kind: "prompt-domain" }
     | { kind: "validate-domain"; domain: string }
@@ -91,6 +100,7 @@ interface Resolved {
     mode: SignerMode;
     buildDir: string;
     domain: string;
+    deployContracts: boolean;
     publishToPlayground: boolean;
     skipBuild: boolean;
     moddable: boolean;
@@ -102,6 +112,8 @@ export function DeployScreen({
     domain: initialDomain,
     buildDir: initialBuildDir,
     mode: initialMode,
+    suri,
+    deployContracts: initialDeployContracts,
     publishToPlayground: initialPublish,
     playgroundPrivate,
     skipBuild: initialSkipBuild,
@@ -117,6 +129,7 @@ export function DeployScreen({
     const effectiveInitialMode: SignerMode | null =
         !hasSession && initialMode === "phone" ? null : initialMode;
     const [mode, setMode] = useState<SignerMode | null>(effectiveInitialMode);
+    const [deployContracts, setDeployContracts] = useState<boolean | null>(initialDeployContracts);
     const [buildDir, setBuildDir] = useState<string | null>(initialBuildDir);
     const [domain, setDomain] = useState<string | null>(initialDomain);
     const [publishToPlayground, setPublishToPlayground] = useState<boolean | null>(initialPublish);
@@ -132,6 +145,7 @@ export function DeployScreen({
         pickInitialStage(
             initialSkipBuild,
             effectiveInitialMode,
+            initialDeployContracts,
             initialBuildDir,
             initialDomain,
             initialPublish,
@@ -148,6 +162,7 @@ export function DeployScreen({
     const advance = (
         nextSkipBuild: boolean | null = skipBuild,
         nextMode: SignerMode | null = mode,
+        nextDeployContracts: boolean | null = deployContracts,
         nextBuildDir: string | null = buildDir,
         nextDomain: string | null = domain,
         nextPublish: boolean | null = publishToPlayground,
@@ -157,6 +172,7 @@ export function DeployScreen({
         const s = pickNextStage(
             nextSkipBuild,
             nextMode,
+            nextDeployContracts,
             nextBuildDir,
             nextDomain,
             nextPublish,
@@ -169,6 +185,7 @@ export function DeployScreen({
     const resolved = useMemo<Resolved | null>(() => {
         if (
             mode === null ||
+            deployContracts === null ||
             buildDir === null ||
             domain === null ||
             publishToPlayground === null ||
@@ -178,6 +195,7 @@ export function DeployScreen({
             return null;
         return {
             mode,
+            deployContracts,
             buildDir,
             domain,
             publishToPlayground,
@@ -185,7 +203,16 @@ export function DeployScreen({
             moddable,
             repositoryUrl,
         };
-    }, [mode, buildDir, domain, publishToPlayground, skipBuild, moddable, repositoryUrl]);
+    }, [
+        mode,
+        deployContracts,
+        buildDir,
+        domain,
+        publishToPlayground,
+        skipBuild,
+        moddable,
+        repositoryUrl,
+    ]);
 
     // Dynamic terminal tab title: subtitle becomes the domain once we know it.
     const headerSubtitle = resolved?.domain ?? domain ?? undefined;
@@ -250,13 +277,32 @@ export function DeployScreen({
                 </Box>
             )}
 
+            {stage.kind === "prompt-contracts" && (
+                <Select<boolean>
+                    label="deploy contracts before frontend?"
+                    options={[
+                        { value: false, label: "no", hint: "frontend deploy only" },
+                        {
+                            value: true,
+                            label: "yes",
+                            hint: "run contract deploy + install first",
+                        },
+                    ]}
+                    initialIndex={0}
+                    onSelect={(yes) => {
+                        setDeployContracts(yes);
+                        advance(skipBuild, mode, yes);
+                    }}
+                />
+            )}
+
             {stage.kind === "prompt-buildDir" && (
                 <Input
                     label="build directory"
                     initial={DEFAULT_BUILD_DIR}
                     onSubmit={(v) => {
                         setBuildDir(v);
-                        advance(skipBuild, mode, v);
+                        advance(skipBuild, mode, deployContracts, v);
                     }}
                 />
             )}
@@ -294,7 +340,7 @@ export function DeployScreen({
                     onAvailable={(result) => {
                         setDomain(result.fullDomain);
                         setPlan(result.plan);
-                        advance(skipBuild, mode, buildDir, result.fullDomain);
+                        advance(skipBuild, mode, deployContracts, buildDir, result.fullDomain);
                     }}
                     onUnavailable={(reason) => {
                         setDomainError(reason);
@@ -314,7 +360,15 @@ export function DeployScreen({
                     onSelect={(yes) => {
                         setPublishToPlayground(yes);
                         if (!yes) setModdable(false);
-                        advance(skipBuild, mode, buildDir, domain, yes, yes ? moddable : false);
+                        advance(
+                            skipBuild,
+                            mode,
+                            deployContracts,
+                            buildDir,
+                            domain,
+                            yes,
+                            yes ? moddable : false,
+                        );
                     }}
                 />
             )}
@@ -336,7 +390,15 @@ export function DeployScreen({
                         if (yes) {
                             setStage({ kind: "moddable-preflight" });
                         } else {
-                            advance(skipBuild, mode, buildDir, domain, publishToPlayground, false);
+                            advance(
+                                skipBuild,
+                                mode,
+                                deployContracts,
+                                buildDir,
+                                domain,
+                                publishToPlayground,
+                                false,
+                            );
                         }
                     }}
                 />
@@ -347,7 +409,16 @@ export function DeployScreen({
                     projectDir={projectDir}
                     onResolved={(url) => {
                         setRepositoryUrl(url);
-                        advance(skipBuild, mode, buildDir, domain, publishToPlayground, true, url);
+                        advance(
+                            skipBuild,
+                            mode,
+                            deployContracts,
+                            buildDir,
+                            domain,
+                            publishToPlayground,
+                            true,
+                            url,
+                        );
                     }}
                     onError={(msg) => {
                         setStage({ kind: "moddable-error", message: msg });
@@ -377,6 +448,7 @@ export function DeployScreen({
                     <RunningStage
                         projectDir={projectDir}
                         inputs={resolved}
+                        suri={suri}
                         playgroundPrivate={playgroundPrivate}
                         userSigner={userSigner}
                         plan={plan}
@@ -414,18 +486,29 @@ export function DeployScreen({
 function pickInitialStage(
     skipBuild: boolean | null,
     mode: SignerMode | null,
+    deployContracts: boolean | null,
     buildDir: string | null,
     domain: string | null,
     publish: boolean | null,
     moddable: boolean | null,
     repositoryUrl: string | null,
 ): Stage {
-    return pickNextStage(skipBuild, mode, buildDir, domain, publish, moddable, repositoryUrl);
+    return pickNextStage(
+        skipBuild,
+        mode,
+        deployContracts,
+        buildDir,
+        domain,
+        publish,
+        moddable,
+        repositoryUrl,
+    );
 }
 
 export function pickNextStage(
     skipBuild: boolean | null,
     mode: SignerMode | null,
+    deployContracts: boolean | null,
     buildDir: string | null,
     domain: string | null,
     publish: boolean | null,
@@ -434,6 +517,7 @@ export function pickNextStage(
 ): Stage {
     if (skipBuild === null) return { kind: "prompt-build" };
     if (mode === null) return { kind: "prompt-signer" };
+    if (deployContracts === null) return { kind: "prompt-contracts" };
     if (buildDir === null) return { kind: "prompt-buildDir" };
     if (domain === null) return { kind: "prompt-domain" };
     if (publish === null) return { kind: "prompt-publish" };
@@ -627,6 +711,7 @@ function ConfirmStage({
         domain: inputs.domain.replace(/\.dot$/, "") + ".dot",
         buildDir: inputs.buildDir,
         skipBuild: inputs.skipBuild,
+        deployContracts: inputs.deployContracts,
         publishToPlayground: inputs.publishToPlayground,
         moddable: inputs.moddable,
         repositoryUrl: inputs.repositoryUrl,
@@ -719,9 +804,25 @@ function stepMark(status: StepStatus): MarkKind {
     }
 }
 
+interface ContractSectionState {
+    deployStatus: StepStatus;
+    installStatus: StepStatus;
+    latestLog: string | null;
+    error?: string;
+}
+
+function initialContractState(enabled: boolean): ContractSectionState {
+    return {
+        deployStatus: enabled ? "pending" : "skipped",
+        installStatus: enabled ? "pending" : "skipped",
+        latestLog: null,
+    };
+}
+
 function RunningStage({
     projectDir,
     inputs,
+    suri,
     playgroundPrivate,
     userSigner,
     plan,
@@ -730,6 +831,7 @@ function RunningStage({
 }: {
     projectDir: string;
     inputs: Resolved;
+    suri?: string;
     playgroundPrivate: boolean;
     userSigner: ResolvedSigner | null;
     plan: DeployPlan | null;
@@ -744,6 +846,9 @@ function RunningStage({
     );
     const frontendState = runningState.frontend;
     const playgroundState = runningState.playground;
+    const [contractState, setContractState] = useState<ContractSectionState>(() =>
+        initialContractState(inputs.deployContracts),
+    );
     const [signingPrompt, setSigningPrompt] = useState<SigningEvent | null>(null);
     // Heads-up rendered from the moment the run starts until the first real
     // sign-request arrives — once the PhoneApprovalCallout takes over, the
@@ -761,6 +866,8 @@ function RunningStage({
     const INFO_MAX_LEN = 160;
     const frontendPendingRef = useRef<string | null>(null);
     const frontendTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const contractPendingRef = useRef<string | null>(null);
+    const contractTimerRef = useRef<NodeJS.Timeout | null>(null);
     const queueFrontendLog = (line: string) => {
         const truncated = line.length > INFO_MAX_LEN ? `${line.slice(0, INFO_MAX_LEN - 1)}…` : line;
         frontendPendingRef.current = truncated;
@@ -778,15 +885,63 @@ function RunningStage({
             }, INFO_THROTTLE_MS);
         }
     };
+    const queueContractLog = (line: string) => {
+        const truncated = line.length > INFO_MAX_LEN ? `${line.slice(0, INFO_MAX_LEN - 1)}…` : line;
+        contractPendingRef.current = truncated;
+        if (contractTimerRef.current === null) {
+            contractTimerRef.current = setTimeout(() => {
+                if (contractPendingRef.current !== null) {
+                    const v = contractPendingRef.current;
+                    contractPendingRef.current = null;
+                    setContractState((s) => ({ ...s, latestLog: v }));
+                }
+                contractTimerRef.current = null;
+            }, INFO_THROTTLE_MS);
+        }
+    };
 
     useEffect(() => {
         // Announce the command + target in the terminal tab on mount.
-        setWindowTitle(`playground deploy · ${inputs.domain} · building`);
+        setWindowTitle(
+            `playground deploy · ${inputs.domain} · ${
+                inputs.deployContracts ? "contracts" : "building"
+            }`,
+        );
 
         let cancelled = false;
+        let runningContracts = false;
 
         (async () => {
             try {
+                if (inputs.deployContracts) {
+                    runningContracts = true;
+                    setContractState({
+                        deployStatus: "running",
+                        installStatus: "pending",
+                        latestLog: "starting contract deploy",
+                    });
+                    const { runContractsBeforeFrontend } = await import("./contracts.js");
+                    const result = await runContractsBeforeFrontend({
+                        projectDir,
+                        mode: inputs.mode,
+                        suri,
+                        userSigner,
+                        onDeployEvent: handleContractDeployEvent,
+                        onInstallEvent: handleContractInstallEvent,
+                        onSigningEvent: handleSigningEvent,
+                    });
+                    runningContracts = false;
+                    if (cancelled) return;
+                    setContractState({
+                        deployStatus: "complete",
+                        installStatus: "complete",
+                        latestLog:
+                            result.installedLibraries.length > 0
+                                ? `installed ${result.installedLibraries.join(", ")}`
+                                : "installed cdm dependencies",
+                    });
+                }
+
                 const { runDeploy } = await import("../../utils/deploy/run.js");
                 const outcome = await runDeploy({
                     projectDir,
@@ -811,11 +966,105 @@ function RunningStage({
             } catch (err) {
                 if (!cancelled) {
                     const message = err instanceof Error ? err.message : String(err);
+                    if (runningContracts) {
+                        setContractState((s) => {
+                            const installFailed = s.deployStatus === "complete";
+                            return {
+                                ...s,
+                                deployStatus: installFailed ? s.deployStatus : "error",
+                                installStatus: installFailed ? "error" : s.installStatus,
+                                error: message,
+                                latestLog: message,
+                            };
+                        });
+                    }
                     setShowPhoneNotice(false);
                     onError(message);
                 }
             }
         })();
+
+        function handleSigningEvent(event: SigningEvent) {
+            if (event.kind === "sign-request") {
+                setShowPhoneNotice(false);
+                setSigningPrompt(event);
+            } else if (event.kind === "sign-complete") {
+                setSigningPrompt(null);
+            } else if (event.kind === "sign-error") {
+                setSigningPrompt(null);
+            }
+        }
+
+        function handleContractDeployEvent(event: ContractDeployEvent) {
+            if (event.type === "detect") {
+                setContractState((s) => ({ ...s, deployStatus: "running" }));
+                queueContractLog(
+                    event.contracts.length === 1
+                        ? "1 contract detected"
+                        : `${event.contracts.length} contracts detected`,
+                );
+            } else if (event.type === "log") {
+                queueContractLog(event.line);
+            } else if (event.type === "build-start") {
+                queueContractLog(`building ${event.crate}`);
+            } else if (event.type === "build-done") {
+                queueContractLog(`built ${event.crate}`);
+            } else if (event.type === "phase") {
+                queueContractLog(event.description);
+            } else if (event.type === "deploy-register-start") {
+                queueContractLog(`registering ${event.crates.join(", ")}`);
+            } else if (event.type === "deploy-register-done") {
+                queueContractLog(`registered ${Object.keys(event.addresses).join(", ")}`);
+            } else if (event.type === "publish-done") {
+                queueContractLog(`published metadata for ${Object.keys(event.cids).join(", ")}`);
+            } else if (event.type === "pipeline-done") {
+                setContractState((s) => ({ ...s, deployStatus: "complete" }));
+                queueContractLog("contract deploy complete");
+            } else if (
+                event.type === "build-error" ||
+                event.type === "deploy-register-error" ||
+                event.type === "pipeline-error"
+            ) {
+                const message = event.error;
+                setContractState((s) => ({
+                    ...s,
+                    deployStatus: "error",
+                    error: message,
+                    latestLog: message,
+                }));
+            }
+        }
+
+        function handleContractInstallEvent(event: ContractInstallEvent) {
+            if (event.type === "install-start") {
+                setContractState((s) => ({
+                    ...s,
+                    deployStatus: "complete",
+                    installStatus: "running",
+                }));
+                queueContractLog(`installing ${event.library}`);
+            } else if (event.type === "query-start") {
+                queueContractLog(`querying ${event.library}`);
+            } else if (event.type === "fetch-start") {
+                queueContractLog(`fetching metadata for ${event.library}`);
+            } else if (event.type === "install-done") {
+                queueContractLog(`installed ${event.library} v${event.result.version}`);
+            } else if (event.type === "pipeline-done") {
+                setContractState((s) => ({
+                    ...s,
+                    installStatus: event.summary.success ? "complete" : "error",
+                    error: event.summary.success ? undefined : "contract install failed",
+                }));
+            } else if (event.type === "install-error" || event.type === "pipeline-error") {
+                const message = event.error;
+                setContractState((s) => ({
+                    ...s,
+                    installStatus: "error",
+                    error: message,
+                    latestLog: message,
+                }));
+            }
+        }
 
         function handleEvent(event: DeployEvent) {
             setRunningState((s) => runningReducer(s, event));
@@ -844,13 +1093,8 @@ function RunningStage({
                     queueFrontendLog(event.event.message);
                 }
             } else if (event.kind === "signing") {
-                if (event.event.kind === "sign-request") {
-                    setShowPhoneNotice(false);
-                    setSigningPrompt(event.event);
-                } else if (event.event.kind === "sign-complete") {
-                    setSigningPrompt(null);
-                } else if (event.event.kind === "sign-error") {
-                    setSigningPrompt(null);
+                handleSigningEvent(event.event);
+                if (event.event.kind === "sign-error") {
                     queueFrontendLog(`signing failed: ${event.event.message}`);
                 }
             }
@@ -861,6 +1105,10 @@ function RunningStage({
             if (frontendTimerRef.current !== null) {
                 clearTimeout(frontendTimerRef.current);
                 frontendTimerRef.current = null;
+            }
+            if (contractTimerRef.current !== null) {
+                clearTimeout(contractTimerRef.current);
+                contractTimerRef.current = null;
             }
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -873,6 +1121,7 @@ function RunningStage({
                     <Text>This deploy may ask you to approve transactions in your mobile app.</Text>
                 </Callout>
             )}
+            {inputs.deployContracts && <ContractSectionView state={contractState} />}
             <FrontendSectionView state={frontendState} />
             {playgroundState.status !== "skipped" && (
                 <Box marginTop={1}>
@@ -888,6 +1137,26 @@ function RunningStage({
                 <PhoneApprovalCallout step={signingPrompt.step} label={signingPrompt.label} />
             )}
         </Box>
+    );
+}
+
+function ContractSectionView({ state }: { state: ContractSectionState }) {
+    const running = state.deployStatus === "running" || state.installStatus === "running";
+    return (
+        <Section title="contracts" gapBelow={false}>
+            <Row
+                mark={stepMark(state.deployStatus)}
+                label="deploy"
+                tone={state.deployStatus === "error" ? "danger" : "muted"}
+            />
+            <Row
+                mark={stepMark(state.installStatus)}
+                label="install"
+                tone={state.installStatus === "error" ? "danger" : "muted"}
+            />
+            {running && state.latestLog && <Hint indent={2}>{truncate(state.latestLog, 120)}</Hint>}
+            {!running && state.error && <Hint indent={2}>{truncate(state.error, 120)}</Hint>}
+        </Section>
     );
 }
 

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -977,7 +977,7 @@ function RunningStage({
                             return {
                                 ...s,
                                 deployStatus: installFailed ? s.deployStatus : "error",
-                                installStatus: installFailed ? "error" : s.installStatus,
+                                installStatus: installFailed ? "error" : "skipped",
                                 error: message,
                                 latestLog: message,
                             };
@@ -1023,8 +1023,22 @@ function RunningStage({
             } else if (event.type === "publish-done") {
                 queueContractLog(`published metadata for ${Object.keys(event.cids).join(", ")}`);
             } else if (event.type === "pipeline-done") {
-                setContractState((s) => ({ ...s, deployStatus: "complete" }));
-                queueContractLog("contract deploy complete");
+                const failed = event.summary.contracts.find(
+                    (contract) => contract.status === "error",
+                );
+                if (failed) {
+                    const message = `${failed.cdmPackage ?? failed.crate}: ${failed.error ?? "error"}`;
+                    setContractState((s) => ({
+                        ...s,
+                        deployStatus: "error",
+                        installStatus: "skipped",
+                        error: message,
+                        latestLog: message,
+                    }));
+                } else {
+                    setContractState((s) => ({ ...s, deployStatus: "complete" }));
+                    queueContractLog("contract deploy complete");
+                }
             } else if (
                 event.type === "build-error" ||
                 event.type === "deploy-register-error" ||
@@ -1034,6 +1048,7 @@ function RunningStage({
                 setContractState((s) => ({
                     ...s,
                     deployStatus: "error",
+                    installStatus: "skipped",
                     error: message,
                     latestLog: message,
                 }));

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -128,12 +128,13 @@ export function DeployScreen({
     const hasSession = userSigner?.source === "session";
     const effectiveInitialMode: SignerMode | null =
         !hasSession && initialMode === "phone" ? null : initialMode;
+    const effectiveInitialSkipBuild = initialDeployContracts === true ? false : initialSkipBuild;
     const [mode, setMode] = useState<SignerMode | null>(effectiveInitialMode);
     const [deployContracts, setDeployContracts] = useState<boolean | null>(initialDeployContracts);
     const [buildDir, setBuildDir] = useState<string | null>(initialBuildDir);
     const [domain, setDomain] = useState<string | null>(initialDomain);
     const [publishToPlayground, setPublishToPlayground] = useState<boolean | null>(initialPublish);
-    const [skipBuild, setSkipBuild] = useState<boolean | null>(initialSkipBuild);
+    const [skipBuild, setSkipBuild] = useState<boolean | null>(effectiveInitialSkipBuild);
     const [moddable, setModdable] = useState<boolean | null>(initialModdable);
     const [repositoryUrl, setRepositoryUrl] = useState<string | null>(null);
     const [domainError, setDomainError] = useState<string | null>(null);
@@ -143,7 +144,7 @@ export function DeployScreen({
     const [plan, setPlan] = useState<DeployPlan | null>(null);
     const [stage, setStage] = useState<Stage>(() =>
         pickInitialStage(
-            initialSkipBuild,
+            effectiveInitialSkipBuild,
             effectiveInitialMode,
             initialDeployContracts,
             initialBuildDir,
@@ -183,13 +184,14 @@ export function DeployScreen({
     };
 
     const resolved = useMemo<Resolved | null>(() => {
+        const effectiveSkipBuild = deployContracts === true ? false : skipBuild;
         if (
             mode === null ||
             deployContracts === null ||
             buildDir === null ||
             domain === null ||
             publishToPlayground === null ||
-            skipBuild === null ||
+            effectiveSkipBuild === null ||
             moddable === null
         )
             return null;
@@ -199,7 +201,7 @@ export function DeployScreen({
             buildDir,
             domain,
             publishToPlayground,
-            skipBuild,
+            skipBuild: effectiveSkipBuild,
             moddable,
             repositoryUrl,
         };
@@ -279,19 +281,21 @@ export function DeployScreen({
 
             {stage.kind === "prompt-contracts" && (
                 <Select<boolean>
-                    label="deploy contracts before frontend?"
+                    label="changed contracts?"
                     options={[
                         { value: false, label: "no", hint: "frontend deploy only" },
                         {
                             value: true,
                             label: "yes",
-                            hint: "run contract deploy + install first",
+                            hint: "deploy + install, then rebuild frontend",
                         },
                     ]}
                     initialIndex={0}
                     onSelect={(yes) => {
                         setDeployContracts(yes);
-                        advance(skipBuild, mode, yes);
+                        const nextSkipBuild = yes ? false : skipBuild;
+                        if (yes) setSkipBuild(false);
+                        advance(nextSkipBuild, mode, yes);
                     }}
                 />
             )}
@@ -515,9 +519,10 @@ export function pickNextStage(
     moddable: boolean | null,
     repositoryUrl: string | null,
 ): Stage {
-    if (skipBuild === null) return { kind: "prompt-build" };
-    if (mode === null) return { kind: "prompt-signer" };
     if (deployContracts === null) return { kind: "prompt-contracts" };
+    const effectiveSkipBuild = deployContracts ? false : skipBuild;
+    if (effectiveSkipBuild === null) return { kind: "prompt-build" };
+    if (mode === null) return { kind: "prompt-signer" };
     if (buildDir === null) return { kind: "prompt-buildDir" };
     if (domain === null) return { kind: "prompt-domain" };
     if (publish === null) return { kind: "prompt-publish" };

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -1030,7 +1030,7 @@ function RunningStage({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const showContractView = inputs.deployContracts && activeView === "contracts";
+    const showFrontendView = activeView === "frontend";
 
     return (
         <Box flexDirection="column">
@@ -1039,7 +1039,7 @@ function RunningStage({
                     <Text>This deploy may ask you to approve transactions in your mobile app.</Text>
                 </Callout>
             )}
-            {showContractView ? (
+            {inputs.deployContracts && (
                 <Box flexDirection="column">
                     <Section
                         title="contract deploy"
@@ -1054,7 +1054,7 @@ function RunningStage({
                         />
                     </Section>
                     {contractInstallLibraries.length > 0 && (
-                        <Section title="contract install" gapBelow={false}>
+                        <Section title="contract install" gapBelow={showFrontendView}>
                             <ContractInstallStatusView
                                 adapter={contractInstallAdapter}
                                 libraries={contractInstallLibraries}
@@ -1063,7 +1063,8 @@ function RunningStage({
                         </Section>
                     )}
                 </Box>
-            ) : (
+            )}
+            {showFrontendView && (
                 <>
                     <FrontendSectionView state={frontendState} />
                     {playgroundState.status !== "skipped" && (

--- a/src/commands/deploy/contracts.test.ts
+++ b/src/commands/deploy/contracts.test.ts
@@ -1,0 +1,46 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DeploySummary } from "@parity/cdm-builder";
+import { describe, expect, it } from "vitest";
+import { installLibrariesFromDeploySummary } from "./contracts.js";
+
+describe("installLibrariesFromDeploySummary", () => {
+    it("deduplicates successful CDM packages and skips failed contracts", () => {
+        const summary: DeploySummary = {
+            totalDurationMs: 123,
+            contracts: [
+                {
+                    crate: "counter",
+                    cdmPackage: "@example/counter",
+                    status: "done",
+                },
+                {
+                    crate: "counter-copy",
+                    cdmPackage: "@example/counter",
+                    status: "cached",
+                },
+                {
+                    crate: "broken",
+                    cdmPackage: "@example/broken",
+                    status: "error",
+                    error: "failed",
+                },
+            ],
+        };
+
+        expect(installLibrariesFromDeploySummary(summary)).toEqual(["@example/counter"]);
+    });
+});

--- a/src/commands/deploy/contracts.ts
+++ b/src/commands/deploy/contracts.ts
@@ -1,0 +1,132 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {
+    DeployEvent as ContractDeployEvent,
+    DeploySummary,
+    InstallEvent as ContractInstallEvent,
+    InstallSummary,
+} from "@parity/cdm-builder";
+import { runContractDeploy, runContractInstall } from "../contract.js";
+import type { SigningEvent } from "../../utils/deploy/signingProxy.js";
+import type { SignerMode } from "../../utils/deploy/signerMode.js";
+import type { ResolvedSigner } from "../../utils/signer.js";
+
+export interface RunContractsBeforeFrontendOptions {
+    projectDir: string;
+    mode: SignerMode;
+    suri?: string;
+    userSigner: ResolvedSigner | null;
+    onDeployEvent?: (event: ContractDeployEvent) => void;
+    onInstallEvent?: (event: ContractInstallEvent) => void;
+    onSigningEvent?: (event: SigningEvent) => void;
+}
+
+export interface RunContractsBeforeFrontendResult {
+    deploySummary: DeploySummary;
+    installSummary: InstallSummary;
+    installedLibraries: string[];
+}
+
+export function installLibrariesFromDeploySummary(summary: DeploySummary): string[] {
+    const seen = new Set<string>();
+    for (const contract of summary.contracts) {
+        if (contract.status === "error" || !contract.cdmPackage) continue;
+        seen.add(contract.cdmPackage);
+    }
+    return [...seen];
+}
+
+export async function runContractsBeforeFrontend({
+    projectDir,
+    mode,
+    suri,
+    userSigner,
+    onDeployEvent,
+    onInstallEvent,
+    onSigningEvent,
+}: RunContractsBeforeFrontendOptions): Promise<RunContractsBeforeFrontendResult> {
+    const deploy = await runContractDeploy(
+        {
+            rootDir: projectDir,
+            signer: mode,
+            suri,
+        },
+        {
+            useUi: false,
+            resolvedSigner: contractSignerOverride(mode, userSigner),
+            onDeployEvent,
+            onSigningEvent,
+        },
+    );
+    if (!deploy.success) {
+        throw new Error(formatContractErrors("Contract deploy failed", deploy.summary));
+    }
+
+    const installedLibraries = installLibrariesFromDeploySummary(deploy.summary);
+    if (deploy.summary.contracts.length > 0 && installedLibraries.length === 0) {
+        throw new Error(
+            "Contract deploy completed, but no CDM package names were registered. " +
+                'Add [package.metadata.cdm] package = "@org/name" to each deployable Cargo.toml.',
+        );
+    }
+
+    const install = await runContractInstall(
+        installedLibraries,
+        { rootDir: projectDir },
+        {
+            useUi: false,
+            onInstallEvent,
+        },
+    );
+    if (!install.success) {
+        throw new Error(formatInstallErrors("Contract install failed", install.summary));
+    }
+
+    return {
+        deploySummary: deploy.summary,
+        installSummary: install.summary,
+        installedLibraries,
+    };
+}
+
+function contractSignerOverride(
+    mode: SignerMode,
+    userSigner: ResolvedSigner | null,
+): ResolvedSigner | undefined {
+    if (mode === "phone") {
+        if (userSigner?.source !== "session") {
+            throw new Error(
+                "Phone signer requested for contract deploy, but no session is active.",
+            );
+        }
+        return userSigner;
+    }
+    return userSigner?.source === "dev" ? userSigner : undefined;
+}
+
+function formatContractErrors(prefix: string, summary: DeploySummary): string {
+    const errors = summary.contracts
+        .filter((contract) => contract.status === "error")
+        .map(
+            (contract) => `${contract.cdmPackage ?? contract.crate}: ${contract.error ?? "error"}`,
+        );
+    return errors.length === 0 ? prefix : `${prefix}: ${errors.join("; ")}`;
+}
+
+function formatInstallErrors(prefix: string, summary: InstallSummary): string {
+    const errors = summary.errors.map((entry) => `${entry.library}: ${entry.error}`);
+    return errors.length === 0 ? prefix : `${prefix}: ${errors.join("; ")}`;
+}

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { shouldResolveUserSigner } from "./index.js";
+import { isFullySpecified, shouldResolveUserSigner } from "./index.js";
 
 describe("shouldResolveUserSigner", () => {
     it("skips signer lookup for pure dev deploys", () => {
@@ -32,5 +32,26 @@ describe("shouldResolveUserSigner", () => {
 
     it("loads a signer when a suri is supplied", () => {
         expect(shouldResolveUserSigner({ mode: "dev", suri: "//Alice" })).toBe(true);
+    });
+});
+
+describe("isFullySpecified", () => {
+    const fullySpecified = {
+        signer: "phone",
+        domain: "my-app",
+        buildDir: "dist",
+        playground: true,
+    } as const;
+
+    it("keeps deploy interactive when the contracts answer is omitted", () => {
+        expect(isFullySpecified(fullySpecified)).toBe(false);
+    });
+
+    it("allows headless deploy when contracts are explicitly enabled", () => {
+        expect(isFullySpecified({ ...fullySpecified, contracts: true })).toBe(true);
+    });
+
+    it("allows headless deploy when contracts are explicitly skipped", () => {
+        expect(isFullySpecified({ ...fullySpecified, contracts: false })).toBe(true);
     });
 });

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -17,6 +17,10 @@ import React from "react";
 import { resolve } from "node:path";
 import { Command, Option } from "commander";
 import { render } from "ink";
+import type {
+    DeployEvent as ContractDeployEvent,
+    InstallEvent as ContractInstallEvent,
+} from "@parity/cdm-builder";
 import { renderSummaryText } from "./summary.js";
 import { captureWarning, errorMessage, withSpan } from "../../telemetry.js";
 import { readLoginStampMs, staleSessionWarning } from "../../utils/loginStamp.js";
@@ -37,6 +41,7 @@ import {
     type AvailabilityResult,
 } from "../../utils/deploy/availability.js";
 import type { DeployOutcome, DeployEvent } from "../../utils/deploy/run.js";
+import type { SigningEvent } from "../../utils/deploy/signingProxy.js";
 import { buildSummaryView } from "./summary.js";
 import { DEFAULT_BUILD_DIR, type Env, resolveLegacyEnv } from "../../config.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
@@ -56,6 +61,8 @@ interface DeployOpts {
      * a `--no-foo` option is declared.
      */
     build?: boolean;
+    /** Run contract deploy + install before the frontend deploy. Tri-state: undefined means prompt in TUI, false skips. */
+    contracts?: boolean;
     /** Publish the source repo so others can `dot mod` it. Commander auto-negates: `--no-moddable` ⇒ false. */
     moddable?: boolean;
     env?: Env;
@@ -74,6 +81,8 @@ export const deployCommand = new Command("deploy")
         `Directory containing build artifacts (default: ${DEFAULT_BUILD_DIR})`,
     )
     .option("--no-build", "Skip the build step and deploy existing artifacts in buildDir")
+    .option("--contracts", "Run `playground contract deploy` and install deployed packages first")
+    .option("--no-contracts", "Skip the contract deploy/install pre-step")
     .option("--playground", "Publish to the playground registry")
     .option(
         "--private",
@@ -302,6 +311,7 @@ async function runHeadless(ctx: {
     const domain = ctx.opts.domain as string;
     const buildDir = ctx.opts.buildDir as string;
     const skipBuild = ctx.opts.build === false;
+    const deployContractsBeforeFrontend = ctx.opts.contracts === true;
 
     // Phone signing needs a paired session. Headless has no TUI to fall back
     // into, so reject an explicit `--signer phone` with no session up front
@@ -375,6 +385,7 @@ async function runHeadless(ctx: {
         domain: availability.fullDomain,
         buildDir,
         skipBuild,
+        deployContracts: deployContractsBeforeFrontend,
         publishToPlayground,
         moddable,
         repositoryUrl,
@@ -393,6 +404,28 @@ async function runHeadless(ctx: {
         claimedOwnerH160: setup.claimedOwnerH160,
     });
     process.stdout.write("\n" + renderSummaryText(view) + "\n");
+
+    if (deployContractsBeforeFrontend) {
+        await withSpan(
+            "cli.deploy.contracts",
+            "contract deploy/install",
+            { "cli.deploy.mode": mode },
+            async () => {
+                process.stdout.write("\n▸ contracts deploy + install…\n");
+                const { runContractsBeforeFrontend } = await import("./contracts.js");
+                await runContractsBeforeFrontend({
+                    projectDir: ctx.projectDir,
+                    mode,
+                    suri: ctx.opts.suri,
+                    userSigner: ctx.userSigner,
+                    onDeployEvent: logHeadlessContractDeployEvent,
+                    onInstallEvent: logHeadlessContractInstallEvent,
+                    onSigningEvent: logHeadlessSigningEvent,
+                });
+                process.stdout.write("✔ contracts deploy + install\n");
+            },
+        );
+    }
 
     const outcome = await withSpan(
         "cli.deploy.orchestrator",
@@ -442,12 +475,15 @@ function runInteractive(ctx: {
                         domain: ctx.opts.domain ?? null,
                         buildDir: ctx.opts.buildDir ?? null,
                         mode: (ctx.opts.signer as SignerMode | undefined) ?? null,
+                        suri: ctx.opts.suri,
                         publishToPlayground:
                             ctx.opts.playground !== undefined ? Boolean(ctx.opts.playground) : null,
                         playgroundPrivate: Boolean(ctx.opts.private),
                         // Only pre-fill when the user explicitly asked to skip via `--no-build`;
                         // otherwise show the prompt so they can hit Enter on the default "yes".
                         skipBuild: ctx.opts.build === false ? true : null,
+                        deployContracts:
+                            ctx.opts.contracts !== undefined ? Boolean(ctx.opts.contracts) : null,
                         moddable:
                             ctx.opts.moddable === true
                                 ? true
@@ -517,6 +553,36 @@ function logHeadlessEvent(event: DeployEvent) {
         );
     } else if (event.kind === "error") {
         process.stderr.write(`  ✖ ${event.phase}: ${event.message}\n`);
+    }
+}
+
+function logHeadlessContractDeployEvent(event: ContractDeployEvent) {
+    if (event.type === "detect") {
+        process.stdout.write(`  contracts detected: ${event.contracts.length}\n`);
+    } else if (event.type === "phase") {
+        process.stdout.write(`  ${event.description}\n`);
+    } else if (event.type === "build-done") {
+        process.stdout.write(`  built ${event.crate}\n`);
+    } else if (event.type === "deploy-register-done") {
+        process.stdout.write(`  registered ${Object.keys(event.addresses).join(", ")}\n`);
+    } else if (event.type === "publish-done") {
+        process.stdout.write(`  published metadata for ${Object.keys(event.cids).join(", ")}\n`);
+    } else if (event.type === "deploy-register-error") {
+        process.stderr.write(`  ✖ ${event.crates.join(", ")}: ${event.error}\n`);
+    }
+}
+
+function logHeadlessContractInstallEvent(event: ContractInstallEvent) {
+    if (event.type === "install-done") {
+        process.stdout.write(`  installed ${event.library} v${event.result.version}\n`);
+    } else if (event.type === "install-error") {
+        process.stderr.write(`  ✖ ${event.library}: ${event.error}\n`);
+    }
+}
+
+function logHeadlessSigningEvent(event: SigningEvent) {
+    if (event.kind === "sign-request") {
+        process.stdout.write(`  approve on your phone (step ${event.step}): ${event.label}\n`);
     }
 }
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -294,12 +294,13 @@ export function shouldResolveUserSigner(opts: {
 
 // ── Dispatch ─────────────────────────────────────────────────────────────────
 
-function isFullySpecified(opts: DeployOpts): boolean {
+export function isFullySpecified(opts: DeployOpts): boolean {
     return (
         typeof opts.signer === "string" &&
         typeof opts.domain === "string" &&
         typeof opts.buildDir === "string" &&
-        typeof opts.playground === "boolean"
+        typeof opts.playground === "boolean" &&
+        typeof opts.contracts === "boolean"
     );
 }
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -81,7 +81,10 @@ export const deployCommand = new Command("deploy")
         `Directory containing build artifacts (default: ${DEFAULT_BUILD_DIR})`,
     )
     .option("--no-build", "Skip the build step and deploy existing artifacts in buildDir")
-    .option("--contracts", "Run `playground contract deploy` and install deployed packages first")
+    .option(
+        "--contracts",
+        "Use when contracts changed: deploy + install them, then rebuild the frontend",
+    )
     .option("--no-contracts", "Skip the contract deploy/install pre-step")
     .option("--playground", "Publish to the playground registry")
     .option(
@@ -310,8 +313,8 @@ async function runHeadless(ctx: {
     const publishToPlayground = Boolean(ctx.opts.playground);
     const domain = ctx.opts.domain as string;
     const buildDir = ctx.opts.buildDir as string;
-    const skipBuild = ctx.opts.build === false;
     const deployContractsBeforeFrontend = ctx.opts.contracts === true;
+    const skipBuild = deployContractsBeforeFrontend ? false : ctx.opts.build === false;
 
     // Phone signing needs a paired session. Headless has no TUI to fall back
     // into, so reject an explicit `--signer phone` with no session up front
@@ -479,9 +482,15 @@ function runInteractive(ctx: {
                         publishToPlayground:
                             ctx.opts.playground !== undefined ? Boolean(ctx.opts.playground) : null,
                         playgroundPrivate: Boolean(ctx.opts.private),
-                        // Only pre-fill when the user explicitly asked to skip via `--no-build`;
-                        // otherwise show the prompt so they can hit Enter on the default "yes".
-                        skipBuild: ctx.opts.build === false ? true : null,
+                        // Contract deploy/install changes cdm.json, so it always rebuilds the
+                        // frontend. Otherwise only pre-fill when the user explicitly asked to
+                        // skip via `--no-build`; default deploys still ask.
+                        skipBuild:
+                            ctx.opts.contracts === true
+                                ? false
+                                : ctx.opts.build === false
+                                  ? true
+                                  : null,
                         deployContracts:
                             ctx.opts.contracts !== undefined ? Boolean(ctx.opts.contracts) : null,
                         moddable:

--- a/src/commands/deploy/summary.test.ts
+++ b/src/commands/deploy/summary.test.ts
@@ -134,6 +134,21 @@ describe("buildSummaryView", () => {
         expect(skip.rows.find((r) => r.label === "Build")?.value).toBe("skip (use existing)");
     });
 
+    it("surfaces the contract pre-step when the deploy flow owns the decision", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "my-app.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            deployContracts: true,
+            publishToPlayground: false,
+            approvals: [],
+        });
+        expect(view.rows.find((r) => r.label === "Contracts")?.value).toBe(
+            "deploy + install first",
+        );
+    });
+
     it("rows stay limited to deploy-owned concerns", () => {
         const view = buildSummaryView({
             mode: "dev",

--- a/src/commands/deploy/summary.ts
+++ b/src/commands/deploy/summary.ts
@@ -26,6 +26,8 @@ export interface SummaryInputs {
     domain: string;
     buildDir: string;
     skipBuild: boolean;
+    /** Whether this deploy will run contract deploy + install before the frontend deploy. */
+    deployContracts?: boolean;
     publishToPlayground: boolean;
     moddable?: boolean;
     repositoryUrl?: string | null;
@@ -75,6 +77,14 @@ export function buildSummaryView(input: SummaryInputs): SummaryView {
         { label: "Signer", value: signerValue },
         { label: "Build", value: input.skipBuild ? "skip (use existing)" : "rebuild first" },
         { label: "Build dir", value: input.buildDir },
+        ...(input.deployContracts === undefined
+            ? []
+            : [
+                  {
+                      label: "Contracts",
+                      value: input.deployContracts ? "deploy + install first" : "skip",
+                  },
+              ]),
         {
             label: "Publish",
             value: input.publishToPlayground ? "Playground + your apps" : "DotNS only",
@@ -104,7 +114,9 @@ export function buildSummaryView(input: SummaryInputs): SummaryView {
         totalApprovals: input.approvals.length,
         approvalHint:
             input.mode === "phone"
-                ? "your phone may also ask to grant or top up the Bulletin storage allowance"
+                ? input.deployContracts
+                    ? "contract deploy and Bulletin allowance requests may add phone approvals"
+                    : "your phone may also ask to grant or top up the Bulletin storage allowance"
                 : null,
     };
 }

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -46,6 +46,7 @@ vi.mock("@parity/product-sdk-terminal/host", () => ({
 import {
     cachedBulletinSlotAuthorization,
     getBulletinAllowanceSigner,
+    getCachedBulletinAllowanceSigner,
     getBulletinSlotAuthorization,
 } from "./bulletin.js";
 
@@ -353,6 +354,71 @@ describe("getBulletinAllowanceSigner — SDK signer passthrough", () => {
         const checkedAddress = checkAuthorizationMock.mock.calls[0][1] as string;
         const { ss58Encode } = await import("@parity/product-sdk-address");
         expect(checkedAddress).toBe(ss58Encode(PUBLIC_KEY));
+    });
+});
+
+describe("getCachedBulletinAllowanceSigner", () => {
+    it("passes through the local signer for dev/SURI deploys without any SDK calls", async () => {
+        const dev = devSigner();
+
+        const signer = await getCachedBulletinAllowanceSigner({ publishSigner: dev });
+
+        expect(signer).toBe(dev.signer);
+        expect(createSlotAccountSignerMock).not.toHaveBeenCalled();
+        expect(ensureSlotAccountSignerMock).not.toHaveBeenCalled();
+        expect(requestResourceAllocationMock).not.toHaveBeenCalled();
+    });
+
+    it("fails with the init hint on a cache miss without requesting allocation", async () => {
+        createSlotAccountSignerMock.mockResolvedValue(null);
+
+        await expect(
+            getCachedBulletinAllowanceSigner({ publishSigner: sessionSigner() }),
+        ).rejects.toThrow(ENV_HINT);
+
+        expect(ensureSlotAccountSignerMock).not.toHaveBeenCalled();
+        expect(requestResourceAllocationMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the cached slot signer when authorization is usable", async () => {
+        createSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        checkAuthorizationMock.mockResolvedValue({
+            authorized: true,
+            remainingTransactions: 1,
+            remainingBytes: 100n,
+            expiration: 1,
+        });
+
+        const signer = await getCachedBulletinAllowanceSigner({
+            publishSigner: sessionSigner(),
+            bulletinApi: {} as any,
+            requiredBytes: 50,
+        });
+
+        expect(signer).toBe(SLOT_SIGNER);
+        expect(ensureSlotAccountSignerMock).not.toHaveBeenCalled();
+        expect(requestResourceAllocationMock).not.toHaveBeenCalled();
+    });
+
+    it("throws the quota error without requesting an Increase", async () => {
+        createSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
+        checkAuthorizationMock.mockResolvedValue({
+            authorized: true,
+            remainingTransactions: 0,
+            remainingBytes: 100n,
+            expiration: 1,
+        });
+
+        await expect(
+            getCachedBulletinAllowanceSigner({
+                publishSigner: sessionSigner(),
+                bulletinApi: {} as any,
+                requiredBytes: 50,
+            }),
+        ).rejects.toThrow(/does not have enough quota/);
+
+        expect(ensureSlotAccountSignerMock).not.toHaveBeenCalled();
+        expect(requestResourceAllocationMock).not.toHaveBeenCalled();
     });
 });
 

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -87,6 +87,12 @@ export interface BulletinAllowanceSignerOptions {
     onPrompt?: AllowancePrompt;
 }
 
+export interface CachedBulletinAllowanceSignerOptions {
+    publishSigner: ResolvedSigner;
+    bulletinApi?: CloudStorageApi;
+    requiredBytes?: number;
+}
+
 function hasUsableAuthorization(status: AuthorizationStatus, requiredBytes = 0): boolean {
     return (
         status.authorized &&
@@ -203,6 +209,40 @@ export async function getBulletinAllowanceSigner({
     }
 
     return slotSigner;
+}
+
+/**
+ * Resolve the cached Bulletin slot signer without issuing any mobile resource
+ * allocation request. Contract deploy uses this path so `playground init`
+ * remains the single place that grants allowances.
+ */
+export async function getCachedBulletinAllowanceSigner({
+    publishSigner,
+    bulletinApi,
+    requiredBytes,
+}: CachedBulletinAllowanceSignerOptions): Promise<PolkadotSigner> {
+    if (publishSigner.source === "dev") return publishSigner.signer;
+
+    const { adapter } = requireSession(publishSigner);
+    const slotSigner = await createSlotAccountSigner(adapter, BULLETIN_RESOURCE);
+    if (!slotSigner) {
+        throw new Error(`No cached Bulletin allowance account available. ${INIT_HINT}`);
+    }
+    if (!bulletinApi) return slotSigner;
+
+    const authorization = await getBulletinSlotAuthorization(
+        bulletinApi,
+        slotSigner,
+        requiredBytes,
+    );
+    if (authorization.usable) return slotSigner;
+
+    const { address, status } = authorization;
+    throw new Error(
+        status.authorized
+            ? `Bulletin allowance for ${address} is live but does not have enough quota. Re-run \`playground init\` and approve on your phone.`
+            : `Bulletin allowance account ${address} is not authorized on-chain yet. Re-run \`playground init\` and approve on your phone.`,
+    );
 }
 
 export function isInvalidPaymentError(err: unknown): boolean {

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { prependPath, TOOL_STEPS } from "./toolchain.js";
+import { hasCargoPvmContract, prependPath, TOOL_STEPS } from "./toolchain.js";
 
 describe("prependPath", () => {
     let originalPath: string | undefined;
@@ -62,5 +62,10 @@ describe("TOOL_STEPS", () => {
         const step = TOOL_STEPS.find((entry) => entry.name === "cargo-pvm-contract");
         expect(step?.manualHint).toContain("cargo-pvm-contract");
         expect(step?.manualHint).not.toContain("contract-dependency-manager");
+    });
+
+    it("validates cargo-pvm-contract by probing the build subcommand", () => {
+        const cargoStep = TOOL_STEPS.find((entry) => entry.name === "cargo-pvm-contract");
+        expect(cargoStep?.check).toBe(hasCargoPvmContract);
     });
 });

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -73,8 +73,14 @@ async function hasRustSrc(): Promise<boolean> {
     }
 }
 
-async function hasCargoPvmContract(): Promise<boolean> {
-    return commandExists("cargo-pvm-contract");
+export async function hasCargoPvmContract(): Promise<boolean> {
+    if (!(await commandExists("cargo-pvm-contract"))) return false;
+    try {
+        await run("cargo pvm-contract build --help");
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 function isIpfsInitialized(): boolean {
@@ -137,7 +143,7 @@ export const TOOL_STEPS: ToolStep[] = [
     },
     {
         name: "cargo-pvm-contract",
-        check: () => hasCargoPvmContract(),
+        check: hasCargoPvmContract,
         install: (onData) => runPiped(CARGO_PVM_CONTRACT_INSTALL, onData),
         manualHint: `Install cargo-pvm-contract from https://github.com/paritytech/cargo-pvm-contract at commit ${CARGO_PVM_CONTRACT_REV}`,
     },


### PR DESCRIPTION
## Summary
- Extract `pg contract deploy` and `pg contract install` into reusable runners so `pg deploy` can run the same contract workflows without shelling out to nested CLI commands.
- Add a contract pre-step to `pg deploy`:
  - interactive deploy asks `changed contracts?` before the frontend build question
  - `yes` runs contract deploy, installs the deployed CDM packages, then rebuilds the frontend
  - `no` keeps the existing frontend-only deploy path
  - headless deploys can use `--contracts` / `--no-contracts`; `--contracts` forces a frontend rebuild even if `--no-build` was also passed
- Reuse the signer/session already resolved by `pg deploy` when running the contract pre-step, so phone, dev, and `--suri` signing stay consistent across contract deploy and frontend deploy.
- Preflight CDM registry package ownership before deploy: detect all CDM packages in the build graph, query registry `getVersionCount` / `getOwner`, compare the owner against the selected signer's Revive H160 address, and fail early with guidance to update the contract `Cargo.toml` `[package.metadata.cdm] package = "..."` value or deploy with the owner account.
- Validate `cargo-pvm-contract` more strictly during `dot init`: an old/init-only binary is no longer accepted unless `cargo pvm-contract build --help` works.
- Fix the embedded contract progress UI so deploy/build failures stay on the `contracts > deploy` row and `install` is skipped instead of appearing as the failed step.

## Why
The frontend needs the freshly written `cdm.json` / generated CDM artifacts after contract changes, so the contract step has to happen before the frontend build and selecting it should always rebuild the frontend.

While testing this flow, a stale `cargo-pvm-contract v0.3.0` binary failed with `unexpected argument 'build'`. `pg contract install` still appeared to work because install only reads an existing registry entry and updates local CDM artifacts; it does not prove a new contract deploy succeeded. The stricter init check prevents that stale binary from being treated as a valid setup.

The CDM registry contract enforces package ownership with the registry caller. In the deploy+register batch, that surfaced to the CLI as a generic `Revive.ContractReverted`, which hid the actionable fix. The new preflight checks the selected signer's mapped H160 against existing registry ownership and reports package-name conflicts before asking for deploy/storage approvals.

## Implementation Notes
- Direct `pg contract deploy` / `pg contract install` still render their standalone Ink UIs.
- `pg deploy` uses the shared non-UI runners and renders a compact embedded contract status section before the existing frontend deploy status.
- Ownership preflight dedupes CDM package names from `detectBuildOrder`; unregistered packages and packages already owned by the selected signer pass.
- Multiple package conflicts are reported together, including each package name and owner, with guidance to update each contract `Cargo.toml` `[package.metadata.cdm] package = "..."` value or deploy with the owner account.
- Contract deploy/install event handling is intentionally compact in the embedded deploy screen; the richer per-contract table remains in the standalone contract commands.
- `@parity/cdm-*` package pins are unchanged in this PR. The available `@parity/cdm-builder` `3.1.4 -> 3.1.5` diff was environment placeholder metadata, not a deploy/install API change needed for this flow.

## Verification
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm vitest run src/commands/contract.test.ts` - 23 tests passed
- `pnpm test` - 663 tests passed
- `pnpm build`
