### PR TITLE
fix(mod): verify setup.sh package managers before running

### DIFF
--- a/.changeset/mod-setup-package-manager-check.md
+++ b/.changeset/mod-setup-package-manager-check.md
@@ -2,4 +2,4 @@
 "playground-cli": patch
 ---
 
-`pg mod` now checks that a project's `setup.sh` can find a JavaScript package manager (npm, pnpm, or bun) before running it. If the script references package managers but none of them are installed, setup stops early with a clear message instead of failing partway through with an opaque error. Scripts that fall back across managers (try bun, else pnpm, else npm) pass as long as any one is installed.
+`pg mod` now checks that a project's `setup.sh` can find a JavaScript package manager (npm, pnpm, yarn, or bun) before running it. If the script references package managers but none of them are installed, setup stops early with a clear message instead of failing partway through with an opaque error. Scripts that fall back across managers (try bun, else pnpm, else npm) pass as long as any one is installed.

--- a/.changeset/mod-setup-package-manager-check.md
+++ b/.changeset/mod-setup-package-manager-check.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`pg mod` now checks that a project's `setup.sh` can find a JavaScript package manager (npm, pnpm, or bun) before running it. If the script references package managers but none of them are installed, setup stops early with a clear message instead of failing partway through with an opaque error. Scripts that fall back across managers (try bun, else pnpm, else npm) pass as long as any one is installed.

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -30,6 +30,10 @@ import { assertPublicGitHubRepo, ModdablePreflightError } from "../../utils/depl
 import { runCommand } from "../../utils/git.js";
 import { createOptionalGitBaseline } from "../../utils/mod/git-baseline.js";
 import { downloadGitHubTarball, parseGitHubRepoUrl } from "../../utils/mod/source.js";
+import {
+    findUnsatisfiedPackageManagers,
+    missingPackageManagerMessage,
+} from "../../utils/mod/packageManager.js";
 import { VERSION_LABEL } from "../../utils/version.js";
 import { getNetworkLabel } from "../../config.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
@@ -148,8 +152,15 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
             name: "run setup.sh",
             keepLogOnSuccess: true,
             run: async (log) => {
-                if (!existsSync(resolve(targetDir, "setup.sh"))) {
+                const setupPath = resolve(targetDir, "setup.sh");
+                if (!existsSync(setupPath)) {
                     throw new StepWarning("no setup.sh found");
+                }
+                const missing = await findUnsatisfiedPackageManagers(
+                    readFileSync(setupPath, "utf8"),
+                );
+                if (missing.length > 0) {
+                    throw new Error(missingPackageManagerMessage(missing));
                 }
                 await runCommand("bash setup.sh", { cwd: targetDir, log, logFile: setupLogFile });
                 setupRanRef.current = true;

--- a/src/utils/mod/packageManager.test.ts
+++ b/src/utils/mod/packageManager.test.ts
@@ -40,6 +40,11 @@ describe("detectReferencedPackageManagers", () => {
         expect(detectReferencedPackageManagers("bunx vite")).toEqual(["bun"]);
     });
 
+    it("detects yarn and yarnpkg", () => {
+        expect(detectReferencedPackageManagers("yarn install")).toEqual(["yarn"]);
+        expect(detectReferencedPackageManagers("yarnpkg add foo")).toEqual(["yarn"]);
+    });
+
     it("detects multiple managers in one script", () => {
         expect(detectReferencedPackageManagers("npm ci\nbun run build")).toEqual(["npm", "bun"]);
     });
@@ -53,6 +58,7 @@ describe("detectReferencedPackageManagers", () => {
         expect(detectReferencedPackageManagers("echo npmrc")).toEqual([]);
         expect(detectReferencedPackageManagers("./bundle.sh")).toEqual([]);
         expect(detectReferencedPackageManagers("run-pnpm-thing")).toEqual([]);
+        expect(detectReferencedPackageManagers("echo yarnball")).toEqual([]);
     });
 
     it("ignores comments", () => {
@@ -85,6 +91,11 @@ describe("findUnsatisfiedPackageManagers", () => {
     it("flags the manager when it is the only one referenced and is missing", async () => {
         mockCommandExists.mockResolvedValue(false);
         await expect(findUnsatisfiedPackageManagers("npm install")).resolves.toEqual(["npm"]);
+    });
+
+    it("flags yarn when a yarn-only script has no yarn installed", async () => {
+        mockCommandExists.mockResolvedValue(false);
+        await expect(findUnsatisfiedPackageManagers("yarn install")).resolves.toEqual(["yarn"]);
     });
 
     it("is satisfied when ANY referenced manager from a fallback chain is present", async () => {

--- a/src/utils/mod/packageManager.test.ts
+++ b/src/utils/mod/packageManager.test.ts
@@ -1,0 +1,136 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { commandExists } from "../toolchain.js";
+import {
+    detectReferencedPackageManagers,
+    findUnsatisfiedPackageManagers,
+    missingPackageManagerMessage,
+} from "./packageManager.js";
+
+vi.mock("../toolchain.js", () => ({ commandExists: vi.fn() }));
+const mockCommandExists = vi.mocked(commandExists);
+
+describe("detectReferencedPackageManagers", () => {
+    it("detects npm and npx", () => {
+        expect(detectReferencedPackageManagers("npm install")).toEqual(["npm"]);
+        expect(detectReferencedPackageManagers("npx vite build")).toEqual(["npm"]);
+    });
+
+    it("detects pnpm and pnpx", () => {
+        expect(detectReferencedPackageManagers("pnpm i")).toEqual(["pnpm"]);
+        expect(detectReferencedPackageManagers("pnpx tsc")).toEqual(["pnpm"]);
+    });
+
+    it("detects bun and bunx", () => {
+        expect(detectReferencedPackageManagers("bun install")).toEqual(["bun"]);
+        expect(detectReferencedPackageManagers("bunx vite")).toEqual(["bun"]);
+    });
+
+    it("detects multiple managers in one script", () => {
+        expect(detectReferencedPackageManagers("npm ci\nbun run build")).toEqual(["npm", "bun"]);
+    });
+
+    it("matches when the command follows a shell operator", () => {
+        expect(detectReferencedPackageManagers("cd app && pnpm install")).toEqual(["pnpm"]);
+        expect(detectReferencedPackageManagers("(npm run build)")).toEqual(["npm"]);
+    });
+
+    it("does not match substrings of other words", () => {
+        expect(detectReferencedPackageManagers("echo npmrc")).toEqual([]);
+        expect(detectReferencedPackageManagers("./bundle.sh")).toEqual([]);
+        expect(detectReferencedPackageManagers("run-pnpm-thing")).toEqual([]);
+    });
+
+    it("ignores comments", () => {
+        expect(detectReferencedPackageManagers("# install with npm\necho hi")).toEqual([]);
+    });
+
+    it("ignores occurrences inside string literals", () => {
+        expect(detectReferencedPackageManagers('echo "use npm to install"')).toEqual([]);
+        expect(detectReferencedPackageManagers("echo 'pnpm is nice'")).toEqual([]);
+    });
+
+    it("returns empty for scripts with no package manager", () => {
+        expect(detectReferencedPackageManagers("make build")).toEqual([]);
+    });
+});
+
+describe("findUnsatisfiedPackageManagers", () => {
+    beforeEach(() => mockCommandExists.mockReset());
+
+    it("returns empty when the script needs no package manager", async () => {
+        await expect(findUnsatisfiedPackageManagers("make build")).resolves.toEqual([]);
+        expect(mockCommandExists).not.toHaveBeenCalled();
+    });
+
+    it("returns empty when the single required manager is installed", async () => {
+        mockCommandExists.mockResolvedValue(true);
+        await expect(findUnsatisfiedPackageManagers("npm install")).resolves.toEqual([]);
+    });
+
+    it("flags the manager when it is the only one referenced and is missing", async () => {
+        mockCommandExists.mockResolvedValue(false);
+        await expect(findUnsatisfiedPackageManagers("npm install")).resolves.toEqual(["npm"]);
+    });
+
+    it("is satisfied when ANY referenced manager from a fallback chain is present", async () => {
+        // setup.sh tries bun, else pnpm, else npm; only npm installed -> fine.
+        mockCommandExists.mockImplementation(async (bin: string) => bin === "npm");
+        const script =
+            "if command -v bun; then bun i; elif command -v pnpm; then pnpm i; else npm i; fi";
+        await expect(findUnsatisfiedPackageManagers(script)).resolves.toEqual([]);
+    });
+
+    it("flags all referenced managers only when none are installed", async () => {
+        mockCommandExists.mockResolvedValue(false);
+        const script =
+            "if command -v bun; then bun i; elif command -v pnpm; then pnpm i; else npm i; fi";
+        await expect(findUnsatisfiedPackageManagers(script)).resolves.toEqual([
+            "npm",
+            "pnpm",
+            "bun",
+        ]);
+    });
+
+    it("short-circuits once a present manager is found", async () => {
+        mockCommandExists.mockResolvedValue(true);
+        await findUnsatisfiedPackageManagers("npm i\npnpm i\nbun i");
+        expect(mockCommandExists).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("missingPackageManagerMessage", () => {
+    it("points npm users at Node.js", () => {
+        const msg = missingPackageManagerMessage(["npm"]);
+        expect(msg).toContain("npm");
+        expect(msg).toContain("none is installed");
+        expect(msg).toContain("nodejs.org");
+    });
+
+    it("uses a generic install hint for a single non-npm manager", () => {
+        const msg = missingPackageManagerMessage(["bun"]);
+        expect(msg).toContain("bun");
+        expect(msg).toContain("Install bun");
+        expect(msg).not.toContain("nodejs.org");
+    });
+
+    it("phrases a fallback chain as 'one of'", () => {
+        const msg = missingPackageManagerMessage(["npm", "pnpm", "bun"]);
+        expect(msg).toContain("one of: npm, pnpm, bun");
+        expect(msg).toContain("none is installed");
+    });
+});

--- a/src/utils/mod/packageManager.ts
+++ b/src/utils/mod/packageManager.ts
@@ -1,0 +1,61 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { commandExists } from "../toolchain.js";
+
+const MANAGERS: Array<{ bin: string; re: RegExp }> = [
+    { bin: "npm", re: /(?:^|[\s;&|(])(?:npx|npm)(?:[\s;&|)]|$)/m },
+    { bin: "pnpm", re: /(?:^|[\s;&|(])(?:pnpx|pnpm)(?:[\s;&|)]|$)/m },
+    { bin: "bun", re: /(?:^|[\s;&|(])(?:bunx|bun)(?:[\s;&|)]|$)/m },
+];
+
+function stripCommentsAndStrings(script: string): string {
+    return script
+        .split("\n")
+        .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+        .join("\n")
+        .replace(/"[^"\n]*"/g, '""')
+        .replace(/'[^'\n]*'/g, "''");
+}
+
+/** Package managers the script invokes as commands (npm/npx, pnpm/pnpx, bun/bunx). */
+export function detectReferencedPackageManagers(script: string): string[] {
+    const code = stripCommentsAndStrings(script);
+    return MANAGERS.filter((m) => m.re.test(code)).map((m) => m.bin);
+}
+
+/**
+ * A `setup.sh` may reference several package managers in a fallback chain
+ * (`command -v bun || ... || npm`) yet only need ONE of them. So this returns
+ * the referenced managers ONLY when none of them are installed — the genuine
+ * "can't run setup at all" case. An empty array means setup can proceed.
+ */
+export async function findUnsatisfiedPackageManagers(script: string): Promise<string[]> {
+    const referenced = detectReferencedPackageManagers(script);
+    if (referenced.length === 0) return [];
+    for (const bin of referenced) {
+        if (await commandExists(bin)) return [];
+    }
+    return referenced;
+}
+
+export function missingPackageManagerMessage(referenced: string[]): string {
+    const list = referenced.join(", ");
+    const phrase = referenced.length > 1 ? `one of: ${list}` : list;
+    const hint = referenced.includes("npm")
+        ? "Install Node.js (which includes npm): https://nodejs.org"
+        : `Install ${referenced.join(" / ")} and try again`;
+    return `setup.sh needs ${phrase}, but none is installed. ${hint}`;
+}

--- a/src/utils/mod/packageManager.ts
+++ b/src/utils/mod/packageManager.ts
@@ -19,6 +19,9 @@ const MANAGERS: Array<{ bin: string; re: RegExp }> = [
     { bin: "npm", re: /(?:^|[\s;&|(])(?:npx|npm)(?:[\s;&|)]|$)/m },
     { bin: "pnpm", re: /(?:^|[\s;&|(])(?:pnpx|pnpm)(?:[\s;&|)]|$)/m },
     { bin: "bun", re: /(?:^|[\s;&|(])(?:bunx|bun)(?:[\s;&|)]|$)/m },
+    // yarn has no `x`-suffixed runner — it uses `yarn dlx` / `yarnpkg`. Kept in
+    // sync with the package managers `src/utils/build/detect.ts` understands.
+    { bin: "yarn", re: /(?:^|[\s;&|(])(?:yarnpkg|yarn)(?:[\s;&|)]|$)/m },
 ];
 
 function stripCommentsAndStrings(script: string): string {


### PR DESCRIPTION
## Problem

Closes #326.

`pg mod`'s setup step assumed `npm` was present. If a cloned project's `setup.sh` needed a package manager that wasn't installed — `npm` missing entirely, or the script using `pnpm`/`bun` — setup failed partway through with an opaque error, blocking onboarding.

## Fix

Before running `setup.sh`, scan it for the package managers it actually invokes (`npm`/`npx`, `pnpm`/`pnpx`, `bun`/`bunx`). Stop early with an actionable message **only when the script references package managers and none of them are installed**.

A `setup.sh` often names several managers in a fallback chain (`if command -v bun; … elif command -v pnpm; … else npm …`) while needing only one. So detection treats a manager as unsatisfied only when *none* of the referenced ones is present — it never requires all of them. A script that runs `npm` (e.g. paritytech/Rock-Paper-Scissors) passes as long as npm is installed; a portable fallback script passes as long as any one is installed.

Detection strips comments and string literals first and word-boundary-matches command tokens, so `npmrc`, `bundle.sh`, `run-pnpm-thing`, and managers mentioned only in echo/comment text don't false-match.

- New `src/utils/mod/packageManager.ts`: `detectReferencedPackageManagers`, `findUnsatisfiedPackageManagers`, `missingPackageManagerMessage`.
- `SetupScreen` runs the check just after locating `setup.sh`, before `bash setup.sh`.

This takes the "check the prerequisite clearly before running" path from the issue; it does not translate one manager's commands into another's.

## Tests

- `src/utils/mod/packageManager.test.ts` — detection (each manager + `x` variant, multi-manager, shell-operator boundaries, comment/string-literal/substring exclusion); fallback-chain satisfaction (any one present → OK), all-missing → flagged, single-missing → flagged, short-circuit on first hit; message wording for npm vs other vs `one of:`.
- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (800) all pass.