### PR TITLE
chore: add Parity copyright notice to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,6 +176,8 @@
 
    END OF TERMS AND CONDITIONS
 
+   Copyright (C) Parity Technologies (UK) Ltd.
+
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following


### PR DESCRIPTION
## Summary

Adds the Parity Technologies (UK) Ltd. copyright line to the root `LICENSE` file, directly below the Apache 2.0 terms (`END OF TERMS AND CONDITIONS`), above the boilerplate APPENDIX.

```
   END OF TERMS AND CONDITIONS

   Copyright (C) Parity Technologies (UK) Ltd.

   APPENDIX: How to apply the Apache License to your work.
```

## Context

Requested by security (Open Source meeting follow-up) to add an explicit copyright attribution to the Apache-2.0 license. The wording matches the per-file header convention already enforced by `scripts/check-license-headers.sh` (`Copyright (C) Parity Technologies (UK) Ltd.`).

No changeset — this is not a user-facing CLI change.