### PR TITLE
fix(init): check and install curl + C linker prerequisites

### DIFF
--- a/.changeset/install-prereqs-curl-cc.md
+++ b/.changeset/install-prereqs-curl-cc.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Handle missing system prerequisites on clean Linux installs (#248): `playground init` now checks for `curl` and a C linker and installs them (via `apt`) before the steps that need them, `install.sh` fails fast with the exact remedy when `curl` is absent, and the README documents the Debian/Ubuntu prerequisite line (`build-essential curl`).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ CLI tooling for Polkadot Playground. Installed as the `playground` command, with
 
 ## Quick Start
 
+On **Windows**, use [WSL](https://learn.microsoft.com/windows/wsl/install) — the installer and CLI support Linux and macOS only — and follow the Debian/Ubuntu steps inside it.
+
 On a fresh **Debian/Ubuntu** system, install the base prerequisites first (macOS needs no preparation — curl ships with the OS and the Xcode Command Line Tools cover the rest):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ CLI tooling for Polkadot Playground. Installed as the `playground` command, with
 
 ## Quick Start
 
+On a fresh **Debian/Ubuntu** system, install the base prerequisites first (macOS needs no preparation — curl ships with the OS and the Xcode Command Line Tools cover the rest):
+
+```bash
+sudo apt update && sudo apt install -y build-essential curl
+```
+
+Then install:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/paritytech/playground-cli/main/install.sh | bash
 ```
@@ -26,7 +34,7 @@ The installer drops the binary into `~/.polkadot/bin/playground`, symlinks both 
 End-to-end first-run setup. Login and toolchain install run **concurrently**; account setup runs **once both have completed successfully**.
 
 1. **Login via the Polkadot mobile app** — a QR code is printed to the terminal. Scan it with the app. If you already have a session persisted in `~/.polkadot-apps/`, this step is skipped.
-2. **Toolchain install** — `rustup`, nightly, `rust-src`, `cargo-pvm-contract`, IPFS, and `git`. Existing installs are detected and skipped.
+2. **Toolchain install** — `git`, `curl`, a C linker (`build-essential`), `rustup`, nightly, `rust-src`, `cargo-pvm-contract`, IPFS, and `wget`. Existing installs are detected and skipped.
 3. **Account setup** (only if a session is available) — in order:
     - **Fund** — if your balance on Paseo Asset Hub is below 1 PAS, Alice sends 10 PAS (testnet).
     - **Map** — `Revive.map_account` is signed by you on the mobile app so an H160 is associated with your SS58 address.

--- a/install.sh
+++ b/install.sh
@@ -11,8 +11,9 @@ ALIAS="pg"
 # saved locally under $CMD, so the old `dot` command name is gone.
 ASSET_PREFIX="dot"
 
-# 1) Detect platform
-OS=$(uname -s); case "$OS" in Linux) OS=linux;; Darwin) OS=darwin;; *) echo "Unsupported OS: $OS"; exit 1;; esac
+# 1) Detect platform. Git Bash / MSYS / Cygwin report MINGW*/MSYS*/CYGWIN* —
+# point Windows users at WSL instead of a bare "Unsupported OS".
+OS=$(uname -s); case "$OS" in Linux) OS=linux;; Darwin) OS=darwin;; MINGW*|MSYS*|CYGWIN*) echo "Windows is not supported natively. Install WSL (https://learn.microsoft.com/windows/wsl/install) and re-run this command inside it."; exit 1;; *) echo "Unsupported OS: $OS"; exit 1;; esac
 ARCH=$(uname -m); case "$ARCH" in x86_64|amd64) ARCH=x64;; arm64|aarch64) ARCH=arm64;; *) echo "Unsupported arch: $ARCH"; exit 1;; esac
 ASSET="$ASSET_PREFIX-$OS-$ARCH"
 

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,19 @@ OS=$(uname -s); case "$OS" in Linux) OS=linux;; Darwin) OS=darwin;; *) echo "Uns
 ARCH=$(uname -m); case "$ARCH" in x86_64|amd64) ARCH=x64;; arm64|aarch64) ARCH=arm64;; *) echo "Unsupported arch: $ARCH"; exit 1;; esac
 ASSET="$ASSET_PREFIX-$OS-$ARCH"
 
+# 1b) Prerequisite guard (#248). Everything below fetches via curl. Reaching
+# this point without curl means the script was fetched some other way (wget,
+# copy-paste), so fail fast with the exact remedy instead of a cryptic error.
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is required but not installed." >&2
+  if [ "$OS" = "linux" ]; then
+    echo "Install prerequisites first: sudo apt update && sudo apt install -y build-essential curl" >&2
+  else
+    echo "Install the Xcode Command Line Tools first: xcode-select --install" >&2
+  fi
+  exit 1
+fi
+
 # 2) Resolve release tag
 #
 #   Use VERSION to install a specific tag. Otherwise, prefer GitHub's no-body

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -69,6 +69,36 @@ describe("TOOL_STEPS", () => {
         expect(gitIndex).toBeLessThan(cargoPvmIndex);
     });
 
+    it("installs curl before any step whose installer fetches with it (#248)", () => {
+        // Bare Ubuntu ships no curl. The rustup and IPFS install commands
+        // both pipe from curl, so the curl step must run first. macOS masks
+        // this because curl ships with the OS.
+        const names = TOOL_STEPS.map((step) => step.name);
+        const curlIndex = names.indexOf("curl");
+        expect(curlIndex).toBeGreaterThanOrEqual(0);
+
+        const rustupIndex = names.indexOf("rustup");
+        expect(rustupIndex).toBeGreaterThanOrEqual(0);
+        expect(curlIndex).toBeLessThan(rustupIndex);
+
+        const ipfsIndex = names.indexOf("IPFS");
+        expect(ipfsIndex).toBeGreaterThanOrEqual(0);
+        expect(curlIndex).toBeLessThan(ipfsIndex);
+    });
+
+    it("installs the C linker before cargo-pvm-contract, which compiles (#248)", () => {
+        // `cargo install` needs a system linker; bare Ubuntu has no cc until
+        // build-essential lands. macOS masks this via Xcode CLT, so the
+        // ordering is pinned by test, same as git in #247.
+        const names = TOOL_STEPS.map((step) => step.name);
+        const ccIndex = names.indexOf("C linker (cc)");
+        expect(ccIndex).toBeGreaterThanOrEqual(0);
+
+        const cargoPvmIndex = names.indexOf("cargo-pvm-contract");
+        expect(cargoPvmIndex).toBeGreaterThanOrEqual(0);
+        expect(ccIndex).toBeLessThan(cargoPvmIndex);
+    });
+
     it("installs cargo-pvm-contract directly instead of the CDM CLI installer", () => {
         const names = TOOL_STEPS.map((step) => step.name);
         expect(names).toContain("cargo-pvm-contract");

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -118,8 +118,10 @@ cargo install --force --locked --target "$host_target" --path "$tmp_dir/crates/c
 // install script starts with `git clone` (#247 — clean Ubuntu has no git, so
 // the clone failed before the git step ran; macOS masked it via Xcode CLT).
 // git goes first overall: it's the cheapest step, so a broken apt surfaces
-// before the multi-hundred-MB rustup/nightly downloads. Pinned by a test in
-// toolchain.test.ts.
+// before the multi-hundred-MB rustup/nightly downloads. Likewise curl MUST
+// come before rustup/IPFS (their installers fetch via curl) and the C linker
+// MUST come before cargo-pvm-contract (`cargo install` links) — #248. Pinned
+// by tests in toolchain.test.ts.
 export const TOOL_STEPS: ToolStep[] = [
     {
         name: "git",
@@ -136,6 +138,46 @@ export const TOOL_STEPS: ToolStep[] = [
             }
         },
         manualHint: "https://git-scm.com/downloads",
+    },
+    {
+        // The rustup and IPFS install commands below fetch via curl (#248).
+        // The install.sh one-liner already implies curl exists, but `playground
+        // init` can also run standalone on a machine the binary was copied to.
+        name: "curl",
+        check: () => commandExists("curl"),
+        install: async (onData) => {
+            if (platform() === "darwin" && (await commandExists("brew"))) {
+                await runPiped("brew install curl", onData);
+            } else if (platform() === "linux") {
+                await runPiped(`${sudo()}apt update && ${sudo()}apt install -y curl`, onData);
+            } else {
+                throw new Error(
+                    "Cannot install curl automatically on this platform — install manually.",
+                );
+            }
+        },
+        manualHint: "https://curl.se/download.html",
+    },
+    {
+        // cargo-pvm-contract's `cargo install` compiles Rust, which needs a
+        // system C linker (#248). Bare Ubuntu ships none; macOS masks the gap
+        // via Xcode CLT, same pattern as #247's missing git.
+        name: "C linker (cc)",
+        check: () => commandExists("cc"),
+        install: async (onData) => {
+            if (platform() === "linux") {
+                await runPiped(
+                    `${sudo()}apt update && ${sudo()}apt install -y build-essential`,
+                    onData,
+                );
+            } else {
+                throw new Error(
+                    "Cannot install a C toolchain automatically on this platform — install manually.",
+                );
+            }
+        },
+        manualHint:
+            "Debian/Ubuntu: sudo apt install -y build-essential — macOS: xcode-select --install",
     },
     {
         name: "rustup",


### PR DESCRIPTION
Closes #248.

On a bare Ubuntu 26.04 the install one-liner and `playground init` failed cryptically because `curl` and a C linker (`build-essential`) were missing. Same bug class as #247 (missing `git`): macOS masks both gaps via the OS-shipped curl and Xcode CLT, so Linux is where it bites.

## Changes

- **`src/utils/toolchain.ts`** — two new `TOOL_STEPS` following the #247 `git`-step pattern:
  - `curl`: ordered before `rustup` and `IPFS`, whose install commands fetch via curl. Installs via `apt` on Linux / `brew` on macOS.
  - `C linker (cc)`: ordered before `cargo-pvm-contract`, whose `cargo install` needs a system linker. Installs `build-essential` via `apt` on Linux; on macOS the manual hint points at `xcode-select --install` (no safe non-interactive automation).
- **`src/utils/toolchain.test.ts`** — ordering pinned by tests, same as the #247 git test.
- **`install.sh`** —
  - fails fast with the exact remedy when `curl` is absent (covers the wget-fetched / pasted-script case; when run via the documented `curl | bash` one-liner curl trivially exists, so the shell-level failure can only be fixed by docs).
  - the platform check now matches `MINGW*|MSYS*|CYGWIN*` and tells Windows (Git Bash) users to install WSL and re-run inside it, instead of the bare `Unsupported OS: MINGW64_NT-…`.
- **`README.md`** —
  - Debian/Ubuntu prerequisite line (`sudo apt update && sudo apt install -y build-essential curl`) above Quick Start.
  - a Windows note pointing at WSL (the installer and CLI support Linux and macOS only).
  - the `playground init` toolchain list corrected to match `TOOL_STEPS`.

Note: the issue also cross-references a playground-app install-page update — that's a separate repo and not covered here. Auto-install on non-Debian distros (dnf/pacman) is deliberately out of scope: those steps fail gracefully with their manual hints, as the existing `git`/`wget` steps already did.

## Verification

`pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, and `pnpm test` (748 passed, including the two new ordering tests) all green; `bash -n install.sh` clean.