### PR TITLE
chore(cdm): sync @w3s/playground-registry snapshot to v6

### DIFF
--- a/.changeset/sync-registry-snapshot-v6.md
+++ b/.changeset/sync-registry-snapshot-v6.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Refresh the bundled `@w3s/playground-registry` contract manifest from the CDM meta-registry, syncing the committed `cdm.json` snapshot to the current on-chain deployment (generation 6, `0x82db2A7013ee5bDC69e12CC998dDb3A3eca1Ce4F`). The ABI is byte-identical to the previous generation and the CLI already resolves the registry address live from the meta-registry at runtime, so this is a snapshot-honesty update with no behavioral change.

--- a/cdm.json
+++ b/cdm.json
@@ -5,8 +5,8 @@
   },
   "contracts": {
     "@w3s/playground-registry": {
-      "version": 3,
-      "address": "0x9938255f40485B25641C9bc263aa8E0bAE8c202d",
+      "version": 6,
+      "address": "0x82db2A7013ee5bDC69e12CC998dDb3A3eca1Ce4F",
       "abi": [
         {
           "type": "constructor",
@@ -1133,7 +1133,7 @@
           "stateMutability": "view"
         }
       ],
-      "metadataCid": "bafk2bzaceafacjrrftyijid6r3hvk54mhpdsoizrj6lxvmqfba5ufndlk2w6o"
+      "metadataCid": "bafk2bzacedzwo2736o7g4j5epc752vf7vw5dfhec3yhtxwatc53pj4xcpfemy"
     }
   }
 }


### PR DESCRIPTION
## What

Refresh the committed `cdm.json` snapshot of `@w3s/playground-registry` from the CDM meta-registry, moving it from generation **v3** (`0x9938255f…2F75`) to the current on-chain generation **v6** (`0x82db2A7013ee5bDC69e12CC998dDb3A3eca1Ce4F`). Also updates the recorded `metadataCid`.

## Why it's safe / a no-op functionally

- The CLI resolves the registry address **live** from the meta-registry at runtime (`src/utils/registry.ts` `fromLiveClient`), so it was already talking to v6. playground-app does the same.
- The ABI is **byte-identical** across v3/v5/v6 (verified by fetching each generation's metadata and diffing the full ABI array — 53 items each, no methods added/removed/changed). `.cdm` typed bindings are unchanged.
- The `version` field is the CDM deploy-generation counter, not a semver; v3→v6 are redeploys of the same Jun-1 contract source (last `contracts/registry/lib.rs` commit predates v3). v5 and v6 were deployed the same day, ~45 min apart.

Net effect: the committed snapshot now matches reality. No behavioral change.

## Verification

- `pnpm format:check` ✓
- `pnpm lint:license` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (65 files, 675 tests)

Nothing in `src/` or `e2e/` pins the old address.