### PR TITLE
fix(init): install git before the cargo-pvm-contract step

### DIFF
--- a/.changeset/clean-ubuntu-git-ordering.md
+++ b/.changeset/clean-ubuntu-git-ordering.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Install git before cargo-pvm-contract in `playground init` so clean Linux installs no longer fail at the `git clone` step (the git dependency used to be installed two steps after the first step that needs it)

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -54,6 +54,21 @@ describe("prependPath", () => {
 });
 
 describe("TOOL_STEPS", () => {
+    it("installs git before any step whose installer shells out to it (#247)", () => {
+        // On a clean Ubuntu install (no Xcode CLT equivalent), git is absent
+        // until our own git step runs. Any earlier step that invokes git in
+        // its install command fails — the DevEx audit hit exactly this with
+        // cargo-pvm-contract's `git clone`. macOS masks the bug because git
+        // is always present, so this ordering is pinned by test instead.
+        const names = TOOL_STEPS.map((step) => step.name);
+        const gitIndex = names.indexOf("git");
+        expect(gitIndex).toBeGreaterThanOrEqual(0);
+
+        const cargoPvmIndex = names.indexOf("cargo-pvm-contract");
+        expect(cargoPvmIndex).toBeGreaterThanOrEqual(0);
+        expect(gitIndex).toBeLessThan(cargoPvmIndex);
+    });
+
     it("installs cargo-pvm-contract directly instead of the CDM CLI installer", () => {
         const names = TOOL_STEPS.map((step) => step.name);
         expect(names).toContain("cargo-pvm-contract");

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -114,7 +114,29 @@ host_target="$(rustc -vV | awk '/^host:/ { print $2 }')"
 cargo install --force --locked --target "$host_target" --path "$tmp_dir/crates/cargo-pvm-contract"
 `.trim();
 
+// Step order is load-bearing: git MUST come before cargo-pvm-contract, whose
+// install script starts with `git clone` (#247 — clean Ubuntu has no git, so
+// the clone failed before the git step ran; macOS masked it via Xcode CLT).
+// git goes first overall: it's the cheapest step, so a broken apt surfaces
+// before the multi-hundred-MB rustup/nightly downloads. Pinned by a test in
+// toolchain.test.ts.
 export const TOOL_STEPS: ToolStep[] = [
+    {
+        name: "git",
+        check: () => commandExists("git"),
+        install: async (onData) => {
+            if (platform() === "darwin" && (await commandExists("brew"))) {
+                await runPiped("brew install git", onData);
+            } else if (platform() === "linux") {
+                await runPiped(`${sudo()}apt update && ${sudo()}apt install -y git`, onData);
+            } else {
+                throw new Error(
+                    "Cannot install git automatically on this platform — install manually.",
+                );
+            }
+        },
+        manualHint: "https://git-scm.com/downloads",
+    },
     {
         name: "rustup",
         check: () => commandExists("rustup"),
@@ -168,22 +190,6 @@ export const TOOL_STEPS: ToolStep[] = [
             }
         },
         manualHint: "https://docs.ipfs.tech/install/ then run: ipfs init",
-    },
-    {
-        name: "git",
-        check: () => commandExists("git"),
-        install: async (onData) => {
-            if (platform() === "darwin" && (await commandExists("brew"))) {
-                await runPiped("brew install git", onData);
-            } else if (platform() === "linux") {
-                await runPiped(`${sudo()}apt update && ${sudo()}apt install -y git`, onData);
-            } else {
-                throw new Error(
-                    "Cannot install git automatically on this platform — install manually.",
-                );
-            }
-        },
-        manualHint: "https://git-scm.com/downloads",
     },
     {
         // Required by `dot decentralize` (mirrors a live site via `wget --mirror`).


### PR DESCRIPTION
## What

`playground init` walks `TOOL_STEPS` in array order. `cargo-pvm-contract`'s install script starts with `git clone`, but the `git` step ran **two steps later** (after IPFS). On a clean Linux box with no git, `cargo-pvm-contract` failed at the clone before git was ever installed. macOS masked the bug because git ships with the Xcode Command Line Tools.

This moves `git` to the front of `TOOL_STEPS` so it installs before any step that shells out to it. Putting it first overall also means a broken `apt` surfaces before the multi-hundred-MB rustup/nightly downloads.

## Changes

- Reorder `TOOL_STEPS` so `git` is first (`src/utils/toolchain.ts`).
- Add a regression test pinning `git` before `cargo-pvm-contract` (`src/utils/toolchain.test.ts`).
- Changeset (patch).

## Verification

- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` all pass (722 tests).
- Proved the new test is a real guard: ran it against the pre-fix ordering and it fails (`expected 5 to be less than 3`); passes against the fix.

## Note

Takes over #282 (re-applied on top of `main` with a signed commit). Original work by @illegalcall, credited via `Co-authored-by`. #282 can be closed.