### PR TITLE
fix(deploy): actionable error when contract pre-step finds no contracts

### DIFF
--- a/.changeset/fix-no-contracts-deploy-error.md
+++ b/.changeset/fix-no-contracts-deploy-error.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix a confusing `pg deploy` failure when the contract pre-step runs against a project with no contracts. Previously, requesting contract deploy (via `--contracts` or the TUI prompt) in a frontend-only project or from the wrong directory failed with the cryptic "No library specified and no dependencies found in cdm.json", surfaced in the TUI under a misleading "Signing Failed" banner. Deploy now reports an actionable error naming the directory and the likely cause, the standalone `pg contract install` error message points at the cdm.json it inspected, and non-signing contract failures are no longer mislabeled as signing failures.

--- a/src/commands/contract.test.ts
+++ b/src/commands/contract.test.ts
@@ -22,11 +22,30 @@ import {
     assertSupportedCdmJson,
     findForeignOwnedCdmPackages,
     formatCdmPackageOwnershipConflicts,
+    installRequestsFromArgs,
     parseContractInstallLibraryArg,
     resolveContractDeployTarget,
     resolveContractInstallTarget,
     resolveContractSignerOptions,
 } from "./contract.js";
+
+describe("installRequestsFromArgs", () => {
+    it("maps cdm.json dependencies when no libraries are passed", () => {
+        expect(
+            installRequestsFromArgs(
+                [],
+                { dependencies: { "@a/b": "latest" }, contracts: {} },
+                "/p",
+            ),
+        ).toEqual([{ library: "@a/b", requestedVersion: "latest" }]);
+    });
+
+    it("throws an actionable error naming the location when there is nothing to install", () => {
+        expect(() =>
+            installRequestsFromArgs([], { dependencies: {}, contracts: {} }, "/proj/cdm.json"),
+        ).toThrow(/\/proj\/cdm\.json/);
+    });
+});
 
 describe("parseContractInstallLibraryArg", () => {
     it("defaults to latest", () => {

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -515,12 +515,20 @@ function detectProjectType(rootDir: string): {
     };
 }
 
-function installRequestsFromArgs(libraries: string[], cdmJson: CdmJson): InstallLibraryRequest[] {
+export function installRequestsFromArgs(
+    libraries: string[],
+    cdmJson: CdmJson,
+    location: string,
+): InstallLibraryRequest[] {
     if (libraries.length > 0) return libraries.map(parseContractInstallLibraryArg);
 
     const deps = cdmJson.dependencies;
     if (!deps || Object.keys(deps).length === 0) {
-        throw new Error("No library specified and no dependencies found in cdm.json.");
+        throw new Error(
+            `No library specified and no dependencies found in cdm.json (looked in ${location}). ` +
+                'Pass a library to install (e.g. "@org/name"), or add a "dependencies" map to ' +
+                "cdm.json. If you meant to deploy a frontend, run from the project root.",
+        );
     }
 
     return Object.entries(deps).map(([library, version]) => ({
@@ -627,7 +635,7 @@ export async function runContractInstall(
     const cdmJson = cdmResult?.cdmJson ?? { dependencies: {}, contracts: {} };
     assertSupportedCdmJson(cdmJson, cdmResult?.cdmJsonPath);
     const target = resolveContractInstallTarget(opts, cdmJson);
-    const requests = installRequestsFromArgs(libraries, cdmJson);
+    const requests = installRequestsFromArgs(libraries, cdmJson, cdmResult?.cdmJsonPath ?? rootDir);
     const useUi = runOptions.useUi ?? true;
 
     let client: Awaited<ReturnType<typeof createCdmAssetHubClient>> | null = null;

--- a/src/commands/contractDeployUi.tsx
+++ b/src/commands/contractDeployUi.tsx
@@ -210,6 +210,11 @@ export function ContractDeployStatusView({
                     <Text>{adapter.signingError}</Text>
                 </Callout>
             )}
+            {adapter.runError && (
+                <Callout tone="danger" title="Contract Deploy Failed">
+                    <Text>{adapter.runError}</Text>
+                </Callout>
+            )}
             <DeployTable
                 statuses={adapter.statuses}
                 displayNames={displayNames}

--- a/src/commands/contractPipelineStatus.test.ts
+++ b/src/commands/contractPipelineStatus.test.ts
@@ -150,4 +150,24 @@ describe("ContractPipelineStatusAdapter", () => {
             error: "Mobile signing failed: unsupported payload",
         });
     });
+
+    it("records a non-signing run error separately from signing errors", () => {
+        const adapter = new ContractPipelineStatusAdapter();
+
+        adapter.setRunError("Contract deploy was requested but no contracts were found in /app.");
+
+        expect(adapter.runError).toBe(
+            "Contract deploy was requested but no contracts were found in /app.",
+        );
+        expect(adapter.signingError).toBeNull();
+    });
+
+    it("keeps the first run error and does not overwrite it", () => {
+        const adapter = new ContractPipelineStatusAdapter();
+
+        adapter.setRunError("first failure");
+        adapter.setRunError("second failure");
+
+        expect(adapter.runError).toBe("first failure");
+    });
 });

--- a/src/commands/contractPipelineStatus.ts
+++ b/src/commands/contractPipelineStatus.ts
@@ -72,8 +72,16 @@ export class ContractPipelineStatusAdapter {
     phase: PhaseInfo | null = null;
     signingPrompt: Extract<SigningEvent, { kind: "sign-request" }> | null = null;
     signingError: string | null = null;
+    // Non-signing failures (e.g. wrong directory, no contracts found, install
+    // errors). Kept separate from signingError so the UI does not mislabel
+    // them as "Signing Failed". First write wins so the root cause is shown.
+    runError: string | null = null;
 
     constructor(private opts: AdapterOptions = {}) {}
+
+    setRunError = (message: string) => {
+        this.runError ??= message;
+    };
 
     handleSigningEvent = (event: SigningEvent) => {
         switch (event.kind) {

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -1145,7 +1145,7 @@ function RunningStage({
             } catch (err) {
                 if (!cancelled) {
                     const message = err instanceof Error ? err.message : String(err);
-                    if (runningContracts) contractDeployAdapter.signingError ??= message;
+                    if (runningContracts) contractDeployAdapter.setRunError(message);
                     setShowPhoneNotice(false);
                     onError(message);
                 }

--- a/src/commands/deploy/contracts.test.ts
+++ b/src/commands/deploy/contracts.test.ts
@@ -14,8 +14,69 @@
 // limitations under the License.
 
 import type { DeploySummary } from "@parity/cdm-builder";
-import { describe, expect, it } from "vitest";
-import { installLibrariesFromDeploySummary } from "./contracts.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../contract.js", () => ({
+    runContractDeploy: vi.fn(),
+    runContractInstall: vi.fn(),
+}));
+
+import { runContractDeploy, runContractInstall } from "../contract.js";
+import { installLibrariesFromDeploySummary, runContractsBeforeFrontend } from "./contracts.js";
+
+describe("runContractsBeforeFrontend", () => {
+    beforeEach(() => {
+        vi.mocked(runContractDeploy).mockReset();
+        vi.mocked(runContractInstall).mockReset();
+        // A benign success so the legacy path would complete normally — the
+        // test then proves our zero-contracts guard fires before this is used.
+        vi.mocked(runContractInstall).mockResolvedValue({
+            success: true,
+            summary: { results: [], errors: [], success: true, totalDurationMs: 0 },
+        } as Awaited<ReturnType<typeof runContractInstall>>);
+    });
+
+    it("throws an actionable error when no contracts are found, without installing", async () => {
+        vi.mocked(runContractDeploy).mockResolvedValue({
+            success: true,
+            summary: { totalDurationMs: 1, contracts: [] },
+        });
+
+        await expect(
+            runContractsBeforeFrontend({
+                projectDir: "/tmp/my-frontend-app",
+                mode: "dev",
+                userSigner: null,
+            }),
+        ).rejects.toThrow(/no contracts were found in \/tmp\/my-frontend-app/);
+
+        expect(runContractInstall).not.toHaveBeenCalled();
+    });
+
+    it("installs the deployed CDM packages when contracts are present", async () => {
+        vi.mocked(runContractDeploy).mockResolvedValue({
+            success: true,
+            summary: {
+                totalDurationMs: 1,
+                contracts: [{ crate: "counter", cdmPackage: "@example/counter", status: "done" }],
+            },
+        });
+
+        const result = await runContractsBeforeFrontend({
+            projectDir: "/tmp/app-with-contracts",
+            mode: "dev",
+            userSigner: null,
+        });
+
+        expect(runContractInstall).toHaveBeenCalledTimes(1);
+        expect(runContractInstall).toHaveBeenCalledWith(
+            ["@example/counter"],
+            { rootDir: "/tmp/app-with-contracts" },
+            expect.objectContaining({ useUi: false }),
+        );
+        expect(result.installedLibraries).toEqual(["@example/counter"]);
+    });
+});
 
 describe("installLibrariesFromDeploySummary", () => {
     it("deduplicates successful CDM packages and skips failed contracts", () => {

--- a/src/commands/deploy/contracts.ts
+++ b/src/commands/deploy/contracts.ts
@@ -75,8 +75,18 @@ export async function runContractsBeforeFrontend({
         throw new Error(formatContractErrors("Contract deploy failed", deploy.summary));
     }
 
+    if (deploy.summary.contracts.length === 0) {
+        throw new Error(
+            `Contract deploy was requested but no contracts were found in ${projectDir}. ` +
+                "Run from the directory containing your contract crates (Cargo.toml) or " +
+                "Solidity sources, or drop --contracts for a frontend-only deploy.",
+        );
+    }
+
+    // Reaching here guarantees contracts.length > 0 (the zero case threw above),
+    // so an empty installedLibraries means contracts deployed without CDM names.
     const installedLibraries = installLibrariesFromDeploySummary(deploy.summary);
-    if (deploy.summary.contracts.length > 0 && installedLibraries.length === 0) {
+    if (installedLibraries.length === 0) {
         throw new Error(
             "Contract deploy completed, but no CDM package names were registered. " +
                 'Add [package.metadata.cdm] package = "@org/name" to each deployable Cargo.toml.',


### PR DESCRIPTION
## Summary

Fixes #319. Requesting the contract pre-step (`pg deploy --contracts`, or the TUI "deploy contracts?" prompt) against a project with **no contracts** — a frontend-only app, or running from the wrong sub-directory — failed with the cryptic `No library specified and no dependencies found in cdm.json`, surfaced in the TUI under a misleading **"Signing Failed"** banner.

## Root cause

cdm-builder's `deployContracts` returns success with an empty `contracts` summary when it detects zero crates. That left `installedLibraries` empty; the existing CDM-package guard (gated on `contracts.length > 0`) was skipped, and `runContractInstall([])` fell through to `installRequestsFromArgs([], cdmJson)`, which threw the cryptic message. In the TUI, that error was stuffed into the signing-error slot and rendered as "Signing Failed".

## Changes

- **`deploy/contracts.ts`** — short-circuit the zero-contracts case in `runContractsBeforeFrontend` with an actionable error naming the directory and likely cause, before reaching the install step. Simplified the now-unreachable `contracts.length > 0` conjunct on the follow-up CDM-package guard.
- **`contract.ts`** — `installRequestsFromArgs` now names the inspected cdm.json path in its error, for standalone `pg contract install` users.
- **`contractPipelineStatus.ts` / `contractDeployUi.tsx` / `deploy/DeployScreen.tsx`** — added a `runError` channel (first-write-wins) so non-signing failures render under a neutral **"Contract Deploy Failed"** callout instead of "Signing Failed".

## Tests

New regression tests in `deploy/contracts.test.ts` (zero-contracts throws + skips install; non-empty summary proceeds to install), `contract.test.ts` (location-named error), and `contractPipelineStatus.test.ts` (`runError` kept separate from `signingError`).

Verified: `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (849 passed) all green.