### PR TITLE
fix(deploy): make "Moddable Setup Needed" recoverable instead of a dead end

### DIFF
--- a/.changeset/moddable-setup-no-deadend.md
+++ b/.changeset/moddable-setup-no-deadend.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-deploy: the "Moddable Setup Needed" screen is no longer a dead end. When the source check fails (for example, no GitHub origin is configured), the deploy now offers "continue without moddable", "go back" (re-answer the remix question, which retries the check), and a clean exit, instead of forcing the whole deploy to abort. The interactive message also no longer references CLI flags.
+deploy: the "Moddable Setup Needed" screen is no longer a dead end. When the source check fails (for example, no GitHub origin is configured), the deploy now offers "continue without moddable" and a clean exit (exit 0 with a friendly nudge), instead of forcing the whole deploy to abort with an error. The interactive message also no longer references CLI flags.

--- a/.changeset/moddable-setup-no-deadend.md
+++ b/.changeset/moddable-setup-no-deadend.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+deploy: the "Moddable Setup Needed" screen is no longer a dead end. When the source check fails (for example, no GitHub origin is configured), the deploy now offers "continue without moddable", "go back" (re-answer the remix question, which retries the check), and a clean exit, instead of forcing the whole deploy to abort. The interactive message also no longer references CLI flags.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -57,7 +57,11 @@ import {
 import type { ResolvedSigner } from "../../utils/signer.js";
 import { DEFAULT_BUILD_DIR, getChainConfig, getNetworkLabel } from "../../config.js";
 import { VERSION_LABEL } from "../../utils/version.js";
-import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
+import {
+    ensureGitInstalled,
+    ModdablePreflightError,
+    resolveRepositoryUrl,
+} from "../../utils/deploy/moddable.js";
 import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { validateDomainLabel } from "../../utils/deploy/dotnsRules.js";
 import { NO_SESSION_NOTICE_TITLE, NO_SESSION_NOTICE_BODY } from "./signerNotice.js";
@@ -99,7 +103,10 @@ export interface DeployScreenInputs {
      */
     tag?: string;
     userSigner: ResolvedSigner | null;
-    onDone: (outcome: DeployOutcome | null, opts?: { graceful?: boolean }) => void;
+    onDone: (
+        outcome: DeployOutcome | null,
+        opts?: { graceful?: boolean; gracefulMessage?: string },
+    ) => void;
 }
 
 export type Stage =
@@ -229,6 +236,14 @@ export function DeployScreen({
             nextTag,
         );
         setStage(s);
+    };
+
+    // Single "user declined moddable" transition, shared by the remix prompt's
+    // "no" answer and the setup-error menu's "continue without moddable", so
+    // the two paths can't drift apart.
+    const declineModdable = () => {
+        setModdable(false);
+        advance(skipBuild, mode, deployContracts, buildDir, domain, publishToPlayground, false);
     };
 
     const resolved = useMemo<Resolved | null>(() => {
@@ -473,19 +488,11 @@ export function DeployScreen({
                         ]}
                         initialIndex={0}
                         onSelect={(yes) => {
-                            setModdable(yes);
                             if (yes) {
+                                setModdable(true);
                                 setStage({ kind: "moddable-preflight" });
                             } else {
-                                advance(
-                                    skipBuild,
-                                    mode,
-                                    deployContracts,
-                                    buildDir,
-                                    domain,
-                                    publishToPlayground,
-                                    false,
-                                );
+                                declineModdable();
                             }
                         }}
                     />
@@ -515,7 +522,24 @@ export function DeployScreen({
             )}
 
             {stage.kind === "moddable-error" && (
-                <ModdableErrorStage message={stage.message} onExit={() => onDone(null)} />
+                <ModdableErrorStage
+                    message={stage.message}
+                    onContinueWithoutModdable={declineModdable}
+                    onBack={() => {
+                        setModdable(null);
+                        setStage({ kind: "prompt-moddable" });
+                    }}
+                    onExit={() =>
+                        onDone(null, {
+                            graceful: true,
+                            // Cause-neutral: this stage is reached for a missing
+                            // origin, a private repo, or a non-GitHub origin, and
+                            // the Callout above already named the specific problem.
+                            gracefulMessage:
+                                "No problem. Fix the GitHub repository setup and re-run `playground deploy` when ready.",
+                        })
+                    }
+                />
             )}
 
             {stage.kind === "prompt-tags" && (
@@ -690,7 +714,13 @@ function ModdablePreflightStage({
                 onResolved(url);
             } catch (err) {
                 if (cancelled) return;
-                onError(err instanceof Error ? err.message : String(err));
+                const message =
+                    err instanceof ModdablePreflightError
+                        ? err.interactiveMessage
+                        : err instanceof Error
+                          ? err.message
+                          : String(err);
+                onError(message);
             }
         })();
         return () => {
@@ -705,24 +735,64 @@ function ModdablePreflightStage({
     );
 }
 
+type ModdableErrorChoice = "continue" | "back" | "exit";
+
 /**
- * Formal warning stage shown when the moddable preflight cannot proceed —
+ * Formal warning stage shown when the moddable preflight cannot proceed,
  * almost always because the user hasn't set up a public GitHub `origin` yet.
  * Renders the actionable error inside a yellow Callout (matching the
  * "check your phone" banner) so it visually registers as a setup requirement
- * rather than a deploy crash. Pressing Enter or Esc exits the deploy.
+ * rather than a deploy crash. Must never dead-end (#332): the menu offers
+ * continuing as non-moddable, going back to the remix question (answering
+ * yes there re-runs the preflight, i.e. a retry), or a graceful exit. Esc
+ * also exits, matching the Ack and Confirm stages (and the previous
+ * incarnation of this screen).
  */
-function ModdableErrorStage({ message, onExit }: { message: string; onExit: () => void }) {
+function ModdableErrorStage({
+    message,
+    onContinueWithoutModdable,
+    onBack,
+    onExit,
+}: {
+    message: string;
+    onContinueWithoutModdable: () => void;
+    onBack: () => void;
+    onExit: () => void;
+}) {
     useInput((_input, key) => {
-        if (key.return || key.escape) onExit();
+        if (key.escape) onExit();
     });
     return (
         <Box flexDirection="column">
             <Callout tone="warning" title="Moddable Setup Needed">
                 <Text>{message}</Text>
             </Callout>
-            <Box marginTop={1}>
-                <Hint>{"enter or esc to exit"}</Hint>
+            <Box marginTop={1} flexDirection="column">
+                <Select<ModdableErrorChoice>
+                    label="how do you want to continue?"
+                    options={[
+                        {
+                            value: "continue",
+                            label: "continue without moddable",
+                            hint: "publish, but keep my source private",
+                        },
+                        {
+                            value: "back",
+                            label: "go back",
+                            hint: "re-answer the remix question",
+                        },
+                        {
+                            value: "exit",
+                            label: "exit",
+                            hint: "set up GitHub first, re-run deploy later",
+                        },
+                    ]}
+                    onSelect={(choice) => {
+                        if (choice === "continue") onContinueWithoutModdable();
+                        else if (choice === "back") onBack();
+                        else onExit();
+                    }}
+                />
             </Box>
         </Box>
     );

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -525,10 +525,6 @@ export function DeployScreen({
                 <ModdableErrorStage
                     message={stage.message}
                     onContinueWithoutModdable={declineModdable}
-                    onBack={() => {
-                        setModdable(null);
-                        setStage({ kind: "prompt-moddable" });
-                    }}
                     onExit={() =>
                         onDone(null, {
                             graceful: true,
@@ -735,7 +731,7 @@ function ModdablePreflightStage({
     );
 }
 
-type ModdableErrorChoice = "continue" | "back" | "exit";
+type ModdableErrorChoice = "continue" | "exit";
 
 /**
  * Formal warning stage shown when the moddable preflight cannot proceed,
@@ -743,20 +739,16 @@ type ModdableErrorChoice = "continue" | "back" | "exit";
  * Renders the actionable error inside a yellow Callout (matching the
  * "check your phone" banner) so it visually registers as a setup requirement
  * rather than a deploy crash. Must never dead-end (#332): the menu offers
- * continuing as non-moddable, going back to the remix question (answering
- * yes there re-runs the preflight, i.e. a retry), or a graceful exit. Esc
- * also exits, matching the Ack and Confirm stages (and the previous
- * incarnation of this screen).
+ * continuing as non-moddable or a graceful exit. Esc also exits, matching the
+ * Ack and Confirm stages (and the previous incarnation of this screen).
  */
 function ModdableErrorStage({
     message,
     onContinueWithoutModdable,
-    onBack,
     onExit,
 }: {
     message: string;
     onContinueWithoutModdable: () => void;
-    onBack: () => void;
     onExit: () => void;
 }) {
     useInput((_input, key) => {
@@ -777,19 +769,14 @@ function ModdableErrorStage({
                             hint: "publish, but keep my source private",
                         },
                         {
-                            value: "back",
-                            label: "go back",
-                            hint: "re-answer the remix question",
-                        },
-                        {
                             value: "exit",
                             label: "exit",
                             hint: "set up GitHub first, re-run deploy later",
                         },
                     ]}
+                    initialIndex={0}
                     onSelect={(choice) => {
                         if (choice === "continue") onContinueWithoutModdable();
-                        else if (choice === "back") onBack();
                         else onExit();
                     }}
                 />

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -18,7 +18,9 @@ import { describe, it, expect } from "vitest";
 import {
     assertPublishFlagsConsistent,
     classifyDeployDone,
+    DEFAULT_GRACEFUL_NUDGE,
     isFullySpecified,
+    resolveGracefulNudge,
     shouldResolveUserSigner,
 } from "./index.js";
 import type { DeployOutcome } from "../../utils/deploy/run.js";
@@ -80,6 +82,21 @@ describe("classifyDeployDone", () => {
         expect(classifyDeployDone(null)).toBe("failure");
         expect(classifyDeployDone(null, {})).toBe("failure");
         expect(classifyDeployDone(null, { graceful: false })).toBe("failure");
+    });
+});
+
+describe("resolveGracefulNudge", () => {
+    it("falls back to the README nudge when no message is supplied", () => {
+        // The README-acknowledgement exit carries no cause-specific copy.
+        expect(resolveGracefulNudge()).toBe(DEFAULT_GRACEFUL_NUDGE);
+        expect(resolveGracefulNudge(undefined)).toBe(DEFAULT_GRACEFUL_NUDGE);
+    });
+
+    it("uses the stage-supplied message verbatim when present", () => {
+        // The moddable setup menu's exit supplies its own cause-neutral nudge.
+        const moddableNudge =
+            "No problem. Fix the GitHub repository setup and re-run `playground deploy` when ready.";
+        expect(resolveGracefulNudge(moddableNudge)).toBe(moddableNudge);
     });
 });
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -316,10 +316,10 @@ export type DeployDoneDisposition = "success" | "graceful-cancel" | "failure";
 /**
  * Maps a `DeployScreen` `onDone` callback into the outcome the interactive
  * runner should produce. A non-null outcome is a success; a null outcome is a
- * failure (exit 1) UNLESS it was a graceful cancel — the user pressing Esc on
- * the README acknowledgement to go edit it, which exits 0 with a friendly
- * nudge. Extracted as a pure function so this branch is unit-testable without
- * rendering the Ink TUI.
+ * failure (exit 1) UNLESS it was a graceful cancel: a deliberate exit from a
+ * setup screen (the README acknowledgement, or the moddable setup menu),
+ * which exits 0 with a friendly nudge. Extracted as a pure function so this
+ * branch is unit-testable without rendering the Ink TUI.
  */
 export function classifyDeployDone(
     outcome: DeployOutcome | null,
@@ -549,21 +549,23 @@ function runInteractive(ctx: {
                         userSigner: ctx.userSigner,
                         onDone: (
                             outcome: DeployOutcome | null,
-                            doneOpts?: { graceful?: boolean },
+                            doneOpts?: { graceful?: boolean; gracefulMessage?: string },
                         ) => {
                             if (settled) return;
                             settled = true;
                             app?.unmount();
                             switch (classifyDeployDone(outcome, doneOpts)) {
-                                case "graceful-cancel":
-                                    // The user pressed Esc on the README
-                                    // acknowledgement to go edit it — not a
+                                case "graceful-cancel": {
+                                    // A deliberate exit from a setup screen
+                                    // (README ack, moddable setup), not a
                                     // failure. Exit 0 with a friendly nudge.
-                                    process.stdout.write(
-                                        "\nNo problem. Update your README.md and re-run `playground deploy` when ready.\n",
-                                    );
+                                    const nudge =
+                                        doneOpts?.gracefulMessage ??
+                                        "No problem. Update your README.md and re-run `playground deploy` when ready.";
+                                    process.stdout.write(`\n${nudge}\n`);
                                     resolvePromise();
                                     break;
+                                }
                                 case "failure":
                                     process.exitCode = 1;
                                     rejectPromise(new Error("Deploy was cancelled or failed."));

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -330,6 +330,24 @@ export function classifyDeployDone(
 }
 
 /**
+ * Default nudge printed on a graceful cancel — the README acknowledgement path,
+ * which has no cause-specific message of its own.
+ */
+export const DEFAULT_GRACEFUL_NUDGE =
+    "No problem. Update your README.md and re-run `playground deploy` when ready.";
+
+/**
+ * Picks the friendly nudge printed when a setup screen exits gracefully (exit
+ * 0). Stages that exit for a specific reason (e.g. the moddable setup menu)
+ * supply their own `gracefulMessage`; the README acknowledgement supplies none
+ * and falls back to {@link DEFAULT_GRACEFUL_NUDGE}. Pure + exported so the
+ * fallback is unit-testable without rendering the Ink TUI.
+ */
+export function resolveGracefulNudge(gracefulMessage?: string): string {
+    return gracefulMessage ?? DEFAULT_GRACEFUL_NUDGE;
+}
+
+/**
  * `--moddable` and `--tag` both only affect the playground metadata JSON, which
  * is uploaded ONLY when publishing. Supplying either without `--playground` is a
  * no-op the user almost certainly didn't intend, so headless deploys reject it
@@ -559,9 +577,7 @@ function runInteractive(ctx: {
                                     // A deliberate exit from a setup screen
                                     // (README ack, moddable setup), not a
                                     // failure. Exit 0 with a friendly nudge.
-                                    const nudge =
-                                        doneOpts?.gracefulMessage ??
-                                        "No problem. Update your README.md and re-run `playground deploy` when ready.";
+                                    const nudge = resolveGracefulNudge(doneOpts?.gracefulMessage);
                                     process.stdout.write(`\n${nudge}\n`);
                                     resolvePromise();
                                     break;

--- a/src/utils/deploy/moddable.test.ts
+++ b/src/utils/deploy/moddable.test.ts
@@ -148,4 +148,39 @@ describe("resolveRepositoryUrl", () => {
             /no github origin configured/i,
         );
     });
+
+    it("carries flag-free interactive copy for the no-origin error (#332)", async () => {
+        tmp = mkdtempSync(join(tmpdir(), "pg-moddable-interactive-"));
+        execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
+
+        const err = await resolveRepositoryUrl({ cwd: tmp, fetch: publicFetch }).then(
+            () => null,
+            (e: unknown) => e,
+        );
+        expect(err).toBeInstanceOf(ModdablePreflightError);
+        const preflightErr = err as ModdablePreflightError;
+        // Headless output keeps the flag hint; the TUI copy must not speak in
+        // flags, since the user may have arrived via a prompt, not --moddable.
+        expect(preflightErr.message).toContain("--no-moddable");
+        expect(preflightErr.interactiveMessage).not.toMatch(/--(no-)?moddable/);
+        expect(preflightErr.interactiveMessage).toMatch(/github/i);
+        expect(preflightErr.interactiveMessage).not.toBe(preflightErr.message);
+    });
+
+    it("defaults interactiveMessage to the thrown message for other failures", async () => {
+        tmp = mkdtempSync(join(tmpdir(), "pg-moddable-private-default-"));
+        execFileSync("git", ["init"], { cwd: tmp, stdio: "ignore" });
+        execFileSync("git", ["remote", "add", "origin", "https://github.com/org/secret.git"], {
+            cwd: tmp,
+            stdio: "ignore",
+        });
+
+        const err = await resolveRepositoryUrl({ cwd: tmp, fetch: privateFetch }).then(
+            () => null,
+            (e: unknown) => e,
+        );
+        expect(err).toBeInstanceOf(ModdablePreflightError);
+        const preflightErr = err as ModdablePreflightError;
+        expect(preflightErr.interactiveMessage).toBe(preflightErr.message);
+    });
 });

--- a/src/utils/deploy/moddable.ts
+++ b/src/utils/deploy/moddable.ts
@@ -28,7 +28,20 @@ import { execFileSync } from "node:child_process";
 import { commandExists, TOOL_STEPS } from "../toolchain.js";
 import { parseGitHubRepoUrl } from "../mod/source.js";
 
-export class ModdablePreflightError extends Error {}
+export class ModdablePreflightError extends Error {
+    /**
+     * Copy for the interactive deploy TUI, which must not reference CLI flags
+     * (the user may have arrived via a prompt, never having typed one).
+     * Defaults to `message`, which stays flag-flavoured for the headless path
+     * that prints it directly.
+     */
+    readonly interactiveMessage: string;
+
+    constructor(message: string, interactiveMessage: string = message) {
+        super(message);
+        this.interactiveMessage = interactiveMessage;
+    }
+}
 
 /**
  * Upper bound on the public-repo HEAD probe. A *stalled* socket (as opposed to
@@ -65,11 +78,22 @@ export interface ResolveRepoOptions {
     fetch?: typeof fetch;
 }
 
+/** Step-by-step remedy shared by both no-origin messages so they can't drift. */
+const NO_ORIGIN_SETUP_STEPS =
+    "Create a public GitHub repository, commit and push your code, set it as " +
+    "`origin` (e.g. `git remote add origin https://github.com/<user>/<repo>` " +
+    "followed by `git push -u origin main`)";
+
 const NO_ORIGIN_MESSAGE =
-    "--moddable: no GitHub origin configured. Create a public GitHub repository, " +
-    "commit and push your code, set it as `origin` (e.g. `git remote add origin " +
-    "https://github.com/<user>/<repo>` followed by `git push -u origin main`), " +
+    `--moddable: no GitHub origin configured. ${NO_ORIGIN_SETUP_STEPS}, ` +
     "and re-run. Pass --no-moddable to skip publishing source.";
+
+/**
+ * Prompt-flow variant of NO_ORIGIN_MESSAGE. The TUI's recovery menu (#332)
+ * owns the continue/back/exit affordances, so this copy stays surface-neutral:
+ * it explains the problem and the setup steps, nothing about flags or menus.
+ */
+export const NO_ORIGIN_INTERACTIVE_MESSAGE = `No GitHub origin is configured for this project. ${NO_ORIGIN_SETUP_STEPS}.`;
 
 /**
  * Verifies that a repository URL is a publicly accessible GitHub repo.
@@ -123,7 +147,7 @@ export async function assertPublicGitHubRepo(url: string, f: typeof fetch = fetc
 export async function resolveRepositoryUrl(opts: ResolveRepoOptions): Promise<string> {
     const f = opts.fetch ?? fetch;
     const origin = readOrigin(opts.cwd);
-    if (!origin) throw new ModdablePreflightError(NO_ORIGIN_MESSAGE);
+    if (!origin) throw new ModdablePreflightError(NO_ORIGIN_MESSAGE, NO_ORIGIN_INTERACTIVE_MESSAGE);
     const normalised = origin.replace(/\.git$/, "");
     opts.onLog?.(`using existing origin (${normalised})…`);
     await assertPublicGitHubRepo(normalised, f);


### PR DESCRIPTION
## What

Fixes #332. The interactive deploy's "Moddable Setup Needed" screen (shown when the moddable source check fails, most commonly because no GitHub `origin` is configured) is no longer a dead end. It now offers:

- **continue without moddable**: the deploy proceeds with source kept private, all answered prompts preserved
- **go back**: returns to the remix question; answering yes re-runs the check, so users can fix the origin in another terminal and retry without restarting
- **exit**: leaves gracefully (exit 0) with a nudge, instead of "Deploy was cancelled or failed." (exit 1)

Esc also exits gracefully, matching the Ack and Confirm stages (and the old screen's `esc to exit`).

## Why

Per the audit feedback in #332, the screen's only affordance was enter/esc, both of which aborted the entire deploy with exit 1 and threw away every answered prompt. There was no way to proceed as non-moddable, retry, or go back. The remix prompt also defaults to "yes", so users without a GitHub origin walked straight into the trap.

## Changes

- `DeployScreen.tsx`: `ModdableErrorStage` is now a 3-way `Select` menu. The remix prompt's "no" branch and the menu's "continue" option share one `declineModdable` transition so the two paths can't drift.
- `moddable.ts`: `ModdablePreflightError` carries an `interactiveMessage` for the TUI, since the old copy spoke in `--moddable`/`--no-moddable` flags to users who arrived via a prompt. The headless path keeps the flag wording verbatim. Both no-origin messages compose a shared setup-steps constant so the instructions can't diverge.
- `deploy/index.ts`: graceful cancels can carry their own nudge message; the moddable exit prints a cause-neutral one (the stage is also reached for private-repo and non-GitHub-origin failures). The README-ack path is unchanged.
- Tests pinning the message split, plus a changeset.
<img width="1118" height="345" alt="image" src="https://github.com/user-attachments/assets/41866d17-ca74-4162-beab-6202b568f51b" />

## Verification

- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (789 passed) all clean
- Drove the compiled binary's TUI end to end: all three menu choices, Esc, and the go-back retry (added a public origin in a second terminal, answered yes, the check passed and the flow continued to the tag prompt)
