### PR TITLE
fix(ui): keep status-row label from fusing into a wrapping value

### DIFF
--- a/.changeset/row-label-value-wrap.md
+++ b/.changeset/row-label-value-wrap.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Long status-row messages no longer fuse into their label when they wrap (e.g. "deploy failedNo smart contracts…"). The label and value now live in separate flex boxes so a wrapping value can't swallow the label's trailing space.

--- a/src/utils/ui/theme/Row.tsx
+++ b/src/utils/ui/theme/Row.tsx
@@ -48,8 +48,19 @@ export function Row({
                         <Mark kind={mark} />
                     </Box>
                 )}
-                <Text>{paddedLabel}</Text>
-                {value !== undefined && <ValueText tone={tone}>{value}</ValueText>}
+                {/* Label and value live in separate boxes: when a long value
+                    wraps, Ink trims the label's trailing pad and the mark's
+                    margin if they share a text run, fusing "label" into
+                    "value" with no space. flexShrink=0 keeps the label
+                    column; the value box absorbs the wrapping. */}
+                <Box flexShrink={0}>
+                    <Text>{paddedLabel}</Text>
+                </Box>
+                {value !== undefined && (
+                    <Box flexGrow={1} flexShrink={1}>
+                        <ValueText tone={tone}>{value}</ValueText>
+                    </Box>
+                )}
             </Box>
             {hint && (
                 <Box paddingLeft={mark ? 4 : 2}>


### PR DESCRIPTION
## Summary

Shared status rows (`src/utils/ui/theme/Row.tsx`) rendered the label and value as adjacent text runs inside one flex row. When a long value wrapped across terminal lines, Ink trimmed the label's trailing padding at the wrap boundary and the label abutted the value with no space — e.g. `deploy failedNo smart contracts…`. This is especially visible now that the contract-deploy paths surface long actionable error messages.

The fix puts the label and value in separate boxes: `flexShrink={0}` pins the label column so its trailing space is reserved, and the value box (`flexGrow={1} flexShrink={1}`) absorbs the wrap. Non-wrapping rows render byte-identically.

This change is salvaged from #368 — it is the only piece of that PR not already covered by the merged #369 (which fixed the underlying #319 contract-deploy error path and the "Signing Failed" mislabeling). #368 can be closed once this lands.

## Proof

Rendered OLD vs NEW Row through an Ink render harness at multiple terminal widths:

| Width | OLD | NEW |
|---|---|---|
| 70 | `deploy failedNo smart contracts…` (fused, no space) | `deploy failed No smart contracts…` |
| 90 (no wrap) | identical | identical (no regression) |
| 30–50 | label itself wraps/misaligns | label intact, value wraps cleanly |

## Tests

No render-level test is added: the repo has no `.tsx` test infrastructure (`vitest.config.ts` only includes `*.test.ts`), so a regression test would require adding `ink-testing-library` + a config change — out of scope for this one-line layout fix. The non-obvious flex structure is documented inline so it isn't flattened back.

Verified: `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (849 passed) all green.