### PR TITLE
Improve playground mod + deploy messaging

### DIFF
--- a/.changeset/deploy-prompt-help-boxes.md
+++ b/.changeset/deploy-prompt-help-boxes.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground deploy`: the interactive prompts now show a plain-language info box above each conceptual choice explaining what the decision means and what each option does, and the labels/hints are reworded for non-technical users. For example "changed contracts?" is now "did you change your smart contracts?" with options "I only changed the website" / "I changed contract code too", and "make this app moddable?" explains what modding is and what gets shared. The prompt order and behavior are unchanged.

--- a/.changeset/friendly-mod-source-unavailable.md
+++ b/.changeset/friendly-mod-source-unavailable.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground mod`: when an app's published source repository is no longer publicly available (the publisher made it private, deleted, or renamed it), show a friendly "Source unavailable" notice instead of a raw GitHub 404. In the interactive picker the notice appears at the bottom and the picker stays open so you can choose another app; the direct `playground mod <domain>` path shows the same notice in place of the red "setup failed" error.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -61,6 +61,17 @@ import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/mod
 import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { validateDomainLabel } from "../../utils/deploy/dotnsRules.js";
 import { NO_SESSION_NOTICE_TITLE, NO_SESSION_NOTICE_BODY } from "./signerNotice.js";
+import {
+    BUILD_HELP,
+    CONTRACTS_HELP,
+    SIGNER_HELP,
+    PUBLISH_HELP,
+    MODDABLE_HELP,
+    TAGS_HELP,
+    BUILD_DIR_HINT,
+    DOMAIN_HINT,
+    type PromptBox,
+} from "./promptHelp.js";
 import { ContractPipelineStatusAdapter } from "../contractPipelineStatus.js";
 import { ContractDeployStatusView, precomputeContractDeployDisplay } from "../contractDeployUi.js";
 import { ContractInstallStatusAdapter, ContractInstallStatusView } from "../contractInstallUi.js";
@@ -118,6 +129,28 @@ interface Resolved {
     repositoryUrl: string | null;
     /** Resolved playground tag, or `null` for untagged. Only meaningful when `publishToPlayground`. */
     tag: string | null;
+}
+
+/**
+ * Plain-language info box rendered above a conceptual deploy prompt. See
+ * `promptHelp.ts`. The `accent` tone marks it as informational (distinct from
+ * the yellow `warning` notices).
+ */
+function PromptInfo({ box }: { box: PromptBox }) {
+    return (
+        <Callout tone="accent" title={box.title}>
+            <Text>{box.body}</Text>
+        </Callout>
+    );
+}
+
+/** One-line dim hint above a trivial text input (domain, build directory). */
+function PromptHint({ text }: { text: string }) {
+    return (
+        <Box marginLeft={2} marginBottom={1}>
+            <Text dimColor>{text}</Text>
+        </Box>
+    );
 }
 
 export function DeployScreen({
@@ -255,18 +288,21 @@ export function DeployScreen({
             />
 
             {stage.kind === "prompt-build" && (
-                <Select<boolean>
-                    label="build before deploy?"
-                    options={[
-                        { value: false, label: "yes", hint: "rebuild the project" },
-                        { value: true, label: "no", hint: "use existing build in buildDir" },
-                    ]}
-                    initialIndex={0}
-                    onSelect={(skip) => {
-                        setSkipBuild(skip);
-                        advance(skip);
-                    }}
-                />
+                <Box flexDirection="column">
+                    <PromptInfo box={BUILD_HELP} />
+                    <Select<boolean>
+                        label="build before deploy?"
+                        options={[
+                            { value: false, label: "yes", hint: "rebuild with my latest code" },
+                            { value: true, label: "no", hint: "redeploy the existing build" },
+                        ]}
+                        initialIndex={0}
+                        onSelect={(skip) => {
+                            setSkipBuild(skip);
+                            advance(skip);
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "prompt-signer" && (
@@ -276,13 +312,14 @@ export function DeployScreen({
                             <Text>{NO_SESSION_NOTICE_BODY}</Text>
                         </Callout>
                     )}
+                    <PromptInfo box={SIGNER_HELP} />
                     <Select<SignerMode>
-                        label="signer"
+                        label="who signs the upload?"
                         options={[
                             {
                                 value: "dev" as SignerMode,
                                 label: "dev signer",
-                                hint: "fast, 0 phone taps for upload",
+                                hint: "fast, no phone needed",
                             },
                             // The phone signer is only offered with a paired
                             // session; otherwise the notice above explains how
@@ -292,7 +329,7 @@ export function DeployScreen({
                                       {
                                           value: "phone" as SignerMode,
                                           label: "your phone signer",
-                                          hint: "signed with your logged-in account",
+                                          hint: "signs with your own account",
                                       },
                                   ]
                                 : []),
@@ -306,55 +343,64 @@ export function DeployScreen({
             )}
 
             {stage.kind === "prompt-contracts" && (
-                <Select<boolean>
-                    label="changed contracts?"
-                    options={[
-                        { value: false, label: "no", hint: "frontend deploy only" },
-                        {
-                            value: true,
-                            label: "yes",
-                            hint: "deploy + install, then rebuild frontend",
-                        },
-                    ]}
-                    initialIndex={0}
-                    onSelect={(yes) => {
-                        setDeployContracts(yes);
-                        const nextSkipBuild = yes ? false : skipBuild;
-                        if (yes) setSkipBuild(false);
-                        advance(nextSkipBuild, mode, yes);
-                    }}
-                />
+                <Box flexDirection="column">
+                    <PromptInfo box={CONTRACTS_HELP} />
+                    <Select<boolean>
+                        label="did you change your smart contracts?"
+                        options={[
+                            { value: false, label: "no", hint: "I only changed the website" },
+                            {
+                                value: true,
+                                label: "yes",
+                                hint: "I changed contract code too",
+                            },
+                        ]}
+                        initialIndex={0}
+                        onSelect={(yes) => {
+                            setDeployContracts(yes);
+                            const nextSkipBuild = yes ? false : skipBuild;
+                            if (yes) setSkipBuild(false);
+                            advance(nextSkipBuild, mode, yes);
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "prompt-buildDir" && (
-                <Input
-                    label="build directory"
-                    initial={DEFAULT_BUILD_DIR}
-                    onSubmit={(v) => {
-                        setBuildDir(v);
-                        advance(skipBuild, mode, deployContracts, v);
-                    }}
-                />
+                <Box flexDirection="column">
+                    <PromptHint text={BUILD_DIR_HINT} />
+                    <Input
+                        label="build directory"
+                        initial={DEFAULT_BUILD_DIR}
+                        onSubmit={(v) => {
+                            setBuildDir(v);
+                            advance(skipBuild, mode, deployContracts, v);
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "prompt-domain" && (
-                <Input
-                    label="domain"
-                    placeholder="my-app"
-                    prefill={domain ?? ""}
-                    externalError={domainError}
-                    validate={(v) => {
-                        const label = v.trim().replace(/\.dot$/i, "");
-                        const result = validateDomainLabel(label);
-                        return result.ok ? null : result.reason;
-                    }}
-                    onSubmit={(v) => {
-                        const trimmed = v.trim();
-                        setDomain(trimmed);
-                        setDomainError(null);
-                        setStage({ kind: "validate-domain", domain: trimmed });
-                    }}
-                />
+                <Box flexDirection="column">
+                    <PromptHint text={DOMAIN_HINT} />
+                    <Input
+                        label="domain"
+                        placeholder="my-app"
+                        prefill={domain ?? ""}
+                        externalError={domainError}
+                        validate={(v) => {
+                            const label = v.trim().replace(/\.dot$/i, "");
+                            const result = validateDomainLabel(label);
+                            return result.ok ? null : result.reason;
+                        }}
+                        onSubmit={(v) => {
+                            const trimmed = v.trim();
+                            setDomain(trimmed);
+                            setDomainError(null);
+                            setStage({ kind: "validate-domain", domain: trimmed });
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "validate-domain" && (
@@ -380,58 +426,68 @@ export function DeployScreen({
             )}
 
             {stage.kind === "prompt-publish" && (
-                <Select<boolean>
-                    label="publish to the playground?"
-                    options={[
-                        { value: false, label: "no", hint: "DotNS only" },
-                        { value: true, label: "yes", hint: "publish to the playground registry" },
-                    ]}
-                    initialIndex={0}
-                    onSelect={(yes) => {
-                        setPublishToPlayground(yes);
-                        if (!yes) setModdable(false);
-                        advance(
-                            skipBuild,
-                            mode,
-                            deployContracts,
-                            buildDir,
-                            domain,
-                            yes,
-                            yes ? moddable : false,
-                        );
-                    }}
-                />
-            )}
-
-            {stage.kind === "prompt-moddable" && (
-                <Select<boolean>
-                    label="make this app moddable? (anyone in the playground can playground mod it)"
-                    options={[
-                        {
-                            value: false,
-                            label: "no",
-                            hint: "metadata will not include a source repo",
-                        },
-                        { value: true, label: "yes", hint: "publishes your source repo URL" },
-                    ]}
-                    initialIndex={1}
-                    onSelect={(yes) => {
-                        setModdable(yes);
-                        if (yes) {
-                            setStage({ kind: "moddable-preflight" });
-                        } else {
+                <Box flexDirection="column">
+                    <PromptInfo box={PUBLISH_HELP} />
+                    <Select<boolean>
+                        label="publish to the playground?"
+                        options={[
+                            { value: false, label: "no", hint: "deploy to my .dot address only" },
+                            { value: true, label: "yes", hint: "list it in the public playground" },
+                        ]}
+                        initialIndex={0}
+                        onSelect={(yes) => {
+                            setPublishToPlayground(yes);
+                            if (!yes) setModdable(false);
                             advance(
                                 skipBuild,
                                 mode,
                                 deployContracts,
                                 buildDir,
                                 domain,
-                                publishToPlayground,
-                                false,
+                                yes,
+                                yes ? moddable : false,
                             );
-                        }
-                    }}
-                />
+                        }}
+                    />
+                </Box>
+            )}
+
+            {stage.kind === "prompt-moddable" && (
+                <Box flexDirection="column">
+                    <PromptInfo box={MODDABLE_HELP} />
+                    <Select<boolean>
+                        label="let others remix (mod) this app?"
+                        options={[
+                            {
+                                value: false,
+                                label: "no",
+                                hint: "keep my source private",
+                            },
+                            {
+                                value: true,
+                                label: "yes",
+                                hint: "share my source so others can remix",
+                            },
+                        ]}
+                        initialIndex={1}
+                        onSelect={(yes) => {
+                            setModdable(yes);
+                            if (yes) {
+                                setStage({ kind: "moddable-preflight" });
+                            } else {
+                                advance(
+                                    skipBuild,
+                                    mode,
+                                    deployContracts,
+                                    buildDir,
+                                    domain,
+                                    publishToPlayground,
+                                    false,
+                                );
+                            }
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "moddable-preflight" && (
@@ -461,27 +517,33 @@ export function DeployScreen({
             )}
 
             {stage.kind === "prompt-tags" && (
-                <Select<string | null>
-                    label="tag this app? (helps people find it in the playground)"
-                    options={[
-                        ...PLAYGROUND_TAGS.map((t) => ({ value: t as string | null, label: t })),
-                        { value: null, label: "skip", hint: "publish without a tag" },
-                    ]}
-                    onSelect={(t) => {
-                        setTag(t);
-                        advance(
-                            skipBuild,
-                            mode,
-                            deployContracts,
-                            buildDir,
-                            domain,
-                            publishToPlayground,
-                            moddable,
-                            repositoryUrl,
-                            t,
-                        );
-                    }}
-                />
+                <Box flexDirection="column">
+                    <PromptInfo box={TAGS_HELP} />
+                    <Select<string | null>
+                        label="tag this app?"
+                        options={[
+                            ...PLAYGROUND_TAGS.map((t) => ({
+                                value: t as string | null,
+                                label: t,
+                            })),
+                            { value: null, label: "skip", hint: "publish without a tag" },
+                        ]}
+                        onSelect={(t) => {
+                            setTag(t);
+                            advance(
+                                skipBuild,
+                                mode,
+                                deployContracts,
+                                buildDir,
+                                domain,
+                                publishToPlayground,
+                                moddable,
+                                repositoryUrl,
+                                t,
+                            );
+                        }}
+                    />
+                </Box>
             )}
 
             {stage.kind === "confirm" && resolved && (

--- a/src/commands/deploy/promptHelp.test.ts
+++ b/src/commands/deploy/promptHelp.test.ts
@@ -1,0 +1,80 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import {
+    BUILD_HELP,
+    CONTRACTS_HELP,
+    SIGNER_HELP,
+    PUBLISH_HELP,
+    MODDABLE_HELP,
+    TAGS_HELP,
+    BUILD_DIR_HINT,
+    DOMAIN_HINT,
+    type PromptBox,
+} from "./promptHelp.js";
+
+const BOXES: Record<string, PromptBox> = {
+    BUILD_HELP,
+    CONTRACTS_HELP,
+    SIGNER_HELP,
+    PUBLISH_HELP,
+    MODDABLE_HELP,
+    TAGS_HELP,
+};
+
+describe("deploy prompt help boxes", () => {
+    it("every box has a non-empty title and body", () => {
+        for (const [name, box] of Object.entries(BOXES)) {
+            expect(box.title.trim(), `${name}.title`).not.toBe("");
+            expect(box.body.trim(), `${name}.body`).not.toBe("");
+        }
+    });
+
+    // Soft cap so the boxes stay glanceable rather than turning into a wall of
+    // text. ~320 chars wraps to roughly four lines at the picker's width.
+    it("keeps every body readable (<= 320 chars)", () => {
+        for (const [name, box] of Object.entries(BOXES)) {
+            expect(box.body.length, `${name}.body length`).toBeLessThanOrEqual(320);
+        }
+    });
+});
+
+describe("plain-language anchors (the prompts the feedback called out)", () => {
+    it("contracts help explains the website-vs-contract distinction without bare jargon", () => {
+        const body = CONTRACTS_HELP.body.toLowerCase();
+        expect(body).toContain("website");
+        expect(body).toContain("contract");
+        // It must tell the user what to pick for each case (not just contain
+        // the bare words "no"/"yes", which would match "another"/"yesterday").
+        expect(body).toContain("choose no");
+        expect(body).toContain("choose yes");
+    });
+
+    it("moddable help explains what modding is and what gets shared", () => {
+        const body = MODDABLE_HELP.body.toLowerCase();
+        expect(body).toContain("playground mod");
+        expect(body).toContain("github");
+    });
+});
+
+describe("trivial-input hints", () => {
+    it("are one-line, non-empty strings", () => {
+        for (const [name, hint] of Object.entries({ BUILD_DIR_HINT, DOMAIN_HINT })) {
+            expect(hint.trim(), name).not.toBe("");
+            expect(hint, name).not.toContain("\n");
+        }
+    });
+});

--- a/src/commands/deploy/promptHelp.ts
+++ b/src/commands/deploy/promptHelp.ts
@@ -1,0 +1,91 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Plain-language help copy for the interactive `playground deploy` prompts.
+ *
+ * Feedback: users who'd been "vibe coding" couldn't interpret prompts like
+ * "changed contracts?" and skipped the moddable step because the choices were
+ * opaque. So each conceptual choice now renders an info box (a `Callout`)
+ * above it explaining what the decision is and what each option does, and the
+ * labels/hints are reworded into everyday language. The prompt ORDER and
+ * gating are intentionally unchanged (contracts must run before the frontend
+ * build, so it stays first); this module only owns the words.
+ *
+ * Boxed prompts (conceptual choices) get a `{ title, body }`; the two trivial
+ * text inputs (domain, build directory) get a single dim hint line instead of
+ * a full bordered box. Keep bodies short enough to read at a glance; the test
+ * enforces a soft length cap.
+ */
+
+export interface PromptBox {
+    title: string;
+    body: string;
+}
+
+export const BUILD_HELP: PromptBox = {
+    title: "Build step",
+    body:
+        "Compiles your latest code into the files we upload. Choose Yes to " +
+        "rebuild now, or No to redeploy the build that's already in your build folder.",
+};
+
+export const CONTRACTS_HELP: PromptBox = {
+    title: "Smart contracts · your app's on-chain backend",
+    body:
+        "Smart contracts hold your app's on-chain logic and data, and deploy " +
+        "separately from your website. If you only changed the website, choose No. " +
+        "If you changed contract code in this project, choose Yes, and we'll redeploy " +
+        "and reinstall them, then rebuild the site to match.",
+};
+
+export const SIGNER_HELP: PromptBox = {
+    title: "Who signs the upload",
+    body:
+        "Publishing writes to the blockchain, which needs a signature. The dev " +
+        "signer uses a shared test account: instant, no phone needed. Your phone " +
+        "signer signs with your own logged-in account, with a few taps on your phone.",
+};
+
+export const PUBLISH_HELP: PromptBox = {
+    title: "Publish to the playground",
+    body:
+        "Choosing Yes lists your app in the public Polkadot Playground so others " +
+        "can find and open it. No still deploys it to your .dot address. It just " +
+        "won't be listed in the playground.",
+};
+
+export const MODDABLE_HELP: PromptBox = {
+    title: "Moddable apps",
+    body:
+        "A moddable app shares its source so anyone can run `playground mod` to " +
+        "clone it as a starting point for their own version. This publishes a link " +
+        "to your public GitHub repo. Your app works exactly the same either way. " +
+        "This only adds a 'remix me' link.",
+};
+
+export const TAGS_HELP: PromptBox = {
+    title: "Category tag",
+    body:
+        "Pick a category so people can filter for your app in the playground. " +
+        "This is optional: choose Skip to publish without a tag.",
+};
+
+/** One-line hints for the trivial text inputs (no bordered box). */
+export const BUILD_DIR_HINT =
+    "The folder holding your built site (the files we upload). The default fits most projects.";
+
+export const DOMAIN_HINT =
+    "Pick the .dot address people will use to reach your app, e.g. my-app.dot.";

--- a/src/commands/mod/AppBrowser.tsx
+++ b/src/commands/mod/AppBrowser.tsx
@@ -17,8 +17,14 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
 import { Mark, Hint, Callout, COLOR } from "../../utils/ui/theme/index.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
+import { assertPublicGitHubRepo, ModdablePreflightError } from "../../utils/deploy/moddable.js";
 
 import { COMMUNITY_NOTICE_TITLE, COMMUNITY_NOTICE_BODY } from "./communityNotice.js";
+import {
+    SOURCE_UNAVAILABLE_TITLE,
+    sourceUnavailableBody,
+    PICK_ANOTHER_APP,
+} from "./sourceUnavailable.js";
 import { filterModdable, type AppEntry } from "./browserFilter.js";
 export type { AppEntry };
 
@@ -47,6 +53,14 @@ export function AppBrowser({ registry, onSelect, onCancel, moddableOnly }: Props
     const [cursor, setCursor] = useState(0);
     const [scroll, setScroll] = useState(0);
     const [fetching, setFetching] = useState(true);
+    // A source check is in flight (HEAD against the picked app's GitHub repo).
+    const [checking, setChecking] = useState(false);
+    // Domain of the app whose repo turned out to be unreachable, or null. The
+    // picker stays open and shows a yellow notice so the user picks another.
+    const [unavailable, setUnavailable] = useState<string | null>(null);
+    // Set when the user quits mid-check so the in-flight verifyAndSelect promise
+    // no-ops instead of calling onSelect/setState on an unmounted component.
+    const cancelledRef = useRef(false);
     // Offset (in reverse-chronological order) of the next page to request.
     // Contract's `getApps(start, count)` treats `start` as a REVERSE offset —
     // `start=0` returns the newest batch, and the next page resumes at
@@ -152,7 +166,51 @@ export function AppBrowser({ registry, onSelect, onCancel, moddableOnly }: Props
         }
     }, [cursor, filtered.length, fetching, loadBatch]);
 
+    // The picker filters to apps that published a repository URL, but that URL
+    // is frozen at deploy time and never re-checked against live GitHub (see
+    // sourceUnavailable.ts). Probe ONLY the picked app — one HEAD request, same
+    // as the old post-pick check — so a stale/now-private repo is caught before
+    // we mount SetupScreen. A 404 keeps the user in the picker with a friendly
+    // notice; transient errors fall through to SetupScreen's clearer download
+    // failure.
+    const verifyAndSelect = useCallback(
+        async (app: AppEntry) => {
+            if (!app.repository) {
+                onSelect(app);
+                return;
+            }
+            setChecking(true);
+            setUnavailable(null);
+            try {
+                await assertPublicGitHubRepo(app.repository);
+                if (cancelledRef.current) return;
+                onSelect(app);
+            } catch (err) {
+                if (cancelledRef.current) return;
+                if (err instanceof ModdablePreflightError) {
+                    setUnavailable(app.domain);
+                    setChecking(false);
+                } else {
+                    onSelect(app);
+                }
+            }
+        },
+        [onSelect],
+    );
+
     useInput((input, key) => {
+        // `q` quits even while a source check is in flight — set the cancel
+        // flag first so the pending verifyAndSelect promise no-ops instead of
+        // resolving onSelect/setState against an unmounted component.
+        if (input === "q") {
+            cancelledRef.current = true;
+            onCancel?.();
+            return;
+        }
+        // Otherwise ignore keystrokes during the brief HEAD check so navigation
+        // and Enter can't race the in-flight verification.
+        if (checking) return;
+        if (key.upArrow || key.downArrow) setUnavailable(null);
         if (key.upArrow && cursor > 0) {
             const next = cursor - 1;
             setCursor(next);
@@ -163,8 +221,7 @@ export function AppBrowser({ registry, onSelect, onCancel, moddableOnly }: Props
             setCursor(next);
             if (next >= scroll + viewH) setScroll(next - viewH + 1);
         }
-        if (key.return && filtered.length > 0) onSelect(filtered[cursor]);
-        if (input === "q") onCancel?.();
+        if (key.return && filtered.length > 0) void verifyAndSelect(filtered[cursor]);
     });
 
     const visible = filtered.slice(scroll, scroll + viewH);
@@ -224,7 +281,18 @@ export function AppBrowser({ registry, onSelect, onCancel, moddableOnly }: Props
                             : `(${apps.length}/${total})`
                     }`}</Hint>
                 </Box>
+                {checking && (
+                    <Box gap={1} marginTop={1}>
+                        <Mark kind="run" />
+                        <Text dimColor>checking source…</Text>
+                    </Box>
+                )}
             </Box>
+            {unavailable && (
+                <Callout tone="warning" title={SOURCE_UNAVAILABLE_TITLE}>
+                    <Text>{sourceUnavailableBody(unavailable, PICK_ANOTHER_APP)}</Text>
+                </Callout>
+            )}
         </Box>
     );
 }

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -20,6 +20,13 @@ import { resolve } from "node:path";
 import { StepRunner, type Step } from "../../utils/ui/components/StepRunner.js";
 import { Header, Hint, Row, Section, Callout } from "../../utils/ui/theme/index.js";
 import { COMMUNITY_NOTICE_TITLE, COMMUNITY_NOTICE_BODY } from "./communityNotice.js";
+import {
+    SOURCE_UNAVAILABLE_TITLE,
+    sourceUnavailableBody,
+    SourceUnavailableHalt,
+    BROWSE_OTHER_APPS,
+} from "./sourceUnavailable.js";
+import { assertPublicGitHubRepo, ModdablePreflightError } from "../../utils/deploy/moddable.js";
 import { runCommand } from "../../utils/git.js";
 import { createOptionalGitBaseline } from "../../utils/mod/git-baseline.js";
 import { downloadGitHubTarball, parseGitHubRepoUrl } from "../../utils/mod/source.js";
@@ -55,6 +62,11 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
     // The matching `Hint` is driven off the state setter for re-render.
     const setupRanRef = useRef(false);
     const [setupRanVisible, setSetupRanVisible] = useState(false);
+    // Set when the app's GitHub source is no longer publicly reachable. Swaps
+    // the red "setup failed" row for a gentle yellow notice (see
+    // sourceUnavailable.ts) — the publisher made the repo private/deleted it
+    // after publishing, which we can't undo and the user can't fix.
+    const [unavailable, setUnavailable] = useState(false);
     const setupLogFile = resolve(targetDir, ".dot-mod-setup.log");
     const sourceLogFile = resolve(targetDir, ".dot-mod-source.log");
 
@@ -100,6 +112,22 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
                 // fallback handles the rare case of an old deploy that
                 // pre-dates the metadata field — codeload returns 404 for a
                 // wrong branch, which surfaces as a clear download error.
+                // The repository URL is frozen into the app metadata at deploy
+                // time; the publisher may since have made the repo private,
+                // deleted, or renamed it. Probe before the codeload download so
+                // we can present that gently instead of a raw 404 step failure.
+                // (The interactive picker pre-checks too, but a direct
+                // `playground mod <domain>` lands here without that guard.)
+                try {
+                    await assertPublicGitHubRepo(repoUrl);
+                } catch (err) {
+                    if (err instanceof ModdablePreflightError) {
+                        setUnavailable(true);
+                        throw new SourceUnavailableHalt("source no longer publicly available");
+                    }
+                    // Transient/non-404 verification error — fall through and
+                    // let the download below surface the real failure.
+                }
                 const branch = meta.branch ?? "main";
                 log(`downloading github.com/${ref.owner}/${ref.repo} (${branch})…`);
                 await downloadGitHubTarball({
@@ -159,8 +187,14 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
                 }}
             />
 
-            <Hint>→ {targetDir}</Hint>
+            {!unavailable && <Hint>→ {targetDir}</Hint>}
             {setupRanVisible && <Hint>full setup log: {setupLogFile}</Hint>}
+
+            {unavailable && (
+                <Callout tone="warning" title={SOURCE_UNAVAILABLE_TITLE}>
+                    <Text>{sourceUnavailableBody(domain, BROWSE_OTHER_APPS)}</Text>
+                </Callout>
+            )}
 
             {error && (
                 <Section>

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -25,7 +25,6 @@ import { SetupScreen } from "./SetupScreen.js";
 import { QuestPicker } from "./QuestPicker.js";
 import { defaultRepoName } from "../../utils/git/repoName.js";
 import { runCliCommand } from "../../cli-runtime.js";
-import { assertPublicGitHubRepo, ModdablePreflightError } from "../../utils/deploy/moddable.js";
 import { parseGitHubRepoUrl, type GitHubRepoRef } from "../../utils/mod/source.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
 
@@ -75,40 +74,13 @@ async function runModCommand(rawDomain: string | undefined): Promise<void> {
             metadata = picked;
         }
 
-        // Lazy verify that the picked app's source repository is publicly
-        // reachable. The picker filters apps that have NO repository URL, but
-        // a publisher can flip a repo to private after deploying, which would
-        // break the anonymous codeload download a few steps down. Bail here
-        // with a clean message so the user can pick a different app before we
-        // mount SetupScreen and start writing files.
-        //
-        // The direct-domain path (`playground mod some-domain.dot`) has no metadata
-        // at this point and falls through to SetupScreen, where a private or
-        // missing repo surfaces as a `downloadGitHubTarball` 404 step failure.
-        // Slightly less polished UX, but lifting the metadata fetch up here
-        // just for symmetry would be a larger refactor.
-        if (metadata?.repository) {
-            const repoUrl = metadata.repository;
-            try {
-                await withSpan(
-                    "cli.mod.repo-check",
-                    "verify repository is public",
-                    { "cli.mod.repo": repoUrl },
-                    () => assertPublicGitHubRepo(repoUrl),
-                );
-            } catch (err) {
-                if (err instanceof ModdablePreflightError) {
-                    console.error();
-                    console.error(`  ${err.message}.`);
-                    console.error(
-                        `  Pick a different app or ask the publisher to make the repo public.`,
-                    );
-                    process.exitCode = 1;
-                    return;
-                }
-                throw err;
-            }
-        }
+        // Source-repository reachability is verified at the point of use, not
+        // here: the interactive picker probes the picked app inline (and stays
+        // open with a friendly notice if the repo is gone), and SetupScreen
+        // re-checks for the direct `playground mod <domain>` path, surfacing the
+        // same gentle "source unavailable" notice instead of a raw 404. A
+        // publisher can make a repo private/delete it after deploying, so the
+        // frozen metadata URL is never trusted blindly. See sourceUnavailable.ts.
 
         // QuestPicker is a read-only display of `quests.json` from the track
         // repo's main. It runs BEFORE the existing setup flow without

--- a/src/commands/mod/sourceUnavailable.test.ts
+++ b/src/commands/mod/sourceUnavailable.test.ts
@@ -1,0 +1,52 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import {
+    sourceUnavailableBody,
+    SourceUnavailableHalt,
+    PICK_ANOTHER_APP,
+    BROWSE_OTHER_APPS,
+} from "./sourceUnavailable.js";
+
+describe("sourceUnavailableBody", () => {
+    it("names the domain and states the source is no longer publicly available", () => {
+        const body = sourceUnavailableBody("playground.dot", PICK_ANOTHER_APP);
+        expect(body).toContain("playground.dot");
+        expect(body).toContain("no longer publicly available");
+    });
+
+    it("appends the picker next-step for the interactive path", () => {
+        expect(sourceUnavailableBody("x.dot", PICK_ANOTHER_APP)).toContain(PICK_ANOTHER_APP);
+    });
+
+    it("appends the browse next-step for the direct path", () => {
+        expect(sourceUnavailableBody("x.dot", BROWSE_OTHER_APPS)).toContain("playground mod");
+    });
+
+    it("does not speculate about the publisher (we can't distinguish private/deleted/renamed)", () => {
+        const body = sourceUnavailableBody("x.dot", PICK_ANOTHER_APP).toLowerCase();
+        expect(body).not.toContain("publisher");
+        expect(body).not.toContain("private");
+    });
+});
+
+describe("SourceUnavailableHalt", () => {
+    it("is an Error carrying the halt-as-warning flag StepRunner duck-types", () => {
+        const err = new SourceUnavailableHalt("nope");
+        expect(err).toBeInstanceOf(Error);
+        expect((err as unknown as { haltAsWarning: boolean }).haltAsWarning).toBe(true);
+    });
+});

--- a/src/commands/mod/sourceUnavailable.ts
+++ b/src/commands/mod/sourceUnavailable.ts
@@ -1,0 +1,59 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Friendly messaging for the "this app's GitHub source is gone" case.
+ *
+ * The picker filters apps to those that published a `repository` URL, but the
+ * URL is frozen into the app's metadata at deploy time and never re-validated
+ * against live GitHub (deliberately — pre-probing the whole list would burn
+ * the 60 req/hr anonymous GitHub quota). A publisher can later make that repo
+ * private, delete it, or rename it, all of which GitHub reports identically as
+ * a 404 — so we can't truthfully say *why* it's gone, only that it isn't
+ * reachable. Both mod entry points (interactive picker + direct
+ * `playground mod <domain>`) surface this gently instead of the raw download
+ * 404 / "private or does not exist" line.
+ */
+
+export const SOURCE_UNAVAILABLE_TITLE = "Source unavailable";
+
+/** Next-step suffix for the interactive picker (stays open, user picks again). */
+export const PICK_ANOTHER_APP = "Pick another app below.";
+
+/** Next-step suffix for the direct `playground mod <domain>` path. */
+export const BROWSE_OTHER_APPS = "Run `playground mod` to browse other apps.";
+
+export function sourceUnavailableBody(domain: string, nextStep: string): string {
+    return (
+        `${domain}'s source repository is no longer publicly available, ` +
+        `so it can't be modded right now. ${nextStep}`
+    );
+}
+
+/**
+ * Thrown inside a StepRunner step to halt the remaining steps WITHOUT marking
+ * the run as a hard failure. StepRunner duck-types the `haltAsWarning` flag
+ * (the same way it reads `isWarning` on non-fatal warnings): it renders the
+ * row with the yellow "warn" mark and reports `ok: false` so callers skip the
+ * success-only "Next steps" footer. SetupScreen pairs this with a friendly
+ * Callout describing the unavailable source.
+ */
+export class SourceUnavailableHalt extends Error {
+    readonly haltAsWarning = true;
+    constructor(message: string) {
+        super(message);
+        this.name = "SourceUnavailableHalt";
+    }
+}

--- a/src/utils/deploy/moddable.test.ts
+++ b/src/utils/deploy/moddable.test.ts
@@ -56,6 +56,16 @@ describe("assertPublicGitHubRepo", () => {
         ).rejects.toThrow(/must use a public github repository/i);
     });
 
+    it("passes an abort signal so a stalled socket can't hang the probe", async () => {
+        let seenSignal: unknown;
+        const mockFetch: typeof fetch = async (_url, init) => {
+            seenSignal = init?.signal;
+            return new Response(null, { status: 200 });
+        };
+        await assertPublicGitHubRepo("https://github.com/foo/bar", mockFetch);
+        expect(seenSignal).toBeInstanceOf(AbortSignal);
+    });
+
     it("does nothing on network error (fail open — codeload reveals truth later)", async () => {
         const mockFetch: typeof fetch = async () => {
             throw new Error("ECONNREFUSED");

--- a/src/utils/deploy/moddable.ts
+++ b/src/utils/deploy/moddable.ts
@@ -30,6 +30,15 @@ import { parseGitHubRepoUrl } from "../mod/source.js";
 
 export class ModdablePreflightError extends Error {}
 
+/**
+ * Upper bound on the public-repo HEAD probe. A *stalled* socket (as opposed to
+ * a fast network error) would otherwise hang the await until the OS-level
+ * socket timeout — minutes — which strands the `playground mod` picker (it
+ * blocks input while a check is in flight). On timeout we abort and fail open,
+ * exactly like any other network error below.
+ */
+const REPO_CHECK_TIMEOUT_MS = 10_000;
+
 export async function ensureGitInstalled(onLog?: (line: string) => void): Promise<void> {
     if (await commandExists("git")) return;
     const step = TOOL_STEPS.find((s) => s.name === "git");
@@ -92,9 +101,12 @@ export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetc
 
     let res: Response;
     try {
-        res = await f(`https://github.com/${ref.owner}/${ref.repo}`, { method: "HEAD" });
+        res = await f(`https://github.com/${ref.owner}/${ref.repo}`, {
+            method: "HEAD",
+            signal: AbortSignal.timeout(REPO_CHECK_TIMEOUT_MS),
+        });
     } catch {
-        return; // network error — can't verify, let downstream fail
+        return; // network error or timeout — can't verify, let downstream fail
     }
 
     if (res.ok) return;

--- a/src/utils/ui/components/StepRunner.tsx
+++ b/src/utils/ui/components/StepRunner.tsx
@@ -19,6 +19,10 @@
  *
  * Errors are passed to onDone for the parent to display below the UI.
  * Warnings (`isWarning = true`) show inline and don't stop execution.
+ * Halting warnings (`haltAsWarning = true`) show inline with the warn mark and
+ * STOP execution, but report `ok: false` with no `error` — for cases the
+ * parent wants to present gently (its own Callout) rather than as a red
+ * failure row, while still skipping any success-only output.
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -117,6 +121,7 @@ export function StepRunner({ title, steps, onDone }: Props) {
 
         (async () => {
             let error: string | undefined;
+            let halted = false;
 
             for (let i = 0; i < steps.length; i++) {
                 if (cancelled) break;
@@ -137,7 +142,18 @@ export function StepRunner({ title, steps, onDone }: Props) {
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     const isWarning = err instanceof Error && (err as any).isWarning === true;
+                    const haltAsWarning =
+                        err instanceof Error && (err as any).haltAsWarning === true;
 
+                    if (haltAsWarning) {
+                        setStates((prev) =>
+                            prev.map((s, j) =>
+                                j === i ? { ...s, status: "warning", message: msg } : s,
+                            ),
+                        );
+                        halted = true;
+                        break;
+                    }
                     if (isWarning) {
                         setStates((prev) =>
                             prev.map((s, j) =>
@@ -154,7 +170,7 @@ export function StepRunner({ title, steps, onDone }: Props) {
                 }
             }
 
-            if (!cancelled) onDone({ ok: !error, error });
+            if (!cancelled) onDone({ ok: !error && !halted, error });
         })();
 
         return () => {


### PR DESCRIPTION
## Summary

Two independent messaging/UX improvements for `playground mod` and `playground deploy`, both addressing the same theme: prompts and errors that non-technical ("vibe coding") users couldn't interpret.

### 1. `mod`: friendly "Source unavailable" notice

A moddable app's GitHub source URL is frozen into its metadata at deploy time and never re-validated against live GitHub (deliberate, to avoid burning the 60 req/hr anonymous GitHub quota across the whole picker list). When a publisher later makes that repo private, deletes, or renames it, the app still shows as moddable but the source 404s.

Previously the user hit a raw `console.error` "private or does not exist" under the picker, or a red `✕ setup failed … 404 Not Found` in the setup screen. Now:

- **Picker (`pg mod`)**: probes the picked app's repo on Enter; on 404 the picker **stays open** with a yellow "Source unavailable" box so the user picks another app. `q` quits even mid-check (guarded against setState-after-unmount).
- **Direct (`pg mod <domain>`)**: `SetupScreen`'s download step shows the same box instead of the red failure row.
- `StepRunner` gains a generic `haltAsWarning` flag (stop steps, render the warn mark, report `ok:false`) mirroring the existing `isWarning`.
- `assertPublicGitHubRepo` now bounds its HEAD probe with a 10s abort timeout so a stalled socket can't hang the picker.

Wording stays neutral ("no longer publicly available", no "made private", no publisher mention) since GitHub returns 404 for private/deleted/renamed alike.

### 2. `deploy`: plain-language info boxes on prompts

Feedback was that prompts like "changed contracts?" were uninterpretable and users skipped the moddable step because the choices were opaque.

Each conceptual prompt now renders an accent-toned info box above it explaining the decision and what each option does, with reworded labels/hints:

- `changed contracts?` → **`did you change your smart contracts?`** · options `I only changed the website` / `I changed contract code too`
- `make this app moddable?` → **`let others remix (mod) this app?`** · box explains what modding is and that it publishes a link to your public GitHub repo

The two trivial text inputs (domain, build directory) get a one-line hint instead of a full box. Copy lives in a single testable `promptHelp.ts` module.

**The prompt order, gating, and deploy behavior are unchanged** (contracts must stay first; moddable default stays "yes").

## Testing

`pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, and `pnpm test` (721 passing) all green. Both features were code-reviewed by a fresh reviewer agent; findings (a picker-cancel timeout, an em-dash slip, a tautological assertion) were fixed.

Note: the Ink JSX wiring is not unit-tested (vitest only picks up `.test.ts`, not `.tsx`), per repo convention; the pure copy/logic is lifted to `.ts` modules and tested there.
