### PR TITLE
feat(deploy): polish interactive prompts and add README detail-page ack

### DIFF
--- a/.changeset/deploy-prompt-defaults.md
+++ b/.changeset/deploy-prompt-defaults.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Polish the `playground deploy` interactive prompts: drop the confusing `my-app` placeholder on the domain input (people tried to backspace it), default the "publish to the playground?" question to "yes", and order every prompt so the default option sits on top.

--- a/.changeset/deploy-readme-ack.md
+++ b/.changeset/deploy-readme-ack.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground deploy` now opens with a short acknowledgement that your README.md becomes your app's detail page on the playground. Press enter to continue into the normal flow, or esc to exit cleanly and update the README first. The screen only appears in interactive mode, so scripted/headless deploys are unaffected.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -99,10 +99,11 @@ export interface DeployScreenInputs {
      */
     tag?: string;
     userSigner: ResolvedSigner | null;
-    onDone: (outcome: DeployOutcome | null) => void;
+    onDone: (outcome: DeployOutcome | null, opts?: { graceful?: boolean }) => void;
 }
 
 export type Stage =
+    | { kind: "ack" }
     | { kind: "prompt-build" }
     | { kind: "prompt-signer" }
     | { kind: "prompt-contracts" }
@@ -193,19 +194,12 @@ export function DeployScreen({
     // the summary card shows the correct phone-approval count (a new register
     // is 3 DotNS taps, an update of a name we already own is 1).
     const [plan, setPlan] = useState<DeployPlan | null>(null);
-    const [stage, setStage] = useState<Stage>(() =>
-        pickInitialStage(
-            effectiveInitialSkipBuild,
-            effectiveInitialMode,
-            initialDeployContracts,
-            initialBuildDir,
-            initialDomain,
-            initialPublish,
-            initialModdable,
-            null,
-            initialTag,
-        ),
-    );
+    // Always open on the README acknowledgement so users learn — before
+    // investing any time in the flow — that their README becomes the app's
+    // playground detail page. Enter drops into the normal prompt sequence
+    // (computed from any pre-filled flags); Esc exits gracefully so they can
+    // go edit the README first.
+    const [stage, setStage] = useState<Stage>({ kind: "ack" });
 
     // Passed down to RunningStage; read back on completion for the sparkline.
     // Ref instead of state so the high-frequency chunk-progress stream doesn't
@@ -287,6 +281,13 @@ export function DeployScreen({
                 network={getNetworkLabel()}
                 right={VERSION_LABEL}
             />
+
+            {stage.kind === "ack" && (
+                <AckStage
+                    onContinue={() => advance()}
+                    onExit={() => onDone(null, { graceful: true })}
+                />
+            )}
 
             {stage.kind === "prompt-build" && (
                 <Box flexDirection="column">
@@ -387,7 +388,6 @@ export function DeployScreen({
                     <PromptHint text={DOMAIN_HINT} />
                     <Input
                         label="domain"
-                        placeholder="my-app"
                         prefill={domain ?? ""}
                         externalError={domainError}
                         validate={(v) => {
@@ -433,8 +433,8 @@ export function DeployScreen({
                     <Select<boolean>
                         label="publish to the playground?"
                         options={[
-                            { value: false, label: "no", hint: "deploy to my .dot address only" },
                             { value: true, label: "yes", hint: "list it in the public playground" },
+                            { value: false, label: "no", hint: "deploy to my .dot address only" },
                         ]}
                         initialIndex={0}
                         onSelect={(yes) => {
@@ -461,17 +461,17 @@ export function DeployScreen({
                         label="let others remix (mod) this app?"
                         options={[
                             {
-                                value: false,
-                                label: "no",
-                                hint: "keep my source private",
-                            },
-                            {
                                 value: true,
                                 label: "yes",
                                 hint: "share my source so others can remix",
                             },
+                            {
+                                value: false,
+                                label: "no",
+                                hint: "keep my source private",
+                            },
                         ]}
-                        initialIndex={1}
+                        initialIndex={0}
                         onSelect={(yes) => {
                             setModdable(yes);
                             if (yes) {
@@ -601,30 +601,6 @@ export function DeployScreen({
 
 // ── Stage pickers ────────────────────────────────────────────────────────────
 
-function pickInitialStage(
-    skipBuild: boolean | null,
-    mode: SignerMode | null,
-    deployContracts: boolean | null,
-    buildDir: string | null,
-    domain: string | null,
-    publish: boolean | null,
-    moddable: boolean | null,
-    repositoryUrl: string | null,
-    tag: string | null | undefined,
-): Stage {
-    return pickNextStage(
-        skipBuild,
-        mode,
-        deployContracts,
-        buildDir,
-        domain,
-        publish,
-        moddable,
-        repositoryUrl,
-        tag,
-    );
-}
-
 export function pickNextStage(
     skipBuild: boolean | null,
     mode: SignerMode | null,
@@ -652,6 +628,34 @@ export function pickNextStage(
     // is fully resolved, and only when no `--tag` flag pre-filled it.
     if (publish && tag === undefined) return { kind: "prompt-tags" };
     return { kind: "confirm" };
+}
+
+// ── README acknowledgement ─────────────────────────────────────────────────────
+
+/**
+ * First screen of every interactive deploy. Many users don't realise the
+ * project README is what renders as their app's detail page in the playground,
+ * so we surface it up front: Enter continues into the normal prompt flow, Esc
+ * exits cleanly (exit code 0) so they can update the README and re-run.
+ */
+function AckStage({ onContinue, onExit }: { onContinue: () => void; onExit: () => void }) {
+    useInput((_input, key) => {
+        if (key.return) onContinue();
+        else if (key.escape) onExit();
+    });
+    return (
+        <Box flexDirection="column">
+            <Callout tone="accent" title="Your app detail page">
+                <Text>
+                    Your README.md becomes your app's detail page on the playground. Make sure it's
+                    up to date before you publish.
+                </Text>
+            </Callout>
+            <Box marginTop={1}>
+                <Hint>{"enter to continue · esc to exit and edit"}</Hint>
+            </Box>
+        </Box>
+    );
 }
 
 // ── Moddable preflight ────────────────────────────────────────────────────────

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -17,9 +17,11 @@ import { describe, it, expect } from "vitest";
 
 import {
     assertPublishFlagsConsistent,
+    classifyDeployDone,
     isFullySpecified,
     shouldResolveUserSigner,
 } from "./index.js";
+import type { DeployOutcome } from "../../utils/deploy/run.js";
 
 describe("shouldResolveUserSigner", () => {
     it("skips signer lookup for pure dev deploys", () => {
@@ -57,6 +59,27 @@ describe("isFullySpecified", () => {
 
     it("allows headless deploy when contracts are explicitly skipped", () => {
         expect(isFullySpecified({ ...fullySpecified, contracts: false })).toBe(true);
+    });
+});
+
+describe("classifyDeployDone", () => {
+    // A realistic non-null outcome — only its non-null-ness matters here.
+    const outcome = { appUrl: "https://x.dot", fullDomain: "x.dot" } as DeployOutcome;
+
+    it("treats a non-null outcome as success", () => {
+        expect(classifyDeployDone(outcome)).toBe("success");
+        // `graceful` is irrelevant once an outcome exists.
+        expect(classifyDeployDone(outcome, { graceful: true })).toBe("success");
+    });
+
+    it("treats a graceful null cancel as graceful-cancel (exit 0)", () => {
+        expect(classifyDeployDone(null, { graceful: true })).toBe("graceful-cancel");
+    });
+
+    it("treats a plain null cancel as a failure (exit 1)", () => {
+        expect(classifyDeployDone(null)).toBe("failure");
+        expect(classifyDeployDone(null, {})).toBe("failure");
+        expect(classifyDeployDone(null, { graceful: false })).toBe("failure");
     });
 });
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -313,6 +313,24 @@ export function isFullySpecified(opts: DeployOpts): boolean {
     );
 }
 
+export type DeployDoneDisposition = "success" | "graceful-cancel" | "failure";
+
+/**
+ * Maps a `DeployScreen` `onDone` callback into the outcome the interactive
+ * runner should produce. A non-null outcome is a success; a null outcome is a
+ * failure (exit 1) UNLESS it was a graceful cancel — the user pressing Esc on
+ * the README acknowledgement to go edit it, which exits 0 with a friendly
+ * nudge. Extracted as a pure function so this branch is unit-testable without
+ * rendering the Ink TUI.
+ */
+export function classifyDeployDone(
+    outcome: DeployOutcome | null,
+    opts?: { graceful?: boolean },
+): DeployDoneDisposition {
+    if (outcome !== null) return "success";
+    return opts?.graceful ? "graceful-cancel" : "failure";
+}
+
 /**
  * `--moddable` and `--tag` both only affect the playground metadata JSON, which
  * is uploaded ONLY when publishing. Supplying either without `--playground` is a
@@ -531,15 +549,30 @@ function runInteractive(ctx: {
                         // when the user opts to publish.
                         tag: ctx.opts.tag,
                         userSigner: ctx.userSigner,
-                        onDone: (outcome: DeployOutcome | null) => {
+                        onDone: (
+                            outcome: DeployOutcome | null,
+                            doneOpts?: { graceful?: boolean },
+                        ) => {
                             if (settled) return;
                             settled = true;
                             app?.unmount();
-                            if (outcome === null) {
-                                process.exitCode = 1;
-                                rejectPromise(new Error("Deploy was cancelled or failed."));
-                            } else {
-                                resolvePromise();
+                            switch (classifyDeployDone(outcome, doneOpts)) {
+                                case "graceful-cancel":
+                                    // The user pressed Esc on the README
+                                    // acknowledgement to go edit it — not a
+                                    // failure. Exit 0 with a friendly nudge.
+                                    process.stdout.write(
+                                        "\nNo problem. Update your README.md and re-run `playground deploy` when ready.\n",
+                                    );
+                                    resolvePromise();
+                                    break;
+                                case "failure":
+                                    process.exitCode = 1;
+                                    rejectPromise(new Error("Deploy was cancelled or failed."));
+                                    break;
+                                case "success":
+                                    resolvePromise();
+                                    break;
                             }
                         },
                     }),


### PR DESCRIPTION
## What & why

Interactive `playground deploy` UX feedback, in three small fixes plus one new screen.

### 1. Drop the `my-app` domain placeholder
The domain input rendered `my-app` between the cursor glyphs, so people read it as pre-filled text and tried to backspace it. Removed the placeholder (it was never used as a submit default anyway).

### 2. Default "publish to the playground?" to **yes**
Reordered the options so `yes` is first with `initialIndex={0}`.

### 3. Defaults on top everywhere
Audited every interactive `Select`. All were already default-on-top except `prompt-moddable` (`initialIndex={1}`); reordered it so the default sits at index 0. Now changing away from a default always means moving *down*. Reordering is behavior-safe because every `onSelect` keys off `option.value`, not list position.

### 4. README detail-page acknowledgement
Many users don't realise their project `README.md` becomes their app's detail page on the playground. Every interactive deploy now opens on a short acknowledgement:

- **Enter** drops into the normal prompt flow (computed from any pre-filled `--flags`, identical to before).
- **Esc** exits cleanly (exit code 0 + a friendly nudge) so they can go edit the README first, rather than the usual "Deploy was cancelled or failed" error.

This is **interactive-only**: the headless path (`isFullySpecified` → `runHeadless`, used by `deploy-all` and all e2e tests) never mounts the TUI, so scripted deploys are unaffected.

## Notes

- The Enter path reuses the screen's existing `advance()` (state-derived), so it lands on exactly the same first prompt the flow used to open on — equivalence is structural, not a re-typed argument list that could drift.
- The graceful-cancel decision is lifted into a pure, exported `classifyDeployDone()` so the exit-0 branch is unit-tested without rendering Ink.

## Verification

`pnpm format:check`, `pnpm lint:license`, `pnpm typecheck` all clean; **769 tests pass** (+3 new for `classifyDeployDone`). Reviewed via a dispatched code-review pass that traced each requirement (Enter-equivalence, headless safety, exit-0 graceful path, reorder safety) against the code.

Two changesets included (`patch`).
