### PR TITLE
Use can_store runtime API for the Bulletin store preflight

### DIFF
--- a/.changeset/bulletin-can-store-preflight.md
+++ b/.changeset/bulletin-can-store-preflight.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+The Bulletin store preflight now asks the chain's `BulletinTransactionStorageApi::can_store` runtime API whether a store will land, instead of reading the chain height and comparing the authorization's `expiration` client-side. A single-byte `can_store` probe folds existence and non-expiry into one on-chain verdict (quota stays a soft limit — never gated, no `Increase` prompt). Mirrors paritytech/bulletin-deploy#693.

--- a/src/utils/allowances/bulletin.test.ts
+++ b/src/utils/allowances/bulletin.test.ts
@@ -54,13 +54,17 @@ const SLOT_SIGNER = { publicKey: PUBLIC_KEY } as any;
 
 const ENV_HINT = /playground login/;
 
-// The Bulletin authorization check reads the live chain height (to evaluate
-// expiry) directly off the typed API. `checkAuthorization` is mocked, but the
-// block read goes through `bulletinApi.query.System.Number`, so the api stub
-// must carry that path. Default height is 0, so any positive `expiration`
-// counts as "not expired".
-function bulletinApiAtBlock(block = 0): any {
-    return { query: { System: { Number: { getValue: async () => block } } } };
+// Usability is decided by the chain's `BulletinTransactionStorageApi::can_store`
+// runtime predicate (a 1-byte probe = exists + unexpired), reached through
+// `bulletinApi.apis.BulletinTransactionStorageApi.can_store`. `checkAuthorization`
+// is mocked separately and only feeds the expired-vs-never-authorized error
+// message, so the api stub just needs to carry the can_store verdict.
+function bulletinApiCanStore(verdict = true): any {
+    return {
+        apis: {
+            BulletinTransactionStorageApi: { can_store: vi.fn(async () => verdict) },
+        },
+    };
 }
 
 // An authorization that exists and has not expired (the only thing that gates
@@ -71,6 +75,16 @@ const ACTIVE_EXHAUSTED = {
     remainingTransactions: 0,
     remainingBytes: 0n,
     expiration: 100,
+};
+
+// An authorization that exists on-chain but is past its expiry — the chain's
+// can_store returns false for it, while `authorized` stays true so the error
+// path reports "has expired" rather than "not authorized".
+const EXPIRED = {
+    authorized: true,
+    remainingTransactions: 5,
+    remainingBytes: 1000n,
+    expiration: 10,
 };
 
 function sessionSigner(): ResolvedSigner {
@@ -124,13 +138,13 @@ describe("getBulletinAllowanceSigner", () => {
         ).rejects.toThrow(ENV_HINT);
     });
 
-    it("returns the slot signer when its authorization exists and is not expired", async () => {
+    it("returns the slot signer when can_store accepts (exists + not expired)", async () => {
         ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
         checkAuthorizationMock.mockResolvedValue(ACTIVE_EXHAUSTED);
 
         const signer = await getBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
         });
 
         expect(signer).toBe(SLOT_SIGNER);
@@ -138,13 +152,14 @@ describe("getBulletinAllowanceSigner", () => {
 
     it("returns the slot signer even when the tx/byte quota counters are exhausted (soft limits)", async () => {
         // The whole point of dropping the quota gate: an authorized, unexpired
-        // slot with zeroed counters still stores fine, so no Increase, no throw.
+        // slot with zeroed counters still stores fine (can_store=true), so no
+        // Increase, no throw.
         ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
         checkAuthorizationMock.mockResolvedValue(ACTIVE_EXHAUSTED);
 
         const signer = await getBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
         });
 
         expect(signer).toBe(SLOT_SIGNER);
@@ -161,19 +176,14 @@ describe("getBulletinAllowanceSigner", () => {
         expect(checkAuthorizationMock).not.toHaveBeenCalled();
     });
 
-    it("throws the expired error when the slot authorization is past its expiration block", async () => {
+    it("throws the expired error when can_store rejects an authorized slot", async () => {
         ensureSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
-        checkAuthorizationMock.mockResolvedValue({
-            authorized: true,
-            remainingTransactions: 5,
-            remainingBytes: 1000n,
-            expiration: 10,
-        });
+        checkAuthorizationMock.mockResolvedValue(EXPIRED);
 
         await expect(
             getBulletinAllowanceSigner({
                 publishSigner: sessionSigner(),
-                bulletinApi: bulletinApiAtBlock(20), // now (20) >= expiration (10) ⇒ expired
+                bulletinApi: bulletinApiCanStore(false), // chain rejects: expired
             }),
         ).rejects.toThrow(/has expired/);
     });
@@ -190,7 +200,7 @@ describe("getBulletinAllowanceSigner", () => {
         await expect(
             getBulletinAllowanceSigner({
                 publishSigner: sessionSigner(),
-                bulletinApi: bulletinApiAtBlock(0),
+                bulletinApi: bulletinApiCanStore(false),
             }),
         ).rejects.toThrow(/not authorized on-chain yet/);
     });
@@ -204,7 +214,7 @@ describe("getBulletinAllowanceSigner", () => {
 
         const signer = await getBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
         });
 
         expect(signer).toBe(SLOT_SIGNER);
@@ -241,7 +251,7 @@ describe("getBulletinAllowanceSigner — phone approval prompts", () => {
 
         await getBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
             onPrompt: prompt,
         });
 
@@ -282,7 +292,7 @@ describe("getBulletinAllowanceSigner — SDK signer passthrough", () => {
 
         const signer = await getBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
         });
 
         expect(signer).toBe(SLOT_SIGNER);
@@ -320,7 +330,7 @@ describe("getCachedBulletinAllowanceSigner", () => {
 
         const signer = await getCachedBulletinAllowanceSigner({
             publishSigner: sessionSigner(),
-            bulletinApi: bulletinApiAtBlock(50),
+            bulletinApi: bulletinApiCanStore(true),
         });
 
         expect(signer).toBe(SLOT_SIGNER);
@@ -329,17 +339,12 @@ describe("getCachedBulletinAllowanceSigner", () => {
 
     it("throws the expired error without requesting an allocation", async () => {
         createSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
-        checkAuthorizationMock.mockResolvedValue({
-            authorized: true,
-            remainingTransactions: 5,
-            remainingBytes: 1000n,
-            expiration: 10,
-        });
+        checkAuthorizationMock.mockResolvedValue(EXPIRED);
 
         await expect(
             getCachedBulletinAllowanceSigner({
                 publishSigner: sessionSigner(),
-                bulletinApi: bulletinApiAtBlock(20),
+                bulletinApi: bulletinApiCanStore(false),
             }),
         ).rejects.toThrow(/has expired/);
 
@@ -351,7 +356,7 @@ describe("cachedBulletinSlotAuthorization", () => {
     it("returns null on a cache miss without touching the wire", async () => {
         createSlotAccountSignerMock.mockResolvedValue(null);
 
-        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiAtBlock());
+        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiCanStore());
 
         expect(result).toBeNull();
         expect(checkAuthorizationMock).not.toHaveBeenCalled();
@@ -361,21 +366,16 @@ describe("cachedBulletinSlotAuthorization", () => {
         createSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
         checkAuthorizationMock.mockResolvedValue(ACTIVE_EXHAUSTED);
 
-        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiAtBlock(50));
+        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiCanStore(true));
 
         expect(result?.usable).toBe(true);
     });
 
     it("flags an expired authorization as not usable", async () => {
         createSlotAccountSignerMock.mockResolvedValue(SLOT_SIGNER);
-        checkAuthorizationMock.mockResolvedValue({
-            authorized: true,
-            remainingTransactions: 5,
-            remainingBytes: 1000n,
-            expiration: 10,
-        });
+        checkAuthorizationMock.mockResolvedValue(EXPIRED);
 
-        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiAtBlock(20));
+        const result = await cachedBulletinSlotAuthorization({} as any, bulletinApiCanStore(false));
 
         expect(result?.usable).toBe(false);
     });
@@ -384,7 +384,7 @@ describe("cachedBulletinSlotAuthorization", () => {
 describe("getBulletinSlotAuthorization", () => {
     it("encodes the signer public key and flags an active authorization as usable", async () => {
         checkAuthorizationMock.mockResolvedValue(ACTIVE_EXHAUSTED);
-        const api = bulletinApiAtBlock(50);
+        const api = bulletinApiCanStore(true);
 
         const result = await getBulletinSlotAuthorization(api, SLOT_SIGNER);
 
@@ -401,7 +401,7 @@ describe("getBulletinSlotAuthorization", () => {
             expiration: 0,
         });
 
-        const result = await getBulletinSlotAuthorization(bulletinApiAtBlock(0), SLOT_SIGNER);
+        const result = await getBulletinSlotAuthorization(bulletinApiCanStore(false), SLOT_SIGNER);
 
         expect(result.usable).toBe(false);
     });

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -92,7 +92,9 @@ export interface CachedBulletinAllowanceSignerOptions {
 
 /**
  * Whether a slot's Bulletin authorization will let `TransactionStorage.store`
- * land. The chain's only hard gate is existence + non-expiry: pallet
+ * land, asked directly of the chain via the
+ * `BulletinTransactionStorageApi::can_store` runtime API rather than evaluated
+ * client-side. The chain's only hard gate is existence + non-expiry: pallet
  * transaction-storage's `check_authorization` rejects a store ONLY when the
  * authorization is missing or expired. The `transactions` / `bytes` extent
  * counters are SOFT limits — they saturate upward on each store and feed a
@@ -100,27 +102,32 @@ export interface CachedBulletinAllowanceSignerOptions {
  * caps apply to `renew`, which this CLI never calls). So remaining quota is
  * irrelevant; we never gate on it and never request an `Increase`.
  *
- * Expiry is `now >= expiration` on-chain, so "not expired" is
- * `currentBlock < expiration`. product-sdk's `checkAuthorization` returns the
- * raw `expiration` block and leaves the comparison to callers, hence the
- * separate block read.
+ * `can_store(account, data_len)` folds existence, expiry and the per-call size
+ * bound into one verdict, so we no longer read the chain height or compare
+ * `expiration` ourselves. We probe with a single byte: `data_len === 0` is
+ * rejected outright, and a 1-byte store passes iff the slot is authorized and
+ * unexpired — exactly the gate we want. Mirrors paritytech/bulletin-deploy#693.
  */
-function isAuthorizationActive(status: AuthorizationStatus, currentBlock: number): boolean {
-    return status.authorized && status.expiration > currentBlock;
+interface BulletinRuntimeApi {
+    apis: {
+        BulletinTransactionStorageApi: {
+            can_store(account: string, dataLen: number): Promise<boolean>;
+        };
+    };
 }
 
 /**
- * Current Bulletin chain height, needed to evaluate authorization expiry.
- * `CloudStorageApi` is the descriptor-typed Bulletin API; `System.Number` is
- * present at runtime but outside the nominal `CloudStorageApi` surface, so we
- * reach it through a narrow structural cast (the same shape `checkAuthorization`
- * uses internally for `TransactionStorage.Authorizations`).
+ * `CloudStorageApi` is the descriptor-typed Bulletin API; the
+ * `BulletinTransactionStorageApi` runtime namespace is present at runtime but
+ * outside the nominal `CloudStorageApi` surface (the hand-written
+ * `BulletinTypedApi` has no `apis` member), so we reach it through a narrow
+ * structural cast — the same skew the `asCloudStorageApi` seam absorbs. Drop it
+ * once the SDK surfaces a `canStore` helper.
  */
-async function readBulletinBlockNumber(bulletinApi: CloudStorageApi): Promise<number> {
-    const api = bulletinApi as unknown as {
-        query: { System: { Number: { getValue(): Promise<number | bigint> } } };
-    };
-    return Number(await api.query.System.Number.getValue());
+async function canStore(bulletinApi: CloudStorageApi, address: string): Promise<boolean> {
+    return (
+        bulletinApi as unknown as BulletinRuntimeApi
+    ).apis.BulletinTransactionStorageApi.can_store(address, 1);
 }
 
 function unusableAuthorizationError({ address, status }: BulletinSlotAuthorization): Error {
@@ -143,11 +150,14 @@ export async function getBulletinSlotAuthorization(
     slotSigner: PolkadotSigner,
 ): Promise<BulletinSlotAuthorization> {
     const address = ss58Encode(slotSigner.publicKey);
-    const [status, currentBlock] = await Promise.all([
+    // `status` is read only for the error-message distinction (expired vs never
+    // authorized); the chain's can_store predicate is the source of truth for
+    // whether a store will actually land.
+    const [status, usable] = await Promise.all([
         checkAuthorization(bulletinApi, address),
-        readBulletinBlockNumber(bulletinApi),
+        canStore(bulletinApi, address),
     ]);
-    return { address, status, usable: isAuthorizationActive(status, currentBlock) };
+    return { address, status, usable };
 }
 
 /**


### PR DESCRIPTION
## Summary

Builds on #337 (drop quota gate + Increase). Instead of reading the chain height and comparing the slot authorization's `expiration` block client-side, the preflight now asks the chain directly via `BulletinTransactionStorageApi::can_store`.

A single-byte `can_store(address, 1)` probe folds existence + non-expiry into one runtime verdict, so `getBulletinSlotAuthorization` no longer reads `System.Number` or evaluates expiry itself. `checkAuthorization` is kept only to distinguish the "expired" vs "not authorized yet" error message. Quota stays a soft limit — never gated, no Increase prompt.

Mirrors paritytech/bulletin-deploy#693.

## Tests

- `bulletin.test.ts` rewritten to drive usability through a mocked `can_store` verdict instead of a stubbed chain height.
- `tsc --noEmit`, `format:check`, `lint:license` clean; full suite passes (the only failures are environment-specific `readGitBranch` tests that need git >= 2.28).