### PR TITLE
Make the quest picker start-first: START row on top, locked levels greyed

### DIFF
--- a/.changeset/quest-picker-start-first.md
+++ b/.changeset/quest-picker-start-first.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Rework the `playground mod` quest picker so the start action is the first row ("START:" + the first unlocked level) and locked levels render greyed out below it, instead of a read-only level list with a separate Start button underneath. Enter now starts the tutorial immediately; removing cursor navigation also fixes rapid arrow keypresses getting lost.

--- a/src/commands/mod/QuestPicker.tsx
+++ b/src/commands/mod/QuestPicker.tsx
@@ -22,28 +22,31 @@ import {
     type QuestEntry,
     type QuestsManifest,
 } from "../../utils/mod/quests.js";
-import { pad, formatDifficulty } from "./questPickerFormat.js";
+import { pad, formatDifficulty, findStartQuestIndex } from "./questPickerFormat.js";
 
 interface Props {
     repoRef: GitHubRepoRef;
     /** Branch to read `quests.json` from (defaults to `main`). */
     branch?: string;
-    /** Resolves once the user is done browsing (Start tutorial or skip). */
+    /** Resolves once the user starts the tutorial (or the picker auto-skips). */
     onDone: () => void;
     /** User cancelled the whole flow. */
     onCancel: () => void;
 }
 
-const COL = { num: 5, id: 16, title: 32, difficulty: 12 };
+const COL = { id: 16, title: 32, difficulty: 12 };
+// Leading marker column; locked rows get the same width in spaces so the
+// id/title/difficulty columns stay aligned with the START row.
+const START_MARKER = "› START: ";
+const LOCKED_INDENT = " ".repeat(START_MARKER.length);
 
 export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
     const { stdout } = useStdout();
+    // Rows available for locked-quest lines (header + summary + hints ≈ 10).
     const viewH = Math.max((stdout?.rows ?? 24) - 10, 5);
 
     const [manifest, setManifest] = useState<QuestsManifest | null>(null);
     const [fetching, setFetching] = useState(true);
-    const [cursor, setCursor] = useState(0);
-    const [scroll, setScroll] = useState(0);
 
     const load = useCallback(async () => {
         try {
@@ -52,7 +55,7 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
             // run — when there's no `quests.json` (not a quest track) OR the
             // manifest defines zero quests. The empty case must behave exactly
             // like the absent one; rendering a quest-less picker would dead-end
-            // the whole `mod` (no "Start tutorial" button, only `q` to quit).
+            // the whole `mod` (no start row, only `q` to quit).
             if (!m || m.quests.length === 0) {
                 onDone();
                 return;
@@ -72,30 +75,18 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
 
     const quests: QuestEntry[] = manifest?.quests ?? [];
 
-    // Cursor moves through quests AND a trailing "Start tutorial" button.
-    // Quest rows are read-only browsing — only the button has an Enter action.
-    const buttonIndex = quests.length;
-    const itemCount = quests.length + 1;
-
+    // The start row is the ONLY interactive element: Enter starts the
+    // tutorial from anywhere, q quits. There is deliberately no cursor —
+    // locked levels are display-only (grey), so there is nothing to navigate
+    // to. This also removes the previous stale-cursor bug where rapid arrow
+    // keypresses (several events between two renders) were lost.
     useInput((input, key) => {
-        if (fetching || !manifest) {
-            if (input === "q") onCancel();
+        if (input === "q") {
+            onCancel();
             return;
         }
-        if (key.upArrow && cursor > 0) {
-            const next = cursor - 1;
-            setCursor(next);
-            if (next < scroll) setScroll(next);
-        }
-        if (key.downArrow && cursor < itemCount - 1) {
-            const next = cursor + 1;
-            setCursor(next);
-            if (next >= scroll + viewH) setScroll(next - viewH + 1);
-        }
-        if (key.return && cursor === buttonIndex && quests.length > 0) {
-            onDone();
-        }
-        if (input === "q") onCancel();
+        if (fetching || !manifest) return;
+        if (key.return && quests.length > 0) onDone();
     });
 
     if (fetching) {
@@ -120,13 +111,27 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
         );
     }
 
-    const visible = quests.slice(scroll, scroll + viewH);
+    const startIndex = findStartQuestIndex(quests);
+    const startQuest = quests[startIndex];
     const notesCol = Math.max(
-        (stdout?.columns ?? 80) - COL.num - COL.id - COL.title - COL.difficulty - 12,
+        (stdout?.columns ?? 80) - START_MARKER.length - COL.id - COL.title - COL.difficulty - 10,
         10,
     );
-    const focusedQuest = cursor < quests.length ? quests[cursor] : null;
-    const buttonFocused = cursor === buttonIndex;
+
+    const row = (q: QuestEntry) => {
+        const notes =
+            q.depends_on && q.depends_on.length > 0 ? `needs: ${q.depends_on.join(", ")}` : "";
+        return `${pad(q.id, COL.id)}  ${pad(q.title, COL.title)}  ${pad(
+            formatDifficulty(q.difficulty),
+            COL.difficulty,
+        )}  ${pad(notes, notesCol)}`;
+    };
+
+    // Locked levels beyond the viewport are summarised in one line instead of
+    // scrolled — there is nothing to select among them anyway.
+    const locked = quests.filter((_, i) => i !== startIndex);
+    const visibleLocked = locked.slice(0, viewH);
+    const hiddenCount = locked.length - visibleLocked.length;
 
     return (
         <Box flexDirection="column" paddingLeft={2}>
@@ -138,57 +143,32 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
                     </Text>
                 </Text>
             </Box>
+
             <Box>
-                <Text dimColor>
-                    {`${pad(" #", COL.num)}  ${pad("id", COL.id)}  ${pad("title", COL.title)}  ${pad(
-                        "difficulty",
-                        COL.difficulty,
-                    )}  notes`}
-                </Text>
-            </Box>
-            <Box>
-                <Text dimColor>
-                    {"─".repeat(COL.num + COL.id + COL.title + COL.difficulty + notesCol + 12)}
+                <Text bold color={COLOR.accent}>
+                    {`${START_MARKER}${row(startQuest)}`}
                 </Text>
             </Box>
 
-            {visible.map((q, i) => {
-                const idx = scroll + i;
-                const sel = idx === cursor;
-                const num = sel
-                    ? `›${String(idx + 1).padStart(COL.num - 1)}`
-                    : ` ${String(idx + 1).padStart(COL.num - 1)}`;
-                const diff = formatDifficulty(q.difficulty);
-                const notes =
-                    q.depends_on && q.depends_on.length > 0
-                        ? `needs: ${q.depends_on.join(", ")}`
-                        : "";
-                return (
-                    <Box key={q.id}>
-                        <Text bold={sel} color={sel ? COLOR.accent : undefined}>
-                            {`${num}  ${pad(q.id, COL.id)}  ${pad(q.title, COL.title)}  ${pad(
-                                diff,
-                                COL.difficulty,
-                            )}  ${pad(notes, notesCol)}`}
-                        </Text>
-                    </Box>
-                );
-            })}
+            {visibleLocked.map((q) => (
+                <Box key={q.id}>
+                    <Text dimColor>{`${LOCKED_INDENT}${row(q)}`}</Text>
+                </Box>
+            ))}
+            {hiddenCount > 0 && (
+                <Box>
+                    <Text dimColor>{`${LOCKED_INDENT}… ${hiddenCount} more locked levels`}</Text>
+                </Box>
+            )}
 
-            {focusedQuest?.summary && (
-                <Box marginTop={1} paddingLeft={0}>
-                    <Text dimColor>↳ {focusedQuest.summary}</Text>
+            {startQuest.summary && (
+                <Box marginTop={1}>
+                    <Text dimColor>↳ {startQuest.summary}</Text>
                 </Box>
             )}
 
             <Box marginTop={1}>
-                <Text bold={buttonFocused} color={buttonFocused ? COLOR.accent : undefined}>
-                    {buttonFocused ? "› [ Start tutorial → ]" : "  [ Start tutorial → ]"}
-                </Text>
-            </Box>
-
-            <Box marginTop={1}>
-                <Hint>↑↓ navigate · ⏎ start tutorial · q quit</Hint>
+                <Hint>⏎ start tutorial · q quit</Hint>
             </Box>
         </Box>
     );

--- a/src/commands/mod/QuestPicker.tsx
+++ b/src/commands/mod/QuestPicker.tsx
@@ -35,14 +35,14 @@ interface Props {
 }
 
 const COL = { id: 16, title: 32, difficulty: 12 };
-// Leading marker column; locked rows get the same width in spaces so the
-// id/title/difficulty columns stay aligned with the START row.
+// Leading marker column; the greyed rows below get the same width in spaces so
+// their id/title/difficulty columns stay aligned with the START row.
 const START_MARKER = "› START: ";
-const LOCKED_INDENT = " ".repeat(START_MARKER.length);
+const LEVEL_INDENT = " ".repeat(START_MARKER.length);
 
 export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
     const { stdout } = useStdout();
-    // Rows available for locked-quest lines (header + summary + hints ≈ 10).
+    // Rows available for the greyed level lines (header + summary + hints ≈ 10).
     const viewH = Math.max((stdout?.rows ?? 24) - 10, 5);
 
     const [manifest, setManifest] = useState<QuestsManifest | null>(null);
@@ -77,9 +77,14 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
 
     // The start row is the ONLY interactive element: Enter starts the
     // tutorial from anywhere, q quits. There is deliberately no cursor —
-    // locked levels are display-only (grey), so there is nothing to navigate
-    // to. This also removes the previous stale-cursor bug where rapid arrow
-    // keypresses (several events between two renders) were lost.
+    // the other levels are display-only (grey), so there is nothing to
+    // navigate to. This also removes the previous stale-cursor bug where rapid
+    // arrow keypresses (several events between two renders) were lost.
+    //
+    // NOTE: `onDone()` carries no quest id — it just continues the existing
+    // clone-of-`main` flow (same effect the old "Start tutorial" button had).
+    // The level named in the START row is informational; we don't start that
+    // specific level, so don't wire downstream logic to the displayed id.
     useInput((input, key) => {
         if (input === "q") {
             onCancel();
@@ -113,8 +118,10 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
 
     const startIndex = findStartQuestIndex(quests);
     const startQuest = quests[startIndex];
+    // row() joins id/title/difficulty/notes with three "  " separators (6 cols);
+    // the marker/indent prefix is subtracted separately via START_MARKER.length.
     const notesCol = Math.max(
-        (stdout?.columns ?? 80) - START_MARKER.length - COL.id - COL.title - COL.difficulty - 10,
+        (stdout?.columns ?? 80) - START_MARKER.length - COL.id - COL.title - COL.difficulty - 6,
         10,
     );
 
@@ -127,11 +134,15 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
         )}  ${pad(notes, notesCol)}`;
     };
 
-    // Locked levels beyond the viewport are summarised in one line instead of
-    // scrolled — there is nothing to select among them anyway.
-    const locked = quests.filter((_, i) => i !== startIndex);
-    const visibleLocked = locked.slice(0, viewH);
-    const hiddenCount = locked.length - visibleLocked.length;
+    // Every quest other than the start row is shown greyed below it. These are
+    // "locked" in the common linear-track case, but a track may declare several
+    // dependency-free quests — only the first becomes the start row, so the
+    // rest are not strictly locked. Keep the displayed copy neutral ("levels").
+    // Rows beyond the viewport are summarised in one line instead of scrolled —
+    // there is nothing to select among them anyway.
+    const otherLevels = quests.filter((_, i) => i !== startIndex);
+    const visibleLevels = otherLevels.slice(0, viewH);
+    const hiddenCount = otherLevels.length - visibleLevels.length;
 
     return (
         <Box flexDirection="column" paddingLeft={2}>
@@ -150,14 +161,14 @@ export function QuestPicker({ repoRef, branch, onDone, onCancel }: Props) {
                 </Text>
             </Box>
 
-            {visibleLocked.map((q) => (
+            {visibleLevels.map((q) => (
                 <Box key={q.id}>
-                    <Text dimColor>{`${LOCKED_INDENT}${row(q)}`}</Text>
+                    <Text dimColor>{`${LEVEL_INDENT}${row(q)}`}</Text>
                 </Box>
             ))}
             {hiddenCount > 0 && (
                 <Box>
-                    <Text dimColor>{`${LOCKED_INDENT}… ${hiddenCount} more locked levels`}</Text>
+                    <Text dimColor>{`${LEVEL_INDENT}… ${hiddenCount} more levels`}</Text>
                 </Box>
             )}
 

--- a/src/commands/mod/questPickerFormat.test.ts
+++ b/src/commands/mod/questPickerFormat.test.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import { describe, it, expect } from "vitest";
-import { pad, formatDifficulty } from "./questPickerFormat.js";
+import { pad, formatDifficulty, findStartQuestIndex } from "./questPickerFormat.js";
 
 describe("pad", () => {
     it("right-pads a short string to the requested width", () => {
@@ -46,5 +46,29 @@ describe("formatDifficulty", () => {
         expect(formatDifficulty(undefined)).toBe("—");
         expect(formatDifficulty(0)).toBe("—");
         expect(formatDifficulty(-2)).toBe("—");
+    });
+});
+
+describe("findStartQuestIndex", () => {
+    it("picks the first quest with no dependencies", () => {
+        expect(
+            findStartQuestIndex([
+                { depends_on: [] },
+                { depends_on: ["level-1"] },
+                { depends_on: ["level-2"] },
+            ]),
+        ).toBe(0);
+    });
+
+    it("treats a missing depends_on as dependency-free", () => {
+        expect(findStartQuestIndex([{}, { depends_on: ["a"] }])).toBe(0);
+    });
+
+    it("skips over leading quests that declare dependencies", () => {
+        expect(findStartQuestIndex([{ depends_on: ["x"] }, {}, {}])).toBe(1);
+    });
+
+    it("falls back to the first quest when every entry has dependencies", () => {
+        expect(findStartQuestIndex([{ depends_on: ["x"] }, { depends_on: ["y"] }])).toBe(0);
     });
 });

--- a/src/commands/mod/questPickerFormat.ts
+++ b/src/commands/mod/questPickerFormat.ts
@@ -29,3 +29,15 @@ export function formatDifficulty(d: number | undefined): string {
     if (typeof d !== "number" || d <= 0) return "—";
     return "★".repeat(Math.min(d, 5));
 }
+
+/**
+ * Index of the quest the learner can start right now: the first one with no
+ * `depends_on`. The CLI has no completion tracking (mod always clones the
+ * track's main), so dependency-free is the only "unlocked" signal available.
+ * Falls back to the first quest when every entry declares dependencies, so a
+ * malformed track still gets a start row instead of an all-locked dead end.
+ */
+export function findStartQuestIndex(quests: { depends_on?: string[] }[]): number {
+    const i = quests.findIndex((q) => !q.depends_on || q.depends_on.length === 0);
+    return i === -1 ? 0 : i;
+}


### PR DESCRIPTION
## Issue
In `playground mod`, the quest picker showed levels as a read-only list with a separate [ Start tutorial ] button below it. Enter on a level row silently did nothing (testers read this as broken, see the tutorial epic), and rapid arrow presses lost keystrokes due to stale cursor state.

## Fix
The start action is now the first row ("START:" + the first dependency-free level) and locked levels render greyed out below it. Enter starts the tutorial immediately; q quits. Removing cursor navigation also removes the lost-keystroke bug.

Before
<img width="729" height="246" alt="image" src="https://github.com/user-attachments/assets/1b2d4e4a-cdf7-48d1-97d3-63d3d04fe232" />

After
<img width="1129" height="215" alt="image" src="https://github.com/user-attachments/assets/ac9c1218-c8e2-4f23-989a-b04cc3809ec5" />

Fixes paritytech/playground-tutorial#5