### PR TITLE
fix(init): stop requesting unused Statement Store allowance

### DIFF
--- a/.changeset/skip-statement-store-allowance.md
+++ b/.changeset/skip-statement-store-allowance.md
@@ -1,0 +1,12 @@
+---
+"playground-cli": patch
+---
+
+`playground init` no longer requests a Statement Store allowance. The CLI never
+consumes the resulting slot key (all phone interactions ride the SSO channel keyed
+on the QR-login secret, and storage uploads use the Bulletin slot key), but
+requesting it was the one grant that needs the phone to seat a slot in the
+scarce on-chain Statement Store ring. Users whose ring was full hit
+`denied: Statement Store` and saw account setup fail over a grant nothing
+consumes. Account setup now requests only the Bulletin and smart-contract gas
+allowances it actually needs.

--- a/src/commands/init/AccountSetup.tsx
+++ b/src/commands/init/AccountSetup.tsx
@@ -208,6 +208,15 @@ export function AccountSetup({
                     const summary = summarizeOutcomes(outcomes, PLAYGROUND_RESOURCES);
 
                     if (summary.rejected.length > 0 || summary.unavailable.length > 0) {
+                        // Telemetry is off by default, so this stderr line is
+                        // the only signal that distinguishes a user decline
+                        // (Rejected) from the account holder being unable to
+                        // provision (NotAvailable — e.g. a full on-chain SSS
+                        // ring). Positional: outcomes[i] ↔ PLAYGROUND_RESOURCES[i].
+                        const detail = PLAYGROUND_RESOURCES.map(
+                            (r, i) => `${r.tag}=${outcomes[i]?.tag ?? "missing"}`,
+                        ).join(" ");
+                        console.error(`[allowances] resource allocation outcomes: ${detail}`);
                         const denied = [...summary.rejected, ...summary.unavailable]
                             .map(describeResource)
                             .join(", ");

--- a/src/utils/allowances/resources.test.ts
+++ b/src/utils/allowances/resources.test.ts
@@ -28,10 +28,13 @@ const rejected: ApAllocationOutcome = { tag: "Rejected", value: undefined };
 const notAvailable: ApAllocationOutcome = { tag: "NotAvailable", value: undefined };
 
 describe("PLAYGROUND_RESOURCES", () => {
-    test("requests all three resources: Bulletin, StatementStore, SmartContract(0)", () => {
+    test("requests only the resources the CLI consumes: Bulletin, SmartContract(0)", () => {
+        // StatementStoreAllowance is intentionally absent — the CLI never
+        // consumes a product Statement Store slot key (see resources.ts), and
+        // requesting it blocked `playground init` for users whose on-chain SSS
+        // ring was full (phone returns NotAvailable).
         expect(PLAYGROUND_RESOURCES.map((r) => r.tag)).toEqual([
             "BulletInAllowance",
-            "StatementStoreAllowance",
             "SmartContractAllowance",
         ]);
         const sc = PLAYGROUND_RESOURCES.find((r) => r.tag === "SmartContractAllowance");
@@ -41,10 +44,13 @@ describe("PLAYGROUND_RESOURCES", () => {
 
 describe("summarizeOutcomes", () => {
     test("buckets outcomes by tag, order-sensitive", () => {
-        const summary = summarizeOutcomes(
-            [allocated, rejected, notAvailable],
-            PLAYGROUND_RESOURCES,
-        );
+        // Explicit resource list so this stays independent of PLAYGROUND_RESOURCES.
+        const resources: typeof PLAYGROUND_RESOURCES = [
+            { tag: "BulletInAllowance", value: undefined },
+            { tag: "StatementStoreAllowance", value: undefined },
+            { tag: "SmartContractAllowance", value: 0 },
+        ];
+        const summary = summarizeOutcomes([allocated, rejected, notAvailable], resources);
         expect(summary.granted.map((r) => r.tag)).toEqual(["BulletInAllowance"]);
         expect(summary.rejected.map((r) => r.tag)).toEqual(["StatementStoreAllowance"]);
         expect(summary.unavailable.map((r) => r.tag)).toEqual(["SmartContractAllowance"]);

--- a/src/utils/allowances/resources.ts
+++ b/src/utils/allowances/resources.ts
@@ -23,15 +23,29 @@
 import type { AllocatableResource, ApAllocationOutcome } from "@parity/product-sdk-terminal/host";
 
 /**
- * The full mobile-granted resource set for the playground product:
- * Bulletin storage, Statement Store, and PGAS sponsoring for Revive
- * contract calls (derivation index 0 = the default playground account).
- * All three are requested in ONE `requestResourceAllocation` call so the
- * user sees a single approval dialog during `playground init`.
+ * The mobile-granted resource set the playground product actually consumes:
+ * Bulletin storage (metadata + chunk uploads) and PGAS sponsoring for Revive
+ * contract calls (derivation index 0 = the default playground account). Both
+ * are requested in ONE `requestResourceAllocation` call so the user sees a
+ * single approval dialog during `playground init`.
+ *
+ * `StatementStoreAllowance` is deliberately NOT requested. The CLI never
+ * consumes a product Statement Store slot key: every phone interaction
+ * (`session.createTransaction` / `signRaw` / `requestResourceAllocation`
+ * itself) rides the SSO channel, whose prover is derived from the QR-login
+ * `ssSecret` (`@novasamatech/host-papp`'s `createSsoStatementProver`), not
+ * from a `StatementStoreAllowance` allocation. The product slot key is only
+ * consumed by `papp.allowance.getStatementStoreProver`, an opt-in API the CLI
+ * never calls; bulletin-deploy's storage path likewise reads only the Bulletin
+ * slot key (we always inject explicit signer/storageSigner). Requesting it was
+ * pure overhead AND a failure source: it is the one resource that needs the
+ * phone to seat a slot in the scarce on-chain SSS ring, so for users whose ring
+ * is full of still-unexpired slots the phone returns `NotAvailable`, which the
+ * old code surfaced as a hard `denied: Statement Store` and aborted account
+ * setup over a grant nothing uses.
  */
 export const PLAYGROUND_RESOURCES: AllocatableResource[] = [
     { tag: "BulletInAllowance", value: undefined },
-    { tag: "StatementStoreAllowance", value: undefined },
     { tag: "SmartContractAllowance", value: 0 },
 ];
 


### PR DESCRIPTION
## Problem

Two users reported `playground init` failing account setup with:

```
× allowances   approve on your Polkadot mobile app…
    denied: Statement Store. Re-run `playground init` and approve on your phone.
```

Re-running and re-approving does not help, because nothing the user does on the phone can fix it.

## Root cause

`playground init` requested three resources in `PLAYGROUND_RESOURCES` (`src/utils/allowances/resources.ts`): `BulletInAllowance`, `StatementStoreAllowance`, `SmartContractAllowance`. The request is one combined wire call; the phone decides each resource independently and returns a positional `Allocated | Rejected | NotAvailable` per resource.

The CLI **never consumes** the product `StatementStoreAllowance` slot key:

- Every phone interaction (`session.createTransaction` / `signRaw` / `requestResourceAllocation` itself) rides the **SSO channel**, whose prover is derived from the QR-login secret (`createSsoStatementProver` keyed on `ssSecret`), not from a `StatementStoreAllowance` grant.
- The CLI signer (`createSessionSignerForAccount`) signs only via `createTransaction` / `signRaw`.
- The product Statement Store slot key is read only by `papp.allowance.getStatementStoreProver`, an opt-in API the CLI never calls.
- `bulletin-deploy`'s storage path reads only the Bulletin slot key; its Statement Store path is in its own `login`/auth-resolution flow, which the CLI bypasses by always injecting explicit `signer` / `storageSigner` / `mnemonic`.

It is also the one resource that needs the phone to seat a slot in the scarce on-chain Statement Store ring. For users whose ring is full of still-unexpired slots, the phone returns a non-`Allocated` outcome — surfaced as a hard `denied: Statement Store` that aborted account setup over a grant nothing uses. (Bulletin and smart-contract gas don't touch that ring, which is why only Statement Store failed.)

## Fix

- Remove `StatementStoreAllowance` from `PLAYGROUND_RESOURCES`. Account setup now requests only the Bulletin and smart-contract gas allowances the CLI actually consumes; Bulletin/SmartContract still hard-fail on denial.
- Add a stderr diagnostic logging per-resource outcome tags when a *needed* resource is denied. Telemetry is off by default, so this is the only signal distinguishing a user decline (`Rejected`) from the account holder being unable to provision (`NotAvailable`).

## Verification

- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck` (0 errors), `pnpm test` (684 passed).
- Verified by grep that no consumer of a Statement Store slot key / prover exists in `src/`; confirmed the cache pre-check, `allReady` gate, and `summarizeOutcomes` are count- and index-agnostic; confirmed no e2e/scripts pin the 3-resource shape or the old error string.
- Recommended manual check before release: install locally, `playground logout && playground init` (confirm only Bulletin + smart-contract requested), then a full `playground deploy` end-to-end (phone signing, chunk upload, registry publish) with no Statement Store grant present.