### PR TITLE
feat(ux): surface XP incentives on deploy signer and login username steps

### DIFF
--- a/.changeset/deploy-dev-signer-no-xp-notice.md
+++ b/.changeset/deploy-dev-signer-no-xp-notice.md
@@ -1,0 +1,8 @@
+---
+"playground-cli": patch
+---
+
+`deploy`: warn that the dev signer earns no XP before you pick it.
+
+- The signer-choice screen now shows a yellow callout above the options, when phone signing is available, explaining that the dev signer publishes from a shared test account and so earns no XP, and that picking your phone signer publishes from your own account and earns XP.
+- When you are not logged in, the existing "Mobile signing unavailable" notice now also mentions that logging in lets your deploys earn XP.

--- a/.changeset/login-username-xp-notice.md
+++ b/.changeset/login-username-xp-notice.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": patch
+---
+
+`login`: show that setting a username earns 25 XP.
+
+- The "set a username?" step at the end of `playground login` now shows a green callout above the choice, telling users that setting a username grants them 25 XP and claims their handle, so the incentive is visible before they decide to skip.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -64,7 +64,12 @@ import {
 } from "../../utils/deploy/moddable.js";
 import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { validateDomainLabel } from "../../utils/deploy/dotnsRules.js";
-import { NO_SESSION_NOTICE_TITLE, NO_SESSION_NOTICE_BODY } from "./signerNotice.js";
+import {
+    NO_SESSION_NOTICE_TITLE,
+    NO_SESSION_NOTICE_BODY,
+    DEV_SIGNER_NO_XP_TITLE,
+    DEV_SIGNER_NO_XP_BODY,
+} from "./signerNotice.js";
 import {
     BUILD_HELP,
     CONTRACTS_HELP,
@@ -330,6 +335,16 @@ export function DeployScreen({
                         </Callout>
                     )}
                     <PromptInfo box={SIGNER_HELP} />
+                    {/* Deliberately placed just above the Select (the decision
+                        point), after the neutral SIGNER_HELP info box, so the
+                        "no XP" trade-off is the last thing read before picking.
+                        Only shown with a session, when the phone alternative
+                        actually exists. */}
+                    {hasSession && (
+                        <Callout tone="warning" title={DEV_SIGNER_NO_XP_TITLE}>
+                            <Text>{DEV_SIGNER_NO_XP_BODY}</Text>
+                        </Callout>
+                    )}
                     <Select<SignerMode>
                         label="who signs the upload?"
                         options={[

--- a/src/commands/deploy/signerNotice.test.ts
+++ b/src/commands/deploy/signerNotice.test.ts
@@ -1,0 +1,51 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import {
+    NO_SESSION_NOTICE_TITLE,
+    NO_SESSION_NOTICE_BODY,
+    DEV_SIGNER_NO_XP_TITLE,
+    DEV_SIGNER_NO_XP_BODY,
+} from "./signerNotice.js";
+
+describe("dev-signer XP notice", () => {
+    it("has a non-empty title and body", () => {
+        expect(DEV_SIGNER_NO_XP_TITLE.trim()).not.toBe("");
+        expect(DEV_SIGNER_NO_XP_BODY.trim()).not.toBe("");
+    });
+
+    it("tells the user the dev signer earns no XP and the phone signer does", () => {
+        const body = DEV_SIGNER_NO_XP_BODY.toLowerCase();
+        expect(body).toContain("xp");
+        expect(body).toContain("phone signer");
+    });
+
+    it("nudges not-logged-in users that logging in unlocks XP", () => {
+        expect(NO_SESSION_NOTICE_BODY.toLowerCase()).toContain("xp");
+    });
+
+    // Em dashes read as machine-written; the house copy stays free of them.
+    it("uses no em dashes anywhere in the signer-notice copy", () => {
+        for (const [name, text] of Object.entries({
+            NO_SESSION_NOTICE_TITLE,
+            NO_SESSION_NOTICE_BODY,
+            DEV_SIGNER_NO_XP_TITLE,
+            DEV_SIGNER_NO_XP_BODY,
+        })) {
+            expect(text, name).not.toContain("—");
+        }
+    });
+});

--- a/src/commands/deploy/signerNotice.ts
+++ b/src/commands/deploy/signerNotice.ts
@@ -28,7 +28,20 @@ export const NO_SESSION_NOTICE_TITLE = "Mobile signing unavailable";
 export const NO_SESSION_NOTICE_BODY =
     "You are not logged in, so signing with your phone is not available yet. " +
     'Run "playground login" to pair your phone, then re-run the deploy. ' +
-    "You can continue now with the dev signer.";
+    "You can continue now with the dev signer. Logging in also lets your deploys earn XP.";
+
+/**
+ * Shown above the signer options when phone signing IS available, so the user
+ * spots the trade-off before picking the dev signer. The dev signer publishes
+ * from a shared test account, so XP earned for a deploy cannot accrue to the
+ * user; only signing from their own (phone) account does. Rendered as a yellow
+ * Callout, alongside `SIGNER_HELP`, only on the logged-in path.
+ */
+export const DEV_SIGNER_NO_XP_TITLE = "Dev signer earns no XP";
+
+export const DEV_SIGNER_NO_XP_BODY =
+    "The dev signer publishes from a shared test account, so this deploy earns you no XP. " +
+    "Pick your phone signer to publish from your own account and earn XP.";
 
 /**
  * Hard-error message for an explicit `--signer phone` with no session in a

--- a/src/commands/login/UsernamePrompt.tsx
+++ b/src/commands/login/UsernamePrompt.tsx
@@ -13,9 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Box } from "ink";
+import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
-import { Input, PhoneApprovalCallout, Row, Section, Select } from "../../utils/ui/theme/index.js";
+import {
+    Callout,
+    Input,
+    PhoneApprovalCallout,
+    Row,
+    Section,
+    Select,
+} from "../../utils/ui/theme/index.js";
+import { USERNAME_XP_TITLE, USERNAME_XP_BODY } from "./usernameNotice.js";
 import { getSessionSigner } from "../../utils/auth.js";
 import {
     describeUsernameValidationError,
@@ -118,6 +126,9 @@ export function UsernamePrompt({ addresses, onDone }: UsernamePromptProps) {
     if (phase.kind === "ask") {
         return (
             <Section title="username">
+                <Callout tone="success" title={USERNAME_XP_TITLE}>
+                    <Text>{USERNAME_XP_BODY}</Text>
+                </Callout>
                 <Select<"yes" | "no">
                     label="Set a username for your playground profile?"
                     initialIndex={0}

--- a/src/commands/login/usernameNotice.test.ts
+++ b/src/commands/login/usernameNotice.test.ts
@@ -1,0 +1,37 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { USERNAME_XP_REWARD, USERNAME_XP_TITLE, USERNAME_XP_BODY } from "./usernameNotice.js";
+
+describe("username XP notice", () => {
+    it("has a non-empty title and body", () => {
+        expect(USERNAME_XP_TITLE.trim()).not.toBe("");
+        expect(USERNAME_XP_BODY.trim()).not.toBe("");
+    });
+
+    it("states the XP reward, single-sourced from the constant", () => {
+        expect(USERNAME_XP_TITLE).toContain(String(USERNAME_XP_REWARD));
+        expect(USERNAME_XP_BODY).toContain(String(USERNAME_XP_REWARD));
+        expect(USERNAME_XP_BODY.toLowerCase()).toContain("xp");
+        expect(USERNAME_XP_BODY.toLowerCase()).toContain("username");
+    });
+
+    // Em dashes read as machine-written; the house copy stays free of them.
+    it("uses no em dashes", () => {
+        expect(USERNAME_XP_TITLE).not.toContain("—");
+        expect(USERNAME_XP_BODY).not.toContain("—");
+    });
+});

--- a/src/commands/login/usernameNotice.ts
+++ b/src/commands/login/usernameNotice.ts
@@ -1,0 +1,27 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Shown above the "set a username?" choice at the end of `playground login`,
+ * so the user sees the XP incentive before deciding whether to claim a handle.
+ * Rendered as a green `success` Callout (a reward, not a warning).
+ */
+export const USERNAME_XP_REWARD = 25;
+
+export const USERNAME_XP_TITLE = `Earn ${USERNAME_XP_REWARD} XP`;
+
+export const USERNAME_XP_BODY =
+    `Setting a username grants you ${USERNAME_XP_REWARD} XP and claims your handle ` +
+    "for your playground profile.";


### PR DESCRIPTION
## What

Two small UX additions that surface XP incentives at the moments users decide, so they don't unknowingly leave XP on the table.

### `playground deploy` — dev signer earns no XP
On the "who signs the upload?" screen, a yellow callout now appears **only when phone signing is available** (logged in), warning that the dev signer publishes from a shared test account and so earns no XP, and that picking the phone signer publishes from your own account and earns XP. It sits directly above the signer `Select` (the decision point).

When **not** logged in, no new box appears; instead the existing "Mobile signing unavailable" notice now also mentions that logging in lets your deploys earn XP. The two paths are mutually exclusive (`hasSession` vs `!hasSession`).

### `playground login` — username grants 25 XP
On the "set a username?" step, a green callout above the Yes/No choice tells users that setting a username grants them 25 XP, so the incentive is visible before they decide to skip.

## How

- Copy lifted into sibling `.ts` modules (`deploy/signerNotice.ts`, `login/usernameNotice.ts`) so vitest never imports React/Ink, matching the existing `promptHelp.ts` idiom.
- The `25` is single-sourced in `USERNAME_XP_REWARD`; the title/body are built from it.
- Uses the existing `Callout` theme primitive — `warning` (yellow) for the caveat, `success` (green) for the reward.

## Testing

- New `signerNotice.test.ts` and `usernameNotice.test.ts` assert the copy is present, mentions XP, ties the number to the constant, and is free of em dashes.
- Full suite green: 77 files / 843 tests. `pnpm format:check`, `pnpm typecheck`, `pnpm lint:license` all pass.

## Notes

The copy states the XP rules as fact (dev signer = no XP; username = 25 XP). If the awarding is conditional server-side, the strings (and the single `USERNAME_XP_REWARD` constant) are the one place to adjust.