### PR TITLE
feat(deploy): tag a published app for playground filtering

### DIFF
--- a/.changeset/deploy-tags.md
+++ b/.changeset/deploy-tags.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+`playground deploy` can now tag a published app so people can filter for it in the playground. When publishing to the playground, the interactive flow asks you to pick one of the predefined tags (social, chat, defi, utility, gaming, marketplace, irl) or skip. Headless deploys accept `--tag <tag>` (requires `--playground`). The tag is written to the app's metadata as `tag`, which the playground-app filter reads.

--- a/src/commands/deploy/DeployScreen.test.ts
+++ b/src/commands/deploy/DeployScreen.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 import { pickNextStage } from "./DeployScreen.js";
 
 describe("pickNextStage", () => {
-    it("continues past moddable preflight once a repository URL is resolved", () => {
+    it("continues past moddable preflight to the tag prompt once a repository URL is resolved", () => {
         expect(
             pickNextStage(
                 false,
@@ -28,24 +28,90 @@ describe("pickNextStage", () => {
                 true,
                 true,
                 "git@github.com:charlesHetterich/tw33d3r",
+                undefined,
+            ),
+        ).toEqual({ kind: "prompt-tags" });
+    });
+
+    it("reaches confirm once a tag choice (or skip) is resolved", () => {
+        // A resolved tag (a string OR an explicit null "skip") clears the last
+        // publish-only prompt.
+        expect(
+            pickNextStage(
+                false,
+                "phone",
+                true,
+                "dist",
+                "tw33d3r.dot",
+                true,
+                true,
+                "git@github.com:charlesHetterich/tw33d3r",
+                "social",
+            ),
+        ).toEqual({ kind: "confirm" });
+        expect(
+            pickNextStage(
+                false,
+                "phone",
+                true,
+                "dist",
+                "tw33d3r.dot",
+                true,
+                true,
+                "git@github.com:charlesHetterich/tw33d3r",
+                null,
+            ),
+        ).toEqual({ kind: "confirm" });
+    });
+
+    it("asks for a tag after the moddable decision when publishing", () => {
+        // moddable resolved to false, no repo URL needed; the tag is still
+        // unset, so the picker must run before confirm.
+        expect(
+            pickNextStage(
+                false,
+                "phone",
+                true,
+                "dist",
+                "tw33d3r.dot",
+                true,
+                false,
+                null,
+                undefined,
+            ),
+        ).toEqual({ kind: "prompt-tags" });
+    });
+
+    it("never asks for a tag when not publishing to the playground", () => {
+        expect(
+            pickNextStage(
+                false,
+                "phone",
+                true,
+                "dist",
+                "tw33d3r.dot",
+                false,
+                false,
+                null,
+                undefined,
             ),
         ).toEqual({ kind: "confirm" });
     });
 
     it("enters moddable preflight when moddable is true and no repository URL is resolved yet", () => {
         expect(
-            pickNextStage(false, "phone", true, "dist", "tw33d3r.dot", true, true, null),
+            pickNextStage(false, "phone", true, "dist", "tw33d3r.dot", true, true, null, undefined),
         ).toEqual({ kind: "moddable-preflight" });
     });
 
     it("asks whether contracts changed before the frontend build choice", () => {
-        expect(pickNextStage(null, null, null, null, null, null, null, null)).toEqual({
+        expect(pickNextStage(null, null, null, null, null, null, null, null, undefined)).toEqual({
             kind: "prompt-contracts",
         });
     });
 
     it("skips the frontend build prompt when contracts will be deployed", () => {
-        expect(pickNextStage(null, null, true, null, null, null, null, null)).toEqual({
+        expect(pickNextStage(null, null, true, null, null, null, null, null, undefined)).toEqual({
             kind: "prompt-signer",
         });
     });

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -58,6 +58,7 @@ import type { ResolvedSigner } from "../../utils/signer.js";
 import { DEFAULT_BUILD_DIR, getChainConfig, getNetworkLabel } from "../../config.js";
 import { VERSION_LABEL } from "../../utils/version.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
+import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { validateDomainLabel } from "../../utils/deploy/dotnsRules.js";
 import { NO_SESSION_NOTICE_TITLE, NO_SESSION_NOTICE_BODY } from "./signerNotice.js";
 import { ContractPipelineStatusAdapter } from "../contractPipelineStatus.js";
@@ -79,6 +80,12 @@ export interface DeployScreenInputs {
     skipBuild: boolean | null;
     /** Pre-set moddable from `--moddable` / `--no-moddable`. null = ask. */
     moddable: boolean | null;
+    /**
+     * Pre-set tag from `--tag`. A string skips the picker; `undefined` means
+     * "ask in the TUI" once the user opts to publish. (The picker itself can
+     * also resolve to `null` = explicitly untagged.)
+     */
+    tag?: string;
     userSigner: ResolvedSigner | null;
     onDone: (outcome: DeployOutcome | null) => void;
 }
@@ -94,6 +101,7 @@ export type Stage =
     | { kind: "prompt-moddable" }
     | { kind: "moddable-preflight" }
     | { kind: "moddable-error"; message: string }
+    | { kind: "prompt-tags" }
     | { kind: "confirm" }
     | { kind: "running" }
     | { kind: "done"; outcome: DeployOutcome }
@@ -108,6 +116,8 @@ interface Resolved {
     skipBuild: boolean;
     moddable: boolean;
     repositoryUrl: string | null;
+    /** Resolved playground tag, or `null` for untagged. Only meaningful when `publishToPlayground`. */
+    tag: string | null;
 }
 
 export function DeployScreen({
@@ -121,6 +131,7 @@ export function DeployScreen({
     playgroundPrivate,
     skipBuild: initialSkipBuild,
     moddable: initialModdable,
+    tag: initialTag,
     userSigner,
     onDone,
 }: DeployScreenInputs) {
@@ -140,6 +151,9 @@ export function DeployScreen({
     const [skipBuild, setSkipBuild] = useState<boolean | null>(effectiveInitialSkipBuild);
     const [moddable, setModdable] = useState<boolean | null>(initialModdable);
     const [repositoryUrl, setRepositoryUrl] = useState<string | null>(null);
+    // Tri-state: `undefined` = not chosen yet (ask when publishing), `null` =
+    // explicitly untagged, a string = chosen tag. A `--tag` flag pre-fills it.
+    const [tag, setTag] = useState<string | null | undefined>(initialTag);
     const [domainError, setDomainError] = useState<string | null>(null);
     // Captured from the availability check; feeds `resolveSignerSetup` so
     // the summary card shows the correct phone-approval count (a new register
@@ -155,6 +169,7 @@ export function DeployScreen({
             initialPublish,
             initialModdable,
             null,
+            initialTag,
         ),
     );
 
@@ -172,6 +187,7 @@ export function DeployScreen({
         nextPublish: boolean | null = publishToPlayground,
         nextModdable: boolean | null = moddable,
         nextRepoUrl: string | null = repositoryUrl,
+        nextTag: string | null | undefined = tag,
     ) => {
         const s = pickNextStage(
             nextSkipBuild,
@@ -182,6 +198,7 @@ export function DeployScreen({
             nextPublish,
             nextModdable,
             nextRepoUrl,
+            nextTag,
         );
         setStage(s);
     };
@@ -195,7 +212,10 @@ export function DeployScreen({
             domain === null ||
             publishToPlayground === null ||
             effectiveSkipBuild === null ||
-            moddable === null
+            moddable === null ||
+            // A tag is only required once the user has opted to publish; an
+            // `undefined` tag there means the picker hasn't run yet.
+            (publishToPlayground && tag === undefined)
         )
             return null;
         return {
@@ -207,6 +227,8 @@ export function DeployScreen({
             skipBuild: effectiveSkipBuild,
             moddable,
             repositoryUrl,
+            // Untagged when not publishing, or when the picker resolved to "skip".
+            tag: publishToPlayground ? (tag ?? null) : null,
         };
     }, [
         mode,
@@ -217,6 +239,7 @@ export function DeployScreen({
         skipBuild,
         moddable,
         repositoryUrl,
+        tag,
     ]);
 
     // Dynamic terminal tab title: subtitle becomes the domain once we know it.
@@ -437,6 +460,30 @@ export function DeployScreen({
                 <ModdableErrorStage message={stage.message} onExit={() => onDone(null)} />
             )}
 
+            {stage.kind === "prompt-tags" && (
+                <Select<string | null>
+                    label="tag this app? (helps people find it in the playground)"
+                    options={[
+                        ...PLAYGROUND_TAGS.map((t) => ({ value: t as string | null, label: t })),
+                        { value: null, label: "skip", hint: "publish without a tag" },
+                    ]}
+                    onSelect={(t) => {
+                        setTag(t);
+                        advance(
+                            skipBuild,
+                            mode,
+                            deployContracts,
+                            buildDir,
+                            domain,
+                            publishToPlayground,
+                            moddable,
+                            repositoryUrl,
+                            t,
+                        );
+                    }}
+                />
+            )}
+
             {stage.kind === "confirm" && resolved && (
                 <ConfirmStage
                     projectDir={projectDir}
@@ -499,6 +546,7 @@ function pickInitialStage(
     publish: boolean | null,
     moddable: boolean | null,
     repositoryUrl: string | null,
+    tag: string | null | undefined,
 ): Stage {
     return pickNextStage(
         skipBuild,
@@ -509,6 +557,7 @@ function pickInitialStage(
         publish,
         moddable,
         repositoryUrl,
+        tag,
     );
 }
 
@@ -521,6 +570,7 @@ export function pickNextStage(
     publish: boolean | null,
     moddable: boolean | null,
     repositoryUrl: string | null,
+    tag: string | null | undefined,
 ): Stage {
     if (deployContracts === null) return { kind: "prompt-contracts" };
     const effectiveSkipBuild = deployContracts ? false : skipBuild;
@@ -534,6 +584,9 @@ export function pickNextStage(
     if (publish && moddable === true && repositoryUrl === null) {
         return { kind: "moddable-preflight" };
     }
+    // Tag is the last publish-only choice — asked after the moddable decision
+    // is fully resolved, and only when no `--tag` flag pre-filled it.
+    if (publish && tag === undefined) return { kind: "prompt-tags" };
     return { kind: "confirm" };
 }
 
@@ -723,6 +776,7 @@ function ConfirmStage({
         publishToPlayground: inputs.publishToPlayground,
         moddable: inputs.moddable,
         repositoryUrl: inputs.repositoryUrl,
+        tag: inputs.tag,
         approvals: "approvals" in setup ? setup.approvals : [],
         // What we show in the "Signer" row reflects who actually submits
         // the on-chain txs, which is mostly setup.publishSigner — that's
@@ -937,6 +991,7 @@ function RunningStage({
                     playgroundPrivate,
                     moddable: inputs.moddable,
                     repositoryUrl: inputs.repositoryUrl,
+                    tag: inputs.tag,
                     userSigner,
                     plan: plan ?? undefined,
                     onEvent: (event) => handleEvent(event),

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -15,7 +15,11 @@
 
 import { describe, it, expect } from "vitest";
 
-import { isFullySpecified, shouldResolveUserSigner } from "./index.js";
+import {
+    assertPublishFlagsConsistent,
+    isFullySpecified,
+    shouldResolveUserSigner,
+} from "./index.js";
 
 describe("shouldResolveUserSigner", () => {
     it("skips signer lookup for pure dev deploys", () => {
@@ -53,5 +57,53 @@ describe("isFullySpecified", () => {
 
     it("allows headless deploy when contracts are explicitly skipped", () => {
         expect(isFullySpecified({ ...fullySpecified, contracts: false })).toBe(true);
+    });
+});
+
+describe("assertPublishFlagsConsistent", () => {
+    it("rejects --tag without --playground", () => {
+        expect(() =>
+            assertPublishFlagsConsistent({
+                moddable: false,
+                tag: "defi",
+                publishToPlayground: false,
+            }),
+        ).toThrow(/--tag requires --playground/);
+    });
+
+    it("rejects --moddable without --playground", () => {
+        expect(() =>
+            assertPublishFlagsConsistent({ moddable: true, tag: null, publishToPlayground: false }),
+        ).toThrow(/--moddable requires --playground/);
+    });
+
+    it("reports the moddable conflict first when both flags are set without --playground", () => {
+        expect(() =>
+            assertPublishFlagsConsistent({
+                moddable: true,
+                tag: "defi",
+                publishToPlayground: false,
+            }),
+        ).toThrow(/--moddable requires --playground/);
+    });
+
+    it("allows a tag when publishing to the playground", () => {
+        expect(() =>
+            assertPublishFlagsConsistent({
+                moddable: true,
+                tag: "defi",
+                publishToPlayground: true,
+            }),
+        ).not.toThrow();
+    });
+
+    it("allows an untagged, non-moddable deploy with no --playground", () => {
+        expect(() =>
+            assertPublishFlagsConsistent({
+                moddable: false,
+                tag: null,
+                publishToPlayground: false,
+            }),
+        ).not.toThrow();
     });
 });

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -45,6 +45,7 @@ import type { SigningEvent } from "../../utils/deploy/signingProxy.js";
 import { buildSummaryView } from "./summary.js";
 import { DEFAULT_BUILD_DIR, type Env, resolveLegacyEnv } from "../../config.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
+import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { NO_SESSION_HEADLESS_ERROR } from "./signerNotice.js";
 
 interface DeployOpts {
@@ -65,6 +66,8 @@ interface DeployOpts {
     contracts?: boolean;
     /** Publish the source repo so others can `dot mod` it. Commander auto-negates: `--no-moddable` ⇒ false. */
     moddable?: boolean;
+    /** Single playground tag to publish with (one of PLAYGROUND_TAGS). Validated by commander `.choices`. Requires --playground. */
+    tag?: string;
     env?: Env;
     /** Project root. Hidden — defaults to cwd. */
     dir?: string;
@@ -96,6 +99,12 @@ export const deployCommand = new Command("deploy")
         "Publish the source repo so others can `playground mod` it. Requires --playground and a public GitHub `origin`.",
     )
     .option("--no-moddable", "Explicitly skip publishing source (the default).")
+    .addOption(
+        new Option(
+            "--tag <tag>",
+            "Tag the published app so people can filter for it in the playground. Requires --playground.",
+        ).choices([...PLAYGROUND_TAGS]),
+    )
     .option("--suri <suri>", "Secret URI for the user signer (e.g. //Alice for dev)")
     .addOption(
         new Option("--env <env>", "Target environment")
@@ -304,6 +313,27 @@ export function isFullySpecified(opts: DeployOpts): boolean {
     );
 }
 
+/**
+ * `--moddable` and `--tag` both only affect the playground metadata JSON, which
+ * is uploaded ONLY when publishing. Supplying either without `--playground` is a
+ * no-op the user almost certainly didn't intend, so headless deploys reject it
+ * up front — before the availability network round-trip — with an actionable
+ * message. Pure + exported so the contract is unit-testable.
+ */
+export function assertPublishFlagsConsistent(opts: {
+    moddable: boolean;
+    tag: string | null;
+    publishToPlayground: boolean;
+}): void {
+    if (opts.publishToPlayground) return;
+    if (opts.moddable) {
+        throw new Error("--moddable requires --playground (no metadata is published without it).");
+    }
+    if (opts.tag) {
+        throw new Error("--tag requires --playground (no metadata is published without it).");
+    }
+}
+
 async function runHeadless(ctx: {
     projectDir: string;
     env: Env;
@@ -316,6 +346,12 @@ async function runHeadless(ctx: {
     const buildDir = ctx.opts.buildDir as string;
     const deployContractsBeforeFrontend = ctx.opts.contracts === true;
     const skipBuild = deployContractsBeforeFrontend ? false : ctx.opts.build === false;
+    const moddable = ctx.opts.moddable === true;
+    const tag = ctx.opts.tag ?? null;
+
+    // Reject metadata-only flags supplied without `--playground` before any
+    // network work — they'd otherwise be silently ignored.
+    assertPublishFlagsConsistent({ moddable, tag, publishToPlayground });
 
     // Phone signing needs a paired session. Headless has no TUI to fall back
     // into, so reject an explicit `--signer phone` with no session up front
@@ -356,15 +392,8 @@ async function runHeadless(ctx: {
     }
     process.stdout.write(`✔ ${formatAvailability(availability)}\n`);
 
-    const moddable = ctx.opts.moddable === true;
-
     let repositoryUrl: string | null = null;
     if (moddable) {
-        if (!publishToPlayground) {
-            throw new Error(
-                "--moddable requires --playground (no metadata is published without it).",
-            );
-        }
         repositoryUrl = await withSpan(
             "cli.deploy.moddable",
             "prepare moddable repository",
@@ -393,6 +422,7 @@ async function runHeadless(ctx: {
         publishToPlayground,
         moddable,
         repositoryUrl,
+        tag,
         approvals: setup.approvals,
         // Mirror the TUI logic in DeployScreen.tsx: prefer the resolved
         // publish signer's address — that's the on-chain identity that
@@ -451,6 +481,7 @@ async function runHeadless(ctx: {
                 playgroundPrivate: Boolean(ctx.opts.private),
                 moddable,
                 repositoryUrl,
+                tag,
                 userSigner: ctx.userSigner,
                 plan: availability.plan,
                 env: ctx.env,
@@ -500,6 +531,10 @@ function runInteractive(ctx: {
                                 : ctx.opts.moddable === false
                                   ? false
                                   : null,
+                        // A flag-provided `--tag` pre-fills the choice and skips
+                        // the picker; absent (`undefined`) means "ask in the TUI"
+                        // when the user opts to publish.
+                        tag: ctx.opts.tag,
                         userSigner: ctx.userSigner,
                         onDone: (outcome: DeployOutcome | null) => {
                             if (settled) return;

--- a/src/commands/deploy/summary.test.ts
+++ b/src/commands/deploy/summary.test.ts
@@ -89,6 +89,44 @@ describe("buildSummaryView", () => {
         expect(ownerRow?.value).toContain("0xbeefbeef");
     });
 
+    it("shows the chosen tag in the Tag row when publishing to playground", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "my-app.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: true,
+            tag: "gaming",
+            approvals: [],
+        });
+        expect(view.rows.find((r) => r.label === "Tag")?.value).toBe("gaming");
+    });
+
+    it("shows 'none' in the Tag row when publishing untagged", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "my-app.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: true,
+            approvals: [],
+        });
+        expect(view.rows.find((r) => r.label === "Tag")?.value).toBe("none");
+    });
+
+    it("omits the Tag row entirely when not publishing to playground", () => {
+        const view = buildSummaryView({
+            mode: "dev",
+            domain: "my-app.dot",
+            buildDir: "dist",
+            skipBuild: false,
+            publishToPlayground: false,
+            tag: "gaming",
+            approvals: [],
+        });
+        expect(view.rows.find((r) => r.label === "Tag")).toBeUndefined();
+    });
+
     it("phone mode with playground has four approvals numbered 1-4", () => {
         const view = buildSummaryView({
             mode: "phone",

--- a/src/commands/deploy/summary.ts
+++ b/src/commands/deploy/summary.ts
@@ -31,6 +31,8 @@ export interface SummaryInputs {
     publishToPlayground: boolean;
     moddable?: boolean;
     repositoryUrl?: string | null;
+    /** Single playground tag the app will be published with, or `null`/undefined for untagged. */
+    tag?: string | null;
     approvals: DeployApproval[];
     /**
      * SS58 of the account that will sign this deploy. Surfaced in the summary
@@ -95,6 +97,7 @@ export function buildSummaryView(input: SummaryInputs): SummaryView {
             label: "Moddable",
             value: input.moddable ? `yes — ${input.repositoryUrl}` : "no",
         });
+        rows.push({ label: "Tag", value: input.tag ? input.tag : "none" });
         if (input.claimedOwnerH160) {
             // Dev mode + session: Alice signs the registry tx but the
             // user's H160 is recorded as owner. Surfacing it here is

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -367,6 +367,7 @@ describe("buildMetadata", () => {
             branch: null,
             readme: null,
             moddedFrom: null,
+            tag: null,
         });
         expect(meta).toEqual({ repository: "https://github.com/x/y" });
     });
@@ -377,6 +378,7 @@ describe("buildMetadata", () => {
             branch: null,
             readme: null,
             moddedFrom: null,
+            tag: null,
         });
         expect(meta.repository).toBeUndefined();
     });
@@ -387,6 +389,7 @@ describe("buildMetadata", () => {
             branch: "develop",
             readme: null,
             moddedFrom: null,
+            tag: null,
         });
         expect(meta).toEqual({ repository: "https://github.com/x/y", branch: "develop" });
     });
@@ -397,6 +400,7 @@ describe("buildMetadata", () => {
             branch: "develop",
             readme: null,
             moddedFrom: null,
+            tag: null,
         });
         expect(meta.branch).toBeUndefined();
     });
@@ -407,6 +411,7 @@ describe("buildMetadata", () => {
             branch: null,
             readme: { kind: "ok", content: "hello", size: 5 },
             moddedFrom: null,
+            tag: null,
         });
         expect(meta).toEqual({ readme: "hello" });
     });
@@ -417,6 +422,7 @@ describe("buildMetadata", () => {
             branch: null,
             readme: null,
             moddedFrom: "original.dot",
+            tag: null,
         });
         expect(meta).toEqual({ moddedFrom: "original.dot" });
     });
@@ -427,8 +433,31 @@ describe("buildMetadata", () => {
             branch: null,
             readme: null,
             moddedFrom: null,
+            tag: null,
         });
         expect(meta.moddedFrom).toBeUndefined();
+    });
+
+    it("includes tag when present (independent of repositoryUrl)", () => {
+        const meta = buildMetadata({
+            repositoryUrl: null,
+            branch: null,
+            readme: null,
+            moddedFrom: null,
+            tag: "defi",
+        });
+        expect(meta).toEqual({ tag: "defi" });
+    });
+
+    it("omits tag when null", () => {
+        const meta = buildMetadata({
+            repositoryUrl: "https://github.com/x/y",
+            branch: null,
+            readme: null,
+            moddedFrom: null,
+            tag: null,
+        });
+        expect(meta.tag).toBeUndefined();
     });
 });
 
@@ -480,6 +509,17 @@ describe("publishToPlayground", () => {
             cwd: "/definitely/not/a/repo",
         });
         expect(result.metadata).toEqual({});
+    });
+
+    it("records the chosen tag in the uploaded metadata JSON", async () => {
+        const result = await publishToPlayground({
+            domain: "tagged-app",
+            publishSigner: fakeSigner,
+            repositoryUrl: null,
+            tag: "gaming",
+            cwd: "/definitely/not/a/repo",
+        });
+        expect(result.metadata).toEqual({ tag: "gaming" });
     });
 
     it("inlines README.md when it is present and within the cap", async () => {

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -78,6 +78,14 @@ export interface PublishToPlaygroundOptions {
     claimedOwnerH160?: `0x${string}` | null;
     /** Repository URL to record in metadata. `null` = omit the field entirely. */
     repositoryUrl: string | null;
+    /**
+     * Single playground tag to record in metadata (one of `PLAYGROUND_TAGS`).
+     * Drives the playground-app tag filter. `null` or omitted ⇒ the app is
+     * published untagged (the field is left out of the JSON). Untagged is a
+     * safe default, so — unlike the `moddable` decision — this is not forced
+     * on callers.
+     */
+    tag?: string | null;
     /** Project root. Used to look for a `README.md` to inline into metadata. */
     cwd?: string;
     /** Progress sink for the metadata-upload sub-step. */
@@ -217,6 +225,12 @@ export function buildMetadata(input: {
     branch: string | null;
     readme: ReadmeStatus | null;
     moddedFrom: string | null;
+    /**
+     * Single playground tag (one of `PLAYGROUND_TAGS`) the user picked at
+     * deploy time, or `null` to omit. The playground-app filters apps by exact
+     * match on this `tag` field — see `./tags.ts`.
+     */
+    tag: string | null;
 }): Record<string, string> {
     const meta: Record<string, string> = {};
     if (input.repositoryUrl) meta.repository = input.repositoryUrl;
@@ -226,6 +240,7 @@ export function buildMetadata(input: {
     if (input.repositoryUrl && input.branch) meta.branch = input.branch;
     if (input.readme && input.readme.kind === "ok") meta.readme = input.readme.content;
     if (input.moddedFrom) meta.moddedFrom = input.moddedFrom;
+    if (input.tag) meta.tag = input.tag;
     return meta;
 }
 
@@ -278,6 +293,7 @@ export async function publishToPlayground(
         branch,
         readme,
         moddedFrom,
+        tag: options.tag ?? null,
     });
 
     const metadataBytes = new Uint8Array(Buffer.from(JSON.stringify(metadata), "utf8"));

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -255,6 +255,41 @@ describe("runDeploy", () => {
         expect(devCall?.isDevSigner).toBe(true);
     });
 
+    it("threads the chosen tag into publishToPlayground (and defaults to null)", async () => {
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            domain: "tagged",
+            mode: "phone",
+            publishToPlayground: true,
+            tag: "defi",
+            userSigner: fakeUserSigner,
+            onEvent: push,
+        });
+        const tagged = (publishToPlaygroundMock.mock.calls as unknown[][])[0]?.[0] as
+            | { tag?: string | null }
+            | undefined;
+        expect(tagged?.tag).toBe("defi");
+
+        publishToPlaygroundMock.mockClear();
+
+        // No tag supplied ⇒ publishToPlayground receives an explicit null.
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "/tmp/proj/dist",
+            domain: "untagged",
+            mode: "phone",
+            publishToPlayground: true,
+            userSigner: fakeUserSigner,
+            onEvent: push,
+        });
+        const untagged = (publishToPlaygroundMock.mock.calls as unknown[][])[0]?.[0] as
+            | { tag?: string | null }
+            | undefined;
+        expect(untagged?.tag).toBeNull();
+    });
+
     it("phone mode with playground: 4 planned approvals, DotNS uses phone signer", async () => {
         const { events, push } = collectEvents();
         const outcome = await runDeploy({

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -80,6 +80,8 @@ export interface RunDeployOptions {
     moddable?: boolean;
     /** Resolved public repository URL to record in metadata (moddable=true) or `null` (moddable=false). */
     repositoryUrl?: string | null;
+    /** Single playground tag to record in metadata, or `null`/omitted to publish untagged. Ignored when `publishToPlayground` is false. */
+    tag?: string | null;
     /** The logged-in phone signer. Required for `mode === "phone"` or `publishToPlayground`. */
     userSigner: ResolvedSigner | null;
     /** Event sink — consumed by the TUI / RevX. */
@@ -242,6 +244,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     publishSigner: wrappedPublishSigner,
                     claimedOwnerH160: setup.claimedOwnerH160,
                     repositoryUrl: options.repositoryUrl ?? null,
+                    tag: options.tag ?? null,
                     cwd: options.projectDir,
                     onLogEvent: (event) => options.onEvent({ kind: "storage-event", event }),
                     onAllowancePrompt: allowancePrompt,

--- a/src/utils/deploy/tags.test.ts
+++ b/src/utils/deploy/tags.test.ts
@@ -1,0 +1,50 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { PLAYGROUND_TAGS, isPlaygroundTag } from "./tags.js";
+
+describe("PLAYGROUND_TAGS", () => {
+    it("mirrors the playground-app TAGS list exactly (keep in sync with App.tsx)", () => {
+        // If this fails because the app added/removed/reordered a tag, update
+        // both this list and the array in `playground-app/src/App.tsx`.
+        expect([...PLAYGROUND_TAGS]).toEqual([
+            "social",
+            "chat",
+            "defi",
+            "utility",
+            "gaming",
+            "marketplace",
+            "irl",
+        ]);
+    });
+});
+
+describe("isPlaygroundTag", () => {
+    it("accepts a canonical tag", () => {
+        expect(isPlaygroundTag("defi")).toBe(true);
+    });
+
+    it("rejects an unknown tag", () => {
+        expect(isPlaygroundTag("productivity")).toBe(false);
+    });
+
+    it("is case-sensitive (the app stores canonical lowercase values)", () => {
+        // The CLI only ever emits the lowercase canonical values (the flag is
+        // validated against the list and the picker offers them verbatim), so
+        // the guard need not normalise — it just confirms membership.
+        expect(isPlaygroundTag("DeFi")).toBe(false);
+    });
+});

--- a/src/utils/deploy/tags.ts
+++ b/src/utils/deploy/tags.ts
@@ -1,0 +1,47 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The canonical playground tag set.
+ *
+ * Each published app carries at most ONE tag, stored in the off-chain metadata
+ * JSON as `tag` (a string) — see `buildMetadata` in `./playground.ts`. The
+ * playground-app reads `metadata.tag` and filters apps by exact,
+ * case-insensitive equality against a hardcoded pill list. That pill list is
+ * the source of truth and lives in the OTHER repo:
+ * `playground-app/src/App.tsx` (`export const TAGS`).
+ *
+ * There is no shared package between the two repos, so this list must be kept
+ * in sync by hand. A tag that is NOT in the app's `TAGS` still renders on the
+ * app card but has no filter pill, so it is effectively unfilterable — which is
+ * why `playground deploy` only offers these predefined values (no free-form
+ * custom tag).
+ */
+export const PLAYGROUND_TAGS = [
+    "social",
+    "chat",
+    "defi",
+    "utility",
+    "gaming",
+    "marketplace",
+    "irl",
+] as const;
+
+export type PlaygroundTag = (typeof PLAYGROUND_TAGS)[number];
+
+/** Type guard: is `value` one of the canonical playground tags (exact match)? */
+export function isPlaygroundTag(value: string): value is PlaygroundTag {
+    return (PLAYGROUND_TAGS as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## What

`playground deploy` can now attach a single **playground tag** to an app it publishes, so people can filter for it in the playground UI.

- **Interactive:** when publishing to the playground, a new prompt (after the moddable decision) offers the predefined tags — `social`, `chat`, `defi`, `utility`, `gaming`, `marketplace`, `irl` — or **skip**.
- **Headless:** `--tag <tag>` (requires `--playground`, validated against the preset list).
- The chosen tag is shown on the confirm/summary card; untagged is the default.

## How it works

Tags are **metadata-only** — there is no contract change. The tag is written into the off-chain metadata JSON as `tag` (singular string), which is exactly the field the playground-app reads and filters on by case-insensitive exact match. This mirrors the existing `--moddable` → `repositoryUrl` precedent end to end (flag/picker → `RunDeployOptions` → `PublishToPlaygroundOptions` → `buildMetadata`).

Presets-only by design: the app's filter pills are a hardcoded list, so a custom/unknown tag would render on the card but be unfilterable. The canonical 7-tag list lives in `src/utils/deploy/tags.ts` as a hand-synced mirror of the app's `TAGS` (no shared package between the repos); a test pins it so drift fails loudly.

## Notable

- The two headless "requires `--playground`" guards (`--moddable`, `--tag`) are unified into one pure, **fail-fast** (pre-network), unit-tested `assertPublishFlagsConsistent`.

## Verification

All four CI gates green locally:

- `pnpm format:check` — clean
- `pnpm lint:license` — clean
- `pnpm typecheck` — clean
- `pnpm test` — **710 passed**

New tests: the tag module + drift guard, `buildMetadata`/`publishToPlayground` tag write, `runDeploy` forwarding (+ `?? null` default), the summary row (set / none / omitted-when-not-publishing), the `pickNextStage` ordering (asks after moddable, never when not publishing), and the `assertPublishFlagsConsistent` guard.
