### PR TITLE
fix(toolchain): surface real cargo-pvm-contract build error on install

### DIFF
--- a/.changeset/cargo-pvm-contract-error.md
+++ b/.changeset/cargo-pvm-contract-error.md
@@ -1,0 +1,8 @@
+---
+"playground-cli": patch
+---
+
+Surface the real cargo-pvm-contract build error during `pg` install instead of a
+generic "Command failed (set -euo pipefail …)". `runShell` now accepts an optional
+`description`/`failurePrefix`, and the cargo-pvm-contract toolchain step uses them so
+failures report a readable label plus the underlying build output.

--- a/src/utils/process.test.ts
+++ b/src/utils/process.test.ts
@@ -163,4 +163,22 @@ describe("runShell", () => {
         await runShell('printf "x\\ny\\n"', (line) => lines.push(line));
         expect(lines).toEqual(["x", "y"]);
     });
+
+    it("uses opts.description and opts.failurePrefix instead of the raw script in failures", async () => {
+        const script = "set -euo pipefail\necho real-cargo-error >&2\nexit 5";
+        await expect(
+            runShell(script, undefined, {
+                description: "cargo install cargo-pvm-contract",
+                failurePrefix: "cargo-pvm-contract build failed",
+            }),
+        ).rejects.toThrow(
+            /cargo-pvm-contract build failed.*cargo install cargo-pvm-contract.*exit code 5[\s\S]*real-cargo-error/,
+        );
+        await expect(
+            runShell(script, undefined, {
+                description: "cargo install cargo-pvm-contract",
+                failurePrefix: "cargo-pvm-contract build failed",
+            }),
+        ).rejects.not.toThrow(/\(set -euo pipefail/);
+    });
 });

--- a/src/utils/process.test.ts
+++ b/src/utils/process.test.ts
@@ -158,6 +158,12 @@ describe("runShell", () => {
         await expect(runShell("echo boom >&2; exit 1")).rejects.toThrow(/echo boom >&2; exit 1/);
     });
 
+    it("falls back to the default prefix and raw cmd when opts is omitted", async () => {
+        // Backward-compat lock: a 2-arg failing call must keep the pre-opts
+        // "Command failed (<raw cmd>)" shape.
+        await expect(runShell("exit 1")).rejects.toThrow(/Command failed \(exit 1\)/);
+    });
+
     it("resolves and forwards stdout lines through onData on success", async () => {
         const lines: string[] = [];
         await runShell('printf "x\\ny\\n"', (line) => lines.push(line));

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -91,6 +91,12 @@ export async function runStreamed(opts: RunStreamedOptions): Promise<void> {
  * string rather than a program + args array. Intended for pasting a shell
  * one-liner verbatim (curl | bash installers, chained commands); anything
  * structured should use the arg-array form for safety.
+ *
+ * `opts.description` is the human label interpolated into the spawn + failure
+ * error messages; it defaults to the raw `cmd`. `opts.failurePrefix` is the
+ * prefix on a non-zero-exit error; an omitted value falls through to
+ * `runStreamed`'s "Command failed". Pass both when the verbatim script would be
+ * unreadable in an error (e.g. a multi-line installer).
  */
 export async function runShell(
     cmd: string,

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -92,11 +92,16 @@ export async function runStreamed(opts: RunStreamedOptions): Promise<void> {
  * one-liner verbatim (curl | bash installers, chained commands); anything
  * structured should use the arg-array form for safety.
  */
-export async function runShell(cmd: string, onData?: (line: string) => void): Promise<void> {
+export async function runShell(
+    cmd: string,
+    onData?: (line: string) => void,
+    opts?: { description?: string; failurePrefix?: string },
+): Promise<void> {
     await runStreamed({
         cmd: "bash",
         args: ["-c", cmd],
-        description: cmd,
+        description: opts?.description ?? cmd,
+        failurePrefix: opts?.failurePrefix,
         onData,
     });
 }

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -166,7 +166,11 @@ export const TOOL_STEPS: ToolStep[] = [
     {
         name: "cargo-pvm-contract",
         check: hasCargoPvmContract,
-        install: (onData) => runPiped(CARGO_PVM_CONTRACT_INSTALL, onData),
+        install: (onData) =>
+            runPiped(CARGO_PVM_CONTRACT_INSTALL, onData, {
+                description: `cargo install cargo-pvm-contract @ ${CARGO_PVM_CONTRACT_REV.slice(0, 12)}`,
+                failurePrefix: "cargo-pvm-contract build failed",
+            }),
         manualHint: `Install cargo-pvm-contract from https://github.com/paritytech/cargo-pvm-contract at commit ${CARGO_PVM_CONTRACT_REV}`,
     },
     {


### PR DESCRIPTION
## Problem

Closes #318.

During `pg` install the cargo-pvm-contract build step failed with a generic
`Command failed (set -euo pipefail …)` — the error dumped the raw multi-line
shell script instead of the actual build output, leaving the failure
undiagnosable.

## Fix

- Add an optional `{ description, failurePrefix }` argument to `runShell`,
  threaded straight into the existing `RunStreamedOptions` fields (no behavior
  change for existing callers — both default to the old values).
- Wire the cargo-pvm-contract toolchain step to pass a readable
  `description` (`cargo install cargo-pvm-contract @ <rev>`) and
  `failurePrefix` (`cargo-pvm-contract build failed`), so a failed install
  now reports a clear label plus the underlying build error tail instead of
  the raw script.

The revision was already pinned (`533087395f…`); this PR addresses the
"surface the real build error" half of the recommended fix.

## Verification

`pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, and the affected
tests (`process.test.ts`, `toolchain.test.ts`, 19 passing) all green. Added a
regression test asserting the failure message uses the description/prefix and
no longer leaks the raw script.