### PR TITLE
fix(decentralize): handle IPFS repo-needs-migration crash

### DIFF
--- a/.changeset/ipfs-repo-migration.md
+++ b/.changeset/ipfs-repo-migration.md
@@ -1,0 +1,8 @@
+---
+"playground-cli": patch
+---
+
+Handle the IPFS "repo needs migration" failure during deploys.
+
+- `playground login` now detects a stale local Kubo repo (older on-disk format than the installed `ipfs` binary) and runs the one-time `ipfs repo migrate` as part of setup, so deploys don't later crash inside `ipfs add`.
+- When a deploy still hits the migration error (e.g. the IPFS binary was upgraded after login), the cryptic `Command failed: ipfs add … repo needs migration` is replaced with a clear instruction to run `ipfs repo migrate` or re-run `playground login`.

--- a/src/utils/deploy/storage.test.ts
+++ b/src/utils/deploy/storage.test.ts
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, expect, it, vi } from "vitest";
-import { runStorageDeploy } from "./storage.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IPFS_MIGRATION_MESSAGE, isIpfsMigrationError, runStorageDeploy } from "./storage.js";
 
 const bulletinDeployMock = vi.hoisted(() =>
     vi.fn(async () => ({
@@ -29,6 +29,15 @@ vi.mock("@parity/polkadot-app-deploy", () => ({
 }));
 
 describe("runStorageDeploy", () => {
+    beforeEach(() => {
+        bulletinDeployMock.mockReset();
+        bulletinDeployMock.mockResolvedValue({
+            cid: "bafyapp",
+            ipfsCid: "bafyapp",
+            carBytes: new Uint8Array(),
+        });
+    });
+
     it("passes the selected env and endpoints to polkadot-app-deploy", async () => {
         await runStorageDeploy({
             content: "/tmp/project/dist",
@@ -46,5 +55,46 @@ describe("runStorageDeploy", () => {
                 assetHubEndpoints: ["wss://paseo-asset-hub-next-rpc.polkadot.io"],
             }),
         );
+    });
+
+    it("remaps Kubo's 'repo needs migration' abort to an actionable message", async () => {
+        bulletinDeployMock.mockRejectedValueOnce(
+            new Error(
+                "Command failed: ipfs add -Q -r /tmp/x\nError: ipfs repo needs migration, please run migration tool.\n",
+            ),
+        );
+
+        await expect(
+            runStorageDeploy({
+                content: "/tmp/project/dist",
+                domainName: "my-app",
+                auth: {},
+                env: "paseo-next-v2",
+            }),
+        ).rejects.toThrow(IPFS_MIGRATION_MESSAGE);
+    });
+
+    it("passes non-migration deploy errors through unchanged", async () => {
+        const original = new Error("AncientBirthBlock: chunk rejected");
+        bulletinDeployMock.mockRejectedValueOnce(original);
+
+        await expect(
+            runStorageDeploy({
+                content: "/tmp/project/dist",
+                domainName: "my-app",
+                auth: {},
+                env: "paseo-next-v2",
+            }),
+        ).rejects.toBe(original);
+    });
+});
+
+describe("isIpfsMigrationError", () => {
+    it("matches Kubo's migration notice regardless of surrounding text", () => {
+        expect(
+            isIpfsMigrationError(new Error("…\nError: ipfs repo needs migration, please run …")),
+        ).toBe(true);
+        expect(isIpfsMigrationError(new Error("some other failure"))).toBe(false);
+        expect(isIpfsMigrationError("repo needs migration")).toBe(true);
     });
 });

--- a/src/utils/deploy/storage.test.ts
+++ b/src/utils/deploy/storage.test.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { IPFS_MIGRATION_MESSAGE, isIpfsMigrationError, runStorageDeploy } from "./storage.js";
+import { IPFS_MIGRATION_MESSAGE, runStorageDeploy } from "./storage.js";
 
 const bulletinDeployMock = vi.hoisted(() =>
     vi.fn(async () => ({
@@ -58,20 +58,28 @@ describe("runStorageDeploy", () => {
     });
 
     it("remaps Kubo's 'repo needs migration' abort to an actionable message", async () => {
-        bulletinDeployMock.mockRejectedValueOnce(
-            new Error(
-                "Command failed: ipfs add -Q -r /tmp/x\nError: ipfs repo needs migration, please run migration tool.\n",
-            ),
+        const original = new Error(
+            "Command failed: ipfs add -Q -r /tmp/x\nError: ipfs repo needs migration, please run migration tool.\n",
+        );
+        bulletinDeployMock.mockRejectedValueOnce(original);
+
+        const err = await runStorageDeploy({
+            content: "/tmp/project/dist",
+            domainName: "my-app",
+            auth: {},
+            env: "paseo-next-v2",
+        }).then(
+            () => {
+                throw new Error("expected runStorageDeploy to reject");
+            },
+            (e: unknown) => e,
         );
 
-        await expect(
-            runStorageDeploy({
-                content: "/tmp/project/dist",
-                domainName: "my-app",
-                auth: {},
-                env: "paseo-next-v2",
-            }),
-        ).rejects.toThrow(IPFS_MIGRATION_MESSAGE);
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe(IPFS_MIGRATION_MESSAGE);
+        // The raw Kubo output must stay reachable for diagnostics — the remap
+        // wraps, never discards, the original error.
+        expect((err as Error).cause).toBe(original);
     });
 
     it("passes non-migration deploy errors through unchanged", async () => {
@@ -86,15 +94,5 @@ describe("runStorageDeploy", () => {
                 env: "paseo-next-v2",
             }),
         ).rejects.toBe(original);
-    });
-});
-
-describe("isIpfsMigrationError", () => {
-    it("matches Kubo's migration notice regardless of surrounding text", () => {
-        expect(
-            isIpfsMigrationError(new Error("…\nError: ipfs repo needs migration, please run …")),
-        ).toBe(true);
-        expect(isIpfsMigrationError(new Error("some other failure"))).toBe(false);
-        expect(isIpfsMigrationError("repo needs migration")).toBe(true);
     });
 });

--- a/src/utils/deploy/storage.ts
+++ b/src/utils/deploy/storage.ts
@@ -37,6 +37,7 @@ import {
 } from "@parity/polkadot-app-deploy";
 import { DeployLogParser, type DeployLogEvent } from "./progress.js";
 import { getChainConfig, type Env } from "../../config.js";
+import { isIpfsMigrationError } from "../toolchain.js";
 
 export interface StorageDeployOptions {
     /**
@@ -125,14 +126,11 @@ export const IPFS_MIGRATION_MESSAGE =
     "Your local IPFS repo needs a one-time migration before it can be used for uploads. " +
     "Run `ipfs repo migrate` (or re-run `playground login`), then try the deploy again.";
 
-/** True when an error is Kubo's "repo needs migration" abort surfacing from the deploy. */
-export function isIpfsMigrationError(err: unknown): boolean {
-    return /needs migration/i.test(err instanceof Error ? err.message : String(err));
-}
-
 /**
  * Replace Kubo's cryptic `Command failed: ipfs add … repo needs migration`
  * with an actionable instruction. Non-migration errors pass through unchanged.
+ * The migration marker is classified by `toolchain.ts::isIpfsMigrationError`,
+ * the single source of truth shared with `playground login`'s setup probe.
  */
 function remapIpfsMigrationError(err: unknown): unknown {
     if (!isIpfsMigrationError(err)) return err;

--- a/src/utils/deploy/storage.ts
+++ b/src/utils/deploy/storage.ts
@@ -107,9 +107,36 @@ export async function runStorageDeploy(options: StorageDeployOptions): Promise<D
             attributes: options.attributes,
         };
         return await bulletinDeploy(options.content, options.domainName, deployOptions);
+    } catch (err) {
+        throw remapIpfsMigrationError(err);
     } finally {
         restore();
     }
+}
+
+/**
+ * Actionable message shown when the deploy's internal `ipfs add` aborts because
+ * the local Kubo repo predates the installed binary's format. We don't migrate
+ * mid-deploy (that mutates `~/.ipfs` behind the user's back) — we tell them the
+ * one-time command. `playground login` migrates it automatically on its next
+ * run; see `toolchain.ts::ipfsRepoNeedsMigration`.
+ */
+export const IPFS_MIGRATION_MESSAGE =
+    "Your local IPFS repo needs a one-time migration before it can be used for uploads. " +
+    "Run `ipfs repo migrate` (or re-run `playground login`), then try the deploy again.";
+
+/** True when an error is Kubo's "repo needs migration" abort surfacing from the deploy. */
+export function isIpfsMigrationError(err: unknown): boolean {
+    return /needs migration/i.test(err instanceof Error ? err.message : String(err));
+}
+
+/**
+ * Replace Kubo's cryptic `Command failed: ipfs add … repo needs migration`
+ * with an actionable instruction. Non-migration errors pass through unchanged.
+ */
+function remapIpfsMigrationError(err: unknown): unknown {
+    if (!isIpfsMigrationError(err)) return err;
+    return new Error(IPFS_MIGRATION_MESSAGE, { cause: err });
 }
 
 /**

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { hasCargoPvmContract, prependPath, TOOL_STEPS } from "./toolchain.js";
+import { hasCargoPvmContract, isIpfsMigrationError, prependPath, TOOL_STEPS } from "./toolchain.js";
 
 describe("prependPath", () => {
     let originalPath: string | undefined;
@@ -119,5 +119,41 @@ describe("TOOL_STEPS", () => {
         // "repo needs migration"; the manual hint must point at the fix.
         const ipfsStep = TOOL_STEPS.find((entry) => entry.name === "IPFS");
         expect(ipfsStep?.manualHint).toContain("ipfs repo migrate");
+    });
+});
+
+describe("isIpfsMigrationError", () => {
+    it("matches Kubo's full migration notice", () => {
+        expect(
+            isIpfsMigrationError(
+                new Error("Error: ipfs repo needs migration, please run migration tool."),
+            ),
+        ).toBe(true);
+    });
+
+    it("matches regardless of surrounding text (Node's exec prefix, trailing newline)", () => {
+        expect(
+            isIpfsMigrationError(
+                new Error(
+                    "Command failed: ipfs add -Q -r /tmp/x\nError: ipfs repo needs migration, please run …\n",
+                ),
+            ),
+        ).toBe(true);
+    });
+
+    it("matches a bare string, not only Error instances", () => {
+        expect(isIpfsMigrationError("repo needs migration")).toBe(true);
+    });
+
+    it("does not match unrelated failures", () => {
+        expect(isIpfsMigrationError(new Error("AncientBirthBlock: chunk rejected"))).toBe(false);
+        expect(isIpfsMigrationError(new Error("some other failure"))).toBe(false);
+    });
+
+    it("is scoped to the IPFS repo, not any 'needs migration' text", () => {
+        // The marker is "repo needs migration"; a generic database-style
+        // "needs migration" from some other dependency must not be remapped
+        // to the IPFS instruction.
+        expect(isIpfsMigrationError(new Error("database needs migration"))).toBe(false);
     });
 });

--- a/src/utils/toolchain.test.ts
+++ b/src/utils/toolchain.test.ts
@@ -113,4 +113,11 @@ describe("TOOL_STEPS", () => {
         const cargoStep = TOOL_STEPS.find((entry) => entry.name === "cargo-pvm-contract");
         expect(cargoStep?.check).toBe(hasCargoPvmContract);
     });
+
+    it("documents the IPFS repo migration in its manual hint", () => {
+        // A stale Kubo repo crashes the deploy's internal `ipfs add` with
+        // "repo needs migration"; the manual hint must point at the fix.
+        const ipfsStep = TOOL_STEPS.find((entry) => entry.name === "IPFS");
+        expect(ipfsStep?.manualHint).toContain("ipfs repo migrate");
+    });
 });

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -88,6 +88,22 @@ function isIpfsInitialized(): boolean {
 }
 
 /**
+ * True when an error is Kubo's "repo needs migration" abort. The exact notice
+ * is "ipfs repo needs migration, please run migration tool."; we match the
+ * stable "repo needs migration" fragment case-insensitively so surrounding
+ * text (Node's `Command failed: …` prefix, a trailing newline) doesn't matter.
+ *
+ * This is the single source of truth for the marker, shared by the login-setup
+ * probe (`ipfsRepoNeedsMigration`) and the deploy-time remap
+ * (`storage.ts::remapIpfsMigrationError`). Scoped to "repo needs migration"
+ * rather than a bare "needs migration" so an unrelated upstream error that
+ * happens to say "needs migration" isn't misattributed to IPFS.
+ */
+export function isIpfsMigrationError(err: unknown): boolean {
+    return /repo needs migration/i.test(err instanceof Error ? err.message : String(err));
+}
+
+/**
  * Detect a stale Kubo repo that the installed `ipfs` binary refuses to use
  * until it's migrated to the current on-disk format. Kubo stamps `~/.ipfs`
  * with a repo version; when the binary is newer than the repo (e.g. the user
@@ -108,7 +124,7 @@ export async function ipfsRepoNeedsMigration(): Promise<boolean> {
     } catch (err) {
         // Node's `exec` appends the child's stderr to the rejection message,
         // which is where Kubo prints the migration notice.
-        return /needs migration/i.test(err instanceof Error ? err.message : String(err));
+        return isIpfsMigrationError(err);
     }
 }
 

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -87,6 +87,31 @@ function isIpfsInitialized(): boolean {
     return existsSync(resolve(homedir(), ".ipfs"));
 }
 
+/**
+ * Detect a stale Kubo repo that the installed `ipfs` binary refuses to use
+ * until it's migrated to the current on-disk format. Kubo stamps `~/.ipfs`
+ * with a repo version; when the binary is newer than the repo (e.g. the user
+ * installed ipfs long ago, then `dot login` installed/upgraded Kubo), every
+ * repo-touching command — including the `ipfs add` polkadot-app-deploy runs
+ * during a deploy — fails with "ipfs repo needs migration, please run
+ * migration tool." We probe with a cheap, offline, read-only command and look
+ * for that marker in the error.
+ *
+ * Returns false when there's no repo to migrate (nothing initialized yet) so
+ * the IPFS step's fresh-install path is unaffected.
+ */
+export async function ipfsRepoNeedsMigration(): Promise<boolean> {
+    if (!isIpfsInitialized()) return false;
+    try {
+        await run("ipfs repo stat --offline");
+        return false;
+    } catch (err) {
+        // Node's `exec` appends the child's stderr to the rejection message,
+        // which is where Kubo prints the migration notice.
+        return /needs migration/i.test(err instanceof Error ? err.message : String(err));
+    }
+}
+
 export interface ToolStep {
     name: string;
     check: () => Promise<boolean>;
@@ -217,7 +242,14 @@ export const TOOL_STEPS: ToolStep[] = [
     },
     {
         name: "IPFS",
-        check: async () => (await commandExists("ipfs")) && isIpfsInitialized(),
+        // A stale repo (older on-disk format than the installed Kubo) passes
+        // the binary + init checks but blows up later inside the deploy's
+        // `ipfs add` with "repo needs migration". Treat it as not-ready so the
+        // install step migrates it before any deploy runs.
+        check: async () =>
+            (await commandExists("ipfs")) &&
+            isIpfsInitialized() &&
+            !(await ipfsRepoNeedsMigration()),
         install: async (onData) => {
             if (!(await commandExists("ipfs"))) {
                 if (platform() === "darwin" && (await commandExists("brew"))) {
@@ -233,9 +265,15 @@ export const TOOL_STEPS: ToolStep[] = [
             }
             if (!isIpfsInitialized()) {
                 await runPiped("ipfs init", onData);
+            } else if (await ipfsRepoNeedsMigration()) {
+                // One-time, offline, idempotent: Kubo bundles its fs-repo
+                // migrations since v0.15, so this needs no network and no-ops
+                // when the repo is already current.
+                await runPiped("ipfs repo migrate", onData);
             }
         },
-        manualHint: "https://docs.ipfs.tech/install/ then run: ipfs init",
+        manualHint:
+            "https://docs.ipfs.tech/install/ then run: ipfs init (or `ipfs repo migrate` if it reports a stale repo)",
     },
     {
         // Required by `dot decentralize` (mirrors a live site via `wget --mirror`).


### PR DESCRIPTION
## What

Fixes the IPFS `repo needs migration` crash from #333 (sub-issue of the `pg decentralize` epic #349). Reported by Alin: `pg decentralize` failed twice with

```
Command failed: ipfs add -Q -r ...
Error: ipfs repo needs migration, please run migration tool.
```

`decentralize` (and `deploy`) hand the site folder to `polkadot-app-deploy`, which runs the local Kubo `ipfs add` to pack it. Kubo stamps `~/.ipfs` with a repo format version; when the installed binary is newer than the on-disk repo, it refuses to touch it until a one-time `ipfs repo migrate` runs. Our setup check was only `ipfs` present + `~/.ipfs` exists, so a stale repo passed as "ready" and the crash surfaced later, mid-deploy.

## Changes

- `playground login` setup now detects a stale repo (`ipfs repo stat` reporting "needs migration") and runs the one-time `ipfs repo migrate`. Kubo bundles its migrations since v0.15, so it's offline and idempotent (no-op when already current). The readiness check treats a migration-pending repo as not-ready so the migrate runs before any deploy.
- A migration failure that still surfaces from the deploy (e.g. the binary was upgraded after login) is remapped from the cryptic `Command failed: ipfs add …` to a clear instruction: run `ipfs repo migrate`, or re-run `playground login`. We deliberately do not migrate mid-deploy — that would mutate `~/.ipfs` behind the user's back.

## Tests

- `storage.test.ts` — migration error remapped to the actionable message, non-migration errors pass through unchanged, `isIpfsMigrationError` matcher.
- `toolchain.test.ts` — the IPFS manual hint documents `ipfs repo migrate`.

All four gates pass locally: `format:check`, `lint:license`, `typecheck`, `test`.