### PR TITLE
fix(deploy): validate build directory in preflight

### DIFF
--- a/.changeset/deploy-builddir-preflight.md
+++ b/.changeset/deploy-builddir-preflight.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": patch
+---
+
+`playground deploy --no-build` now validates the build directory up front. A missing or mistyped `--buildDir` fails immediately with an actionable message (`Build directory not found: …`) before the availability check, summary, and any on-chain work, instead of surfacing late as an opaque `Path not found` inside the storage phase.
+
+The build directory is now resolved against `--dir` (the project root) for the storage upload as well, so deploys run with `--dir` pointing outside the current working directory upload the directory the build actually wrote to.

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -51,6 +51,7 @@ import {
     resolveLegacyEnv,
 } from "../../config.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
+import { assertBuildDirExists } from "../../utils/deploy/buildDir.js";
 import { PLAYGROUND_TAGS } from "../../utils/deploy/tags.js";
 import { NO_SESSION_HEADLESS_ERROR } from "./signerNotice.js";
 
@@ -386,6 +387,14 @@ async function runHeadless(ctx: {
     // Reject metadata-only flags supplied without `--playground` before any
     // network work — they'd otherwise be silently ignored.
     assertPublishFlagsConsistent({ moddable, tag, publishToPlayground });
+
+    // Fail fast on a missing/typo'd `--buildDir` when skipping the build, before
+    // the availability round-trip, the summary block, and any on-chain work.
+    // `runDeploy` re-checks as a universal backstop, but catching it here keeps
+    // CI from wasting a network call and printing a summary it'll never use.
+    if (skipBuild) {
+        assertBuildDirExists(ctx.projectDir, buildDir);
+    }
 
     // Phone signing needs a paired session. Headless has no TUI to fall back
     // into, so reject an explicit `--signer phone` with no session up front

--- a/src/utils/deploy/buildDir.test.ts
+++ b/src/utils/deploy/buildDir.test.ts
@@ -1,0 +1,63 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { assertBuildDirExists } from "./buildDir.js";
+
+describe("assertBuildDirExists", () => {
+    let root: string;
+
+    beforeEach(() => {
+        root = mkdtempSync(join(tmpdir(), "builddir-test-"));
+    });
+
+    afterEach(() => {
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    it("does not throw when the build directory exists", () => {
+        mkdirSync(join(root, "dist"));
+        expect(() => assertBuildDirExists(root, "dist")).not.toThrow();
+    });
+
+    it("throws with the resolved absolute path when the directory is missing", () => {
+        expect(() => assertBuildDirExists(root, "dist")).toThrow(
+            new RegExp(`Build directory not found: ${resolve(root, "dist")}`),
+        );
+    });
+
+    it("throws when the build path exists but is a file, not a directory", () => {
+        writeFileSync(join(root, "dist"), "not a dir");
+        expect(() => assertBuildDirExists(root, "dist")).toThrow(/not a directory/);
+    });
+
+    it("resolves a relative buildDir against projectDir", () => {
+        // The directory exists under projectDir, but NOT under process.cwd(),
+        // so a check that resolved against cwd would wrongly fail.
+        mkdirSync(join(root, "build", "out"), { recursive: true });
+        expect(() => assertBuildDirExists(root, "build/out")).not.toThrow();
+    });
+
+    it("honours an absolute buildDir", () => {
+        const abs = join(root, "artifacts");
+        mkdirSync(abs);
+        // projectDir is irrelevant when buildDir is absolute.
+        expect(() => assertBuildDirExists("/some/other/root", abs)).not.toThrow();
+    });
+});

--- a/src/utils/deploy/buildDir.ts
+++ b/src/utils/deploy/buildDir.ts
@@ -1,0 +1,54 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Preflight check for a `--no-build` (skip-build) deploy: the build artifacts
+ * must already exist on disk, since nothing is going to produce them.
+ *
+ * Without this, a missing/typo'd `--buildDir` is only discovered deep inside
+ * polkadot-app-deploy's storage phase (`▸ storage-and-dotns`) — after the
+ * availability round-trip, the summary block, and any on-chain work — where it
+ * surfaces as an opaque `Path not found`. Calling this up front turns that into
+ * a fast, actionable failure before any of that happens.
+ *
+ * `buildDir` is interpreted relative to `projectDir` (the build's working
+ * directory, where artifacts land), matching `RunDeployOptions.buildDir`. An
+ * absolute `buildDir` is used as-is.
+ *
+ * Pure (throws on failure, returns void on success) so it stays unit-testable
+ * without rendering the TUI or running a deploy.
+ */
+export function assertBuildDirExists(projectDir: string, buildDir: string): void {
+    const abs = resolve(projectDir, buildDir);
+    let stats;
+    try {
+        stats = statSync(abs);
+    } catch {
+        throw new Error(
+            `Build directory not found: ${abs}\n` +
+                "Build the project first (remove --no-build), or point --buildDir at the " +
+                "directory that holds your build artifacts.",
+        );
+    }
+    if (!stats.isDirectory()) {
+        throw new Error(
+            `Build path is not a directory: ${abs}\n` +
+                "Point --buildDir at the directory that holds your build artifacts.",
+        );
+    }
+}

--- a/src/utils/deploy/run.test.ts
+++ b/src/utils/deploy/run.test.ts
@@ -72,6 +72,14 @@ vi.mock("../build/index.js", () => ({
     loadDetectInput: loadDetectInputMock,
     detectBuildConfig: detectBuildConfigMock,
 }));
+// These orchestration tests use a fake `/tmp/proj` and mock every I/O boundary;
+// the real skip-build artifacts check (covered by buildDir.test.ts) would trip
+// on the non-existent path, so stub it to a no-op here. Hoisted so the wiring
+// (called with projectDir + buildDir on skip-build) can be asserted.
+const { assertBuildDirExistsMock } = vi.hoisted(() => ({
+    assertBuildDirExistsMock: vi.fn(),
+}));
+vi.mock("./buildDir.js", () => ({ assertBuildDirExists: assertBuildDirExistsMock }));
 vi.mock("../../telemetry.js", () => ({
     withSpan: (...args: unknown[]) =>
         withSpanMock(args[0] as string, args[1] as string, args[2], args[3]),
@@ -135,6 +143,7 @@ beforeEach(() => {
     runStorageDeploy.mockClear();
     publishToPlaygroundMock.mockClear();
     runBuildMock.mockClear();
+    assertBuildDirExistsMock.mockClear();
     withSpanMock.mockClear();
     getBulletinAllowanceSignerMock.mockReset();
     getBulletinAllowanceSignerMock.mockResolvedValue(slotSigner);
@@ -402,6 +411,57 @@ describe("runDeploy", () => {
             onEvent: push,
         });
         expect(runBuildMock).not.toHaveBeenCalled();
+    });
+
+    it("checks the build artifacts exist before deploying when skipping the build", async () => {
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "dist",
+            skipBuild: true,
+            domain: "my-app",
+            mode: "dev",
+            publishToPlayground: false,
+            userSigner: null,
+            onEvent: push,
+        });
+        expect(assertBuildDirExistsMock).toHaveBeenCalledWith("/tmp/proj", "dist");
+    });
+
+    it("uploads the build artifacts resolved against projectDir, not the process cwd", async () => {
+        // polkadot-app-deploy resolves a relative `content` against process.cwd()
+        // (deploy.js: `path.resolve(content)`), but the build writes to
+        // `projectDir/<buildDir>`. Passing the raw relative path would make a
+        // `--dir`-from-another-cwd deploy upload the wrong directory. We resolve
+        // against projectDir so storage reads exactly where the build wrote.
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "dist",
+            skipBuild: true,
+            domain: "my-app",
+            mode: "dev",
+            publishToPlayground: false,
+            userSigner: null,
+            onEvent: push,
+        });
+        const arg = runStorageDeploy.mock.calls[0][0];
+        expect(arg.content).toBe("/tmp/proj/dist");
+    });
+
+    it("does NOT check build artifacts when a build will produce them", async () => {
+        const { push } = collectEvents();
+        await runDeploy({
+            projectDir: "/tmp/proj",
+            buildDir: "dist",
+            skipBuild: false,
+            domain: "my-app",
+            mode: "dev",
+            publishToPlayground: false,
+            userSigner: null,
+            onEvent: push,
+        });
+        expect(assertBuildDirExistsMock).not.toHaveBeenCalled();
     });
 
     it("emits error event and rethrows when storage fails", async () => {

--- a/src/utils/deploy/run.ts
+++ b/src/utils/deploy/run.ts
@@ -22,8 +22,10 @@
  * off the same events.
  */
 
+import { resolve } from "node:path";
 import { runBuild, loadDetectInput, detectBuildConfig, type BuildConfig } from "../build/index.js";
 import { publishToPlayground, normalizeDomain } from "./playground.js";
+import { assertBuildDirExists } from "./buildDir.js";
 import {
     resolveSignerSetup,
     resolveStorageSignerOptions,
@@ -139,6 +141,16 @@ export interface DeployOutcome {
 // ── Orchestrator ─────────────────────────────────────────────────────────────
 
 export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcome> {
+    // Universal preflight backstop for every caller (headless, interactive TUI,
+    // and SDK/RevX consumers): when skipping the build, the artifacts must
+    // already exist, or the storage phase fails opaquely with `Path not found`.
+    // We only check on skip-build — a real build produces `buildDir` itself.
+    // (`--contracts` always forces a rebuild, so skipBuild and contracts can
+    // never both be set; nothing on-chain runs ahead of this check.)
+    if (options.skipBuild) {
+        assertBuildDirExists(options.projectDir, options.buildDir);
+    }
+
     const { label, fullDomain } = normalizeDomain(options.domain);
 
     const setup = resolveSignerSetup({
@@ -159,7 +171,14 @@ export async function runDeploy(options: RunDeployOptions): Promise<DeployOutcom
         options.onEvent({ kind: "signing", event }),
     );
 
-    const buildAbs = options.buildDir;
+    // Resolve against projectDir, NOT the process cwd. The build writes to
+    // `projectDir/<buildDir>` (build runs with `cwd: projectDir`), but
+    // polkadot-app-deploy resolves a relative `content` against `process.cwd()`
+    // (`path.resolve(content)`). Passing the raw relative path would make a
+    // `--dir`-from-another-cwd deploy upload the wrong directory (or fail with
+    // `Path not found`). An absolute `buildDir` is unchanged (resolve is a
+    // no-op), so the common `projectDir === cwd` case is byte-for-byte identical.
+    const buildAbs = resolve(options.projectDir, options.buildDir);
 
     // Build first, OUTSIDE any signing gate — tsc+vite is the slow part and must
     // stay parallel across concurrent deploys. Only the on-chain signing phases


### PR DESCRIPTION
## Summary

Fixes #267. `playground deploy --no-build` passed a missing or mistyped `--buildDir` all the way into polkadot-app-deploy's storage phase, where it surfaced as an opaque `Path not found` — only after the availability round-trip, the summary block, and any on-chain work.

## Changes

- **New `assertBuildDirExists(projectDir, buildDir)`** (`src/utils/deploy/buildDir.ts`) — pure, no React/Ink (respects the SDK-surface boundary). Throws an actionable `Build directory not found: …` / `is not a directory` error.
- **Called on skip-build deploys in two places:**
  - Early in `runHeadless` — before the availability call and summary, so CI fails fast without a wasted network round-trip (matches the issue's "before the summary block" ask).
  - At the top of `runDeploy` as a universal backstop — covers the interactive TUI and SDK/RevX consumers.
- Only runs when `skipBuild` is true — a real build produces the directory itself. (`--contracts` always forces a rebuild, so `skipBuild` and contracts can never both be set; nothing on-chain precedes the check.)
- **Upload path now resolves against the project root.** The build writes to `projectDir/<buildDir>`, but polkadot-app-deploy resolves a relative `content` against `process.cwd()` (`path.resolve(content)`), so a `--dir`-from-another-cwd deploy uploaded the wrong directory. Resolving against `projectDir` is a no-op when `projectDir === cwd` (the default) and for absolute build dirs.

## Behavior

Before:
```
Checking availability of e2epreflight00.dot…
✔ e2epreflight00.dot is available
Deploying e2epreflight00.dot
...
▸ storage-and-dotns…
 ✖ storage-and-dotns: Path not found: /tmp/definitely-does-not-exist/dist
```

After:
```
✖ Build directory not found: /tmp/definitely-does-not-exist/dist
Build the project first (remove --no-build), or point --buildDir at the directory that holds your build artifacts.
```

## Testing

- New `buildDir.test.ts` (real fs temp dirs): missing dir, file-not-dir, relative-vs-projectDir, absolute.
- New wiring tests in `run.test.ts`: guard called on skip-build, not called when building, and `content` resolved against `projectDir`.
- Verified live: #267 repro fails early before "Checking availability"; `--dir` pointing at a valid dir from a different cwd passes preflight; cwd-has-dir-but-`--dir`-doesn't correctly rejects.
- `pnpm format:check`, `lint:license`, `typecheck`, and the full test suite (857 tests) all pass.