### PR TITLE
fix(deploy): record immediate parent for mod-of-a-mod on the SDK path

### DIFF
--- a/.changeset/modded-from-sdk-precedence.md
+++ b/.changeset/modded-from-sdk-precedence.md
@@ -1,0 +1,15 @@
+---
+"playground-cli": patch
+---
+
+Fix mod-of-a-mod XP attribution for SDK/RevX deploys. The `moddedFrom` lineage
+field was only rewritten by the `dot mod` TUI, while SDK consumers that clone a
+source app themselves (RevX in a WebContainer) and deploy via `runDeploy` re-published
+whatever `moddedFrom` the cloned repo's `dot.json` carried. Because a moddable app
+that was itself modded from the tutorial ships `moddedFrom: <tutorial>` in its
+committed `dot.json`, modding such an app credited the tutorial's owner instead of
+the immediate parent's owner (playground-app#335).
+
+`runDeploy` now accepts an explicit `moddedFrom`, and an explicit value takes
+precedence over the (possibly stale) `dot.json` field so callers that just performed
+the mod record the true immediate parent.

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -651,6 +651,72 @@ describe("publishToPlayground", () => {
         }
     });
 
+    // playground-app#335: an SDK/RevX consumer that clones the source itself
+    // (skipping the `dot mod` TUI that rewrites `dot.json`) passes the true
+    // immediate parent via the `moddedFrom` option. It MUST win over the stale
+    // value the cloned repo's `dot.json` carried — otherwise a mod-of-a-mod
+    // re-publishes the grandparent and credits the wrong owner.
+    it("prefers an explicit moddedFrom option over a stale dot.json value", async () => {
+        const dir = makeTmpDir();
+        try {
+            // Stale value inherited from the cloned source (e.g. tutorial).
+            writeFileSync(
+                join(dir, "dot.json"),
+                JSON.stringify({ moddedFrom: "playground-tutorial.dot" }),
+            );
+            await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                // True immediate parent, known by the caller that did the mod.
+                moddedFrom: "steampunk-lizard-spock01.dot",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "steampunk-lizard-spock01.dot",
+                false,
+                false,
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("falls back to dot.json when the explicit moddedFrom is empty/whitespace", async () => {
+        const dir = makeTmpDir();
+        try {
+            writeFileSync(join(dir, "dot.json"), JSON.stringify({ moddedFrom: "original.dot" }));
+            await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                moddedFrom: "   ",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "original.dot",
+                false,
+                false,
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     it("retries up to 3 times on registry publish failure", async () => {
         publishTx.mockImplementationOnce(async () => {
             throw new Error("nonce race");

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -111,11 +111,18 @@ export interface PublishToPlaygroundOptions {
      */
     isModdable?: boolean;
     /**
-     * Domain (`<label>.dot`) the user `dot mod`'d this app from, or `""` if
+     * Domain (`<label>.dot`) the user modded this app from, or `""`/omitted if
      * this is a first-party publish. Recorded on-chain so the playground-app
-     * can render a "modded from" badge. Normally captured by `dot mod` into
-     * `dot.json` and read via `readModdedFrom`; this option is an explicit
-     * fallback for callers that already know the source domain.
+     * can render a "modded from" badge AND so the contract credits the SOURCE
+     * app's owner the mod XP.
+     *
+     * When set (non-empty), this is AUTHORITATIVE — it takes precedence over
+     * any `moddedFrom` read from `dot.json`. A caller that just performed the
+     * mod (the `dot mod` TUI captures it in `dot.json`; an SDK consumer like
+     * RevX clones the source itself and passes it here) knows the true
+     * immediate parent, whereas `dot.json`'s field can be a STALE value that
+     * merely rode along in a cloned repo. See the precedence note in
+     * `publishToPlayground` (playground-app#335).
      */
     moddedFrom?: string;
     /**
@@ -374,12 +381,14 @@ export async function publishToPlayground(
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
                     const visibility = options.isPrivate ? 0 : 1;
-                    // Prefer the lineage captured by `dot mod` in `dot.json`
-                    // (the `moddedFrom` read above); fall back to an explicit option.
-                    // The contract awards the source owner the "your app is
-                    // modded" XP off this argument, so an empty string here
-                    // means no lineage edge is ever recorded.
-                    const moddedFromArg = moddedFrom ?? options.moddedFrom ?? "";
+                    // Explicit `options.moddedFrom` wins over the `dot.json`
+                    // value (see the option's doc + playground-app#335); an
+                    // empty/whitespace explicit value falls through to
+                    // `dot.json` ("not provided", not "no parent"). The contract
+                    // credits the source owner the mod XP off this argument, so
+                    // an empty string records no lineage edge.
+                    const explicitModdedFrom = options.moddedFrom?.trim();
+                    const moddedFromArg = explicitModdedFrom || moddedFrom || "";
                     const isModdable = options.isModdable ?? false;
                     const isDevSigner = options.isDevSigner ?? false;
                     const result = await registry.publish.tx(

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -81,6 +81,18 @@ export interface RunDeployOptions {
     moddable?: boolean;
     /** Resolved public repository URL to record in metadata (moddable=true) or `null` (moddable=false). */
     repositoryUrl?: string | null;
+    /**
+     * Domain (`<label>.dot`) this deploy was modded from. For SDK/RevX
+     * consumers that perform the clone themselves and therefore never run the
+     * `dot mod` TUI step that writes `moddedFrom` into `dot.json`: pass the
+     * source domain here so the contract credits the right owner. When set
+     * (non-empty) it takes precedence over any (possibly stale) `moddedFrom`
+     * in the project's `dot.json` — see `publishToPlayground` and
+     * playground-app#335. Omit for the normal `dot deploy` path, which reads
+     * the value `dot mod` captured in `dot.json`. Ignored when
+     * `publishToPlayground` is false.
+     */
+    moddedFrom?: string | null;
     /** Single playground tag to record in metadata, or `null`/omitted to publish untagged. Ignored when `publishToPlayground` is false. */
     tag?: string | null;
     /** The logged-in phone signer. Required for `mode === "phone"` or `publishToPlayground`. */
@@ -267,6 +279,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     repositoryUrl: options.repositoryUrl ?? null,
                     tag: options.tag ?? null,
                     cwd: options.projectDir,
+                    moddedFrom: options.moddedFrom ?? undefined,
                     onLogEvent: (event) => options.onEvent({ kind: "storage-event", event }),
                     onAllowancePrompt: allowancePrompt,
                     env: options.env,


### PR DESCRIPTION
The `moddedFrom` lineage field was rewritten only by the `dot mod` TUI (SetupScreen.tsx). SDK consumers (RevX) that clone a source app themselves and deploy through `runDeploy` never run that step, so they re-published whatever `moddedFrom` the cloned repo's committed `dot.json` carried. Because an app that was itself modded from the tutorial ships `moddedFrom: <tutorial>` in its `dot.json`, modding such an app credited the tutorial owner instead of the immediate parent owner (playground-app#335).

- Thread an explicit `moddedFrom` through `RunDeployOptions` → `publishToPlayground` (the SDK surface RevX consumes).
- An explicit, non-empty `moddedFrom` now takes precedence over the value read from `dot.json`, so a caller that just performed the mod records the true immediate parent; empty/whitespace falls through to `dot.json`.

The CLI `dot deploy` + `dot mod` TUI path is unchanged (it still reads the value `dot mod` wrote into `dot.json`); `decentralize` is unaffected. Adds precedence tests + changeset.