### PR TITLE
chore: refresh @w3s/playground-registry snapshot to v7

### DIFF
--- a/.changeset/refresh-playground-registry-v7.md
+++ b/.changeset/refresh-playground-registry-v7.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Refresh the bundled `@w3s/playground-registry` contract snapshot to version 7 (new contract address + metadata CID). The ABI is unchanged, so this only updates the fallback snapshot that backs live address resolution.

--- a/cdm.json
+++ b/cdm.json
@@ -5,8 +5,8 @@
   },
   "contracts": {
     "@w3s/playground-registry": {
-      "version": 6,
-      "address": "0x82db2A7013ee5bDC69e12CC998dDb3A3eca1Ce4F",
+      "version": 7,
+      "address": "0xeB814656e2466b5A8e613F8121D57c75F684A35D",
       "abi": [
         {
           "type": "constructor",
@@ -1133,7 +1133,7 @@
           "stateMutability": "view"
         }
       ],
-      "metadataCid": "bafk2bzacedzwo2736o7g4j5epc752vf7vw5dfhec3yhtxwatc53pj4xcpfemy"
+      "metadataCid": "bafk2bzaceavewu2aczp237db4dtzgej4tkjavhwfczp3jgaottwzzgpzuadry"
     }
   }
 }


### PR DESCRIPTION
The `@w3s/playground-registry` contract had a new on-chain release. This refreshes the bundled `cdm.json` snapshot from **v6 to v7** via the CDM install backend (which resolves `"latest"` from the on-chain meta-registry, re-fetches ABI/metadata, and regenerates the gitignored `.cdm/*.d.ts` bindings).

## Changes
- `cdm.json`: `version` 6 → 7, new contract `address` (`0xeB81…A35D`), new `metadataCid`.
- **The ABI is byte-identical** between v6 and v7 — this is a contract redeploy, not an interface change, so no code, types, or call sites needed touching.
- The regenerated `.cdm/` bindings are gitignored (local cache), so they don't appear in the diff.

## Verification
- ABI unchanged, proven by diffing the v6/v7 snapshots.
- Meta-`registry` address (`0xf62c2ece…`) and the `"latest"` dependency are unchanged (CLAUDE.md invariant: must not drift from playground-app).
- On-chain meta-registry confirms `getVersionCount = 8` for `@w3s/playground-registry` (versions 0–7) → latest = **v7**.
- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, and full `pnpm test` (766 passing) all green.

`patch` bump: the snapshot is only the fallback behind live address resolution and the surface is unchanged.
