### PR TITLE
fix(deploy): record immediate parent for mod-of-a-mod on the SDK path

### DIFF
--- a/.changeset/modded-from-sdk-precedence.md
+++ b/.changeset/modded-from-sdk-precedence.md
@@ -1,0 +1,15 @@
+---
+"playground-cli": patch
+---
+
+Fix mod-of-a-mod XP attribution for SDK/RevX deploys. The `moddedFrom` lineage
+field was only rewritten by the `dot mod` TUI, while SDK consumers that clone a
+source app themselves (RevX in a WebContainer) and deploy via `runDeploy` re-published
+whatever `moddedFrom` the cloned repo's `dot.json` carried. Because a moddable app
+that was itself modded from the tutorial ships `moddedFrom: <tutorial>` in its
+committed `dot.json`, modding such an app credited the tutorial's owner instead of
+the immediate parent's owner (playground-app#335).
+
+`runDeploy` now accepts an explicit `moddedFrom`, and an explicit value takes
+precedence over the (possibly stale) `dot.json` field so callers that just performed
+the mod record the true immediate parent.

--- a/.changeset/modded-from-sdk-precedence.md
+++ b/.changeset/modded-from-sdk-precedence.md
@@ -12,4 +12,7 @@ the immediate parent's owner (playground-app#335).
 
 `runDeploy` now accepts an explicit `moddedFrom`, and an explicit value takes
 precedence over the (possibly stale) `dot.json` field so callers that just performed
-the mod record the true immediate parent.
+the mod record the true immediate parent. The resolved value drives both the on-chain
+lineage edge and the metadata JSON `moddedFrom` (so the badge and the XP credit can't
+disagree), and is canonicalized to `<label>.dot` — an empty or malformed explicit value
+falls through to `dot.json` rather than recording garbage on-chain.

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -82,6 +82,7 @@ import {
     publishToPlayground,
     buildMetadata,
     normalizeDomain,
+    normalizeModdedFrom,
     readGitBranch,
     readModdedFrom,
     readReadme,
@@ -145,6 +146,27 @@ describe("normalizeDomain", () => {
 
     it("rejects a one-digit suffix", () => {
         expect(() => normalizeDomain("myapp1")).toThrow(/two digits/i);
+    });
+});
+
+describe("normalizeModdedFrom", () => {
+    it("returns null for omitted/empty/whitespace input", () => {
+        expect(normalizeModdedFrom(undefined)).toBeNull();
+        expect(normalizeModdedFrom(null)).toBeNull();
+        expect(normalizeModdedFrom("")).toBeNull();
+        expect(normalizeModdedFrom("   ")).toBeNull();
+    });
+
+    it("canonicalizes to <label>.dot, adding the suffix and trimming", () => {
+        expect(normalizeModdedFrom("original")).toBe("original.dot");
+        expect(normalizeModdedFrom("original.dot")).toBe("original.dot");
+        expect(normalizeModdedFrom("  original.dot  ")).toBe("original.dot");
+    });
+
+    it("returns null for a malformed domain so it can't reach on-chain", () => {
+        expect(normalizeModdedFrom("Not A Domain!")).toBeNull();
+        expect(normalizeModdedFrom("../etc.dot")).toBeNull();
+        expect(normalizeModdedFrom("foo/bar.dot")).toBeNull();
     });
 });
 
@@ -664,7 +686,7 @@ describe("publishToPlayground", () => {
                 join(dir, "dot.json"),
                 JSON.stringify({ moddedFrom: "playground-tutorial.dot" }),
             );
-            await publishToPlayground({
+            const result = await publishToPlayground({
                 domain: "my-mod",
                 publishSigner: fakeSigner,
                 repositoryUrl: null,
@@ -684,6 +706,41 @@ describe("publishToPlayground", () => {
                 false,
                 false,
             );
+            // The explicit value must ALSO drive the metadata JSON, not just the
+            // on-chain arg — otherwise the badge and the XP edge disagree.
+            expect(result.metadata.moddedFrom).toBe("steampunk-lizard-spock01.dot");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    // The contract matches lineage on the canonical `<label>.dot` string, so a
+    // caller passing a bare label or trailing `.dot`-less value must still land
+    // on the canonical form — same as the `dot.json` path goes through
+    // `normalizeDomain`.
+    it("canonicalizes a non-`.dot` explicit moddedFrom before publishing", async () => {
+        const dir = makeTmpDir();
+        try {
+            const result = await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                moddedFrom: "steampunk-lizard-spock01",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "steampunk-lizard-spock01.dot",
+                false,
+                false,
+            );
+            expect(result.metadata.moddedFrom).toBe("steampunk-lizard-spock01.dot");
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -693,7 +750,7 @@ describe("publishToPlayground", () => {
         const dir = makeTmpDir();
         try {
             writeFileSync(join(dir, "dot.json"), JSON.stringify({ moddedFrom: "original.dot" }));
-            await publishToPlayground({
+            const result = await publishToPlayground({
                 domain: "my-mod",
                 publishSigner: fakeSigner,
                 repositoryUrl: null,
@@ -712,6 +769,39 @@ describe("publishToPlayground", () => {
                 false,
                 false,
             );
+            expect(result.metadata.moddedFrom).toBe("original.dot");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    // A malformed explicit value is treated as "not provided" (it can't reach
+    // on-chain), so it falls through to the `dot.json` value rather than
+    // recording garbage or wiping the lineage edge.
+    it("falls back to dot.json when the explicit moddedFrom is malformed", async () => {
+        const dir = makeTmpDir();
+        try {
+            writeFileSync(join(dir, "dot.json"), JSON.stringify({ moddedFrom: "original.dot" }));
+            const result = await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                moddedFrom: "Not A Domain!",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "original.dot",
+                false,
+                false,
+            );
+            expect(result.metadata.moddedFrom).toBe("original.dot");
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -651,6 +651,72 @@ describe("publishToPlayground", () => {
         }
     });
 
+    // playground-app#335: an SDK/RevX consumer that clones the source itself
+    // (skipping the `dot mod` TUI that rewrites `dot.json`) passes the true
+    // immediate parent via the `moddedFrom` option. It MUST win over the stale
+    // value the cloned repo's `dot.json` carried — otherwise a mod-of-a-mod
+    // re-publishes the grandparent and credits the wrong owner.
+    it("prefers an explicit moddedFrom option over a stale dot.json value", async () => {
+        const dir = makeTmpDir();
+        try {
+            // Stale value inherited from the cloned source (e.g. tutorial).
+            writeFileSync(
+                join(dir, "dot.json"),
+                JSON.stringify({ moddedFrom: "playground-tutorial.dot" }),
+            );
+            await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                // True immediate parent, known by the caller that did the mod.
+                moddedFrom: "steampunk-lizard-spock01.dot",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "steampunk-lizard-spock01.dot",
+                false,
+                false,
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("falls back to dot.json when the explicit moddedFrom is empty/whitespace", async () => {
+        const dir = makeTmpDir();
+        try {
+            writeFileSync(join(dir, "dot.json"), JSON.stringify({ moddedFrom: "original.dot" }));
+            await publishToPlayground({
+                domain: "my-mod",
+                publishSigner: fakeSigner,
+                repositoryUrl: null,
+                cwd: dir,
+                moddedFrom: "   ",
+            });
+            expect(publishTx).toHaveBeenCalledWith(
+                "my-mod.dot",
+                "bafymeta",
+                1,
+                {
+                    isSome: false,
+                    value: "0x0000000000000000000000000000000000000000",
+                },
+                "original.dot",
+                false,
+                false,
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     it("retries up to 3 times on registry publish failure", async () => {
         publishTx.mockImplementationOnce(async () => {
             throw new Error("nonce race");

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -111,11 +111,18 @@ export interface PublishToPlaygroundOptions {
      */
     isModdable?: boolean;
     /**
-     * Domain (`<label>.dot`) the user `dot mod`'d this app from, or `""` if
+     * Domain (`<label>.dot`) the user modded this app from, or `""`/omitted if
      * this is a first-party publish. Recorded on-chain so the playground-app
-     * can render a "modded from" badge. Normally captured by `dot mod` into
-     * `dot.json` and read via `readModdedFrom`; this option is an explicit
-     * fallback for callers that already know the source domain.
+     * can render a "modded from" badge AND so the contract credits the SOURCE
+     * app's owner the mod XP.
+     *
+     * When set (non-empty), this is AUTHORITATIVE — it takes precedence over
+     * any `moddedFrom` read from `dot.json`. A caller that just performed the
+     * mod (the `dot mod` TUI captures it in `dot.json`; an SDK consumer like
+     * RevX clones the source itself and passes it here) knows the true
+     * immediate parent, whereas `dot.json`'s field can be a STALE value that
+     * merely rode along in a cloned repo. See the precedence note in
+     * `publishToPlayground` (playground-app#335).
      */
     moddedFrom?: string;
     /**
@@ -374,12 +381,14 @@ export async function publishToPlayground(
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
                     const visibility = options.isPrivate ? 0 : 1;
-                    // Prefer the lineage captured by `dot mod` in `dot.json`
-                    // (the `moddedFrom` read above); fall back to an explicit option.
-                    // The contract awards the source owner the "your app is
-                    // modded" XP off this argument, so an empty string here
-                    // means no lineage edge is ever recorded.
-                    const moddedFromArg = moddedFrom ?? options.moddedFrom ?? "";
+                    // Explicit `options.moddedFrom` wins over the `dot.json`
+                    // value (see the option's doc + playground-app#335); an
+                    // empty/whitespace explicit value falls through to
+                    // `dot.json` ("not provided", not "no parent"). The contract
+                    // credits the source owner the mod XP off this argument, so
+                    // an empty string records no lineage edge.
+                    const explicitModdedFrom = options.moddedFrom?.trim();
+                    const moddedFromArg = explicitModdedFrom || moddedFrom || "";
                     const isModdable = options.isModdable ?? false;
                     const isDevSigner = options.isDevSigner ?? false;
                     const result = await registry.publish.tx(

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -116,13 +116,16 @@ export interface PublishToPlaygroundOptions {
      * can render a "modded from" badge AND so the contract credits the SOURCE
      * app's owner the mod XP.
      *
-     * When set (non-empty), this is AUTHORITATIVE — it takes precedence over
-     * any `moddedFrom` read from `dot.json`. A caller that just performed the
-     * mod (the `dot mod` TUI captures it in `dot.json`; an SDK consumer like
-     * RevX clones the source itself and passes it here) knows the true
-     * immediate parent, whereas `dot.json`'s field can be a STALE value that
-     * merely rode along in a cloned repo. See the precedence note in
-     * `publishToPlayground` (playground-app#335).
+     * When set to a non-empty, shape-valid domain, this is AUTHORITATIVE — it
+     * takes precedence over any `moddedFrom` read from `dot.json`, and drives
+     * BOTH the metadata JSON field and the on-chain lineage arg. A caller that
+     * just performed the mod (the `dot mod` TUI captures it in `dot.json`; an
+     * SDK consumer like RevX clones the source itself and passes it here) knows
+     * the true immediate parent, whereas `dot.json`'s field can be a STALE value
+     * that merely rode along in a cloned repo. The value is canonicalized via
+     * `normalizeModdedFrom`, so an empty/whitespace/invalid value falls through
+     * to `dot.json` ("not provided", not "no parent"). See the precedence note
+     * in `publishToPlayground` (playground-app#335).
      */
     moddedFrom?: string;
     /**
@@ -252,6 +255,25 @@ export function buildMetadata(input: {
 }
 
 /**
+ * Canonicalizes a caller-supplied `moddedFrom` to `<label>.dot`, or returns
+ * `null` for any unusable value (omitted, empty/whitespace, or a string that
+ * doesn't pass `normalizeDomain`). BOTH the explicit `moddedFrom` option and
+ * the `dot.json` field flow through here so a non-canonical or invalid source
+ * domain can never reach the on-chain lineage edge — the contract matches the
+ * source app by its canonical domain string, so `"foo"` and `"Foo.dot"` would
+ * silently miss the XP credit. See playground-app#335.
+ */
+export function normalizeModdedFrom(value: string | null | undefined): string | null {
+    const trimmed = value?.trim();
+    if (!trimmed) return null;
+    try {
+        return normalizeDomain(trimmed).fullDomain;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Returns the canonical `<label>.dot` form, or `null` for any unusable value
  * (missing file, parse fail, non-string, or a value that doesn't pass
  * `normalizeDomain`). `dot.json` is user-editable, so we shape-validate before
@@ -275,11 +297,7 @@ export function readModdedFrom(cwd: string): string | null {
     if (!parsed || typeof parsed !== "object") return null;
     const value = (parsed as Record<string, unknown>).moddedFrom;
     if (typeof value !== "string") return null;
-    try {
-        return normalizeDomain(value).fullDomain;
-    } catch {
-        return null;
-    }
+    return normalizeModdedFrom(value);
 }
 
 export async function publishToPlayground(
@@ -294,7 +312,16 @@ export async function publishToPlayground(
     // GitHub API call per `dot mod` invocation — see
     // `src/commands/mod/SetupScreen.tsx`.
     const branch = options.cwd && options.repositoryUrl ? readGitBranch(options.cwd) : null;
-    const moddedFrom = options.cwd ? readModdedFrom(options.cwd) : null;
+    // Resolve the mod source ONCE, canonicalized, and use it for BOTH the
+    // metadata JSON and the on-chain arg so the two can never diverge. An
+    // explicit `options.moddedFrom` (the SDK/RevX path, which knows the true
+    // immediate parent) wins over the `dot.json` value when it is a non-empty,
+    // shape-valid domain; an empty/whitespace/invalid explicit value falls
+    // through to `dot.json` ("not provided", not "no parent"). Both sources go
+    // through `normalizeModdedFrom`, so the on-chain lineage edge always lands
+    // on the source app's canonical `<label>.dot` — see playground-app#335.
+    const dotJsonModdedFrom = options.cwd ? readModdedFrom(options.cwd) : null;
+    const moddedFrom = normalizeModdedFrom(options.moddedFrom) ?? dotJsonModdedFrom;
     const metadata = buildMetadata({
         repositoryUrl: options.repositoryUrl,
         branch,
@@ -381,14 +408,11 @@ export async function publishToPlayground(
             for (let attempt = 1; attempt <= MAX_REGISTRY_RETRIES; attempt++) {
                 try {
                     const visibility = options.isPrivate ? 0 : 1;
-                    // Explicit `options.moddedFrom` wins over the `dot.json`
-                    // value (see the option's doc + playground-app#335); an
-                    // empty/whitespace explicit value falls through to
-                    // `dot.json` ("not provided", not "no parent"). The contract
-                    // credits the source owner the mod XP off this argument, so
-                    // an empty string records no lineage edge.
-                    const explicitModdedFrom = options.moddedFrom?.trim();
-                    const moddedFromArg = explicitModdedFrom || moddedFrom || "";
+                    // `moddedFrom` was resolved above (explicit option wins over
+                    // `dot.json`, both canonicalized — see playground-app#335).
+                    // The contract credits the source owner the mod XP off this
+                    // argument, so an empty string records no lineage edge.
+                    const moddedFromArg = moddedFrom ?? "";
                     const isModdable = options.isModdable ?? false;
                     const isDevSigner = options.isDevSigner ?? false;
                     const result = await registry.publish.tx(

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -81,6 +81,18 @@ export interface RunDeployOptions {
     moddable?: boolean;
     /** Resolved public repository URL to record in metadata (moddable=true) or `null` (moddable=false). */
     repositoryUrl?: string | null;
+    /**
+     * Domain (`<label>.dot`) this deploy was modded from. For SDK/RevX
+     * consumers that perform the clone themselves and therefore never run the
+     * `dot mod` TUI step that writes `moddedFrom` into `dot.json`: pass the
+     * source domain here so the contract credits the right owner. When set
+     * (non-empty) it takes precedence over any (possibly stale) `moddedFrom`
+     * in the project's `dot.json` — see `publishToPlayground` and
+     * playground-app#335. Omit for the normal `dot deploy` path, which reads
+     * the value `dot mod` captured in `dot.json`. Ignored when
+     * `publishToPlayground` is false.
+     */
+    moddedFrom?: string | null;
     /** Single playground tag to record in metadata, or `null`/omitted to publish untagged. Ignored when `publishToPlayground` is false. */
     tag?: string | null;
     /** The logged-in phone signer. Required for `mode === "phone"` or `publishToPlayground`. */
@@ -267,6 +279,7 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
                     repositoryUrl: options.repositoryUrl ?? null,
                     tag: options.tag ?? null,
                     cwd: options.projectDir,
+                    moddedFrom: options.moddedFrom ?? undefined,
                     onLogEvent: (event) => options.onEvent({ kind: "storage-event", event }),
                     onAllowancePrompt: allowancePrompt,
                     env: options.env,


### PR DESCRIPTION
Builds on #342. Threads an explicit `moddedFrom` through `RunDeployOptions` → `publishToPlayground` so SDK/RevX consumers that clone a source app themselves (and never run the `dot mod` TUI that rewrites `dot.json`) record the true immediate parent rather than re-publishing the stale `moddedFrom` a cloned repo carried — which otherwise credits the grandparent/tutorial owner (playground-app#335).

On top of #342, this resolves the lineage value **once**, before building metadata, and uses it for both sinks:

- The resolved value now drives **both** the on-chain lineage arg and the metadata JSON `moddedFrom`, so the "modded from" badge and the XP credit can't disagree (previously the metadata kept the stale `dot.json` value on SDK deploys).
- Both the explicit option and the `dot.json` field are canonicalized via `normalizeModdedFrom` to `<label>.dot`; an empty/whitespace/malformed explicit value falls through to `dot.json` rather than recording garbage on-chain.

The CLI `dot deploy` + `dot mod` TUI path is behaviorally unchanged. Adds precedence, canonicalization, malformed-fallback, and metadata-consistency tests plus a `normalizeModdedFrom` unit block, and a changeset.