### PR TITLE
fix(deploy): add --yes for non-interactive deploys, stop non-TTY crash

### DIFF
--- a/.changeset/deploy-yes-non-interactive.md
+++ b/.changeset/deploy-yes-non-interactive.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground deploy` no longer crashes with an opaque `Raw mode is not supported on the current process.stdin` error when run without an interactive terminal (agents, CI, piped input). A new `-y, --yes` flag runs the deploy non-interactively using defaults (requires `--domain`; `--signer` defaults to `dev`). When prompts are needed but stdin is not a TTY and `--yes` was not passed, the command now exits with an actionable message pointing at `--yes` instead of the internal Ink crash.

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from "vitest";
 
 import {
     assertPublishFlagsConsistent,
+    chooseDeployDispatch,
     classifyDeployDone,
     DEFAULT_GRACEFUL_NUDGE,
     isFullySpecified,
@@ -101,6 +102,38 @@ describe("resolveYesDeployOpts", () => {
         expect(resolved.domain).toBe("my-app");
         expect(resolved.playground).toBe(true);
         expect(resolved.private).toBe(true);
+    });
+});
+
+describe("chooseDeployDispatch", () => {
+    const interactiveOpts = { signer: "phone", domain: "my-app" } as const; // not fully specified
+
+    it("runs headless when --yes is set, even without a TTY (the P0 escape hatch)", () => {
+        expect(chooseDeployDispatch({ ...interactiveOpts, yes: true }, false)).toBe("headless");
+    });
+
+    it("runs headless when --yes is set in a TTY (no TUI)", () => {
+        expect(chooseDeployDispatch({ ...interactiveOpts, yes: true }, true)).toBe("headless");
+    });
+
+    it("runs headless when fully specified without --yes", () => {
+        const full = {
+            signer: "phone",
+            domain: "my-app",
+            buildDir: "dist",
+            playground: true,
+            contracts: false,
+        } as const;
+        expect(chooseDeployDispatch(full, true)).toBe("headless");
+    });
+
+    it("renders the interactive TUI when underspecified in a TTY", () => {
+        expect(chooseDeployDispatch(interactiveOpts, true)).toBe("interactive");
+    });
+
+    it("errors (never renders the TUI) when underspecified without a TTY", () => {
+        // This is the P0 guard: a non-TTY interactive deploy must not reach Ink.
+        expect(chooseDeployDispatch(interactiveOpts, false)).toBe("non-tty-error");
     });
 });
 

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -20,9 +20,12 @@ import {
     classifyDeployDone,
     DEFAULT_GRACEFUL_NUDGE,
     isFullySpecified,
+    NON_TTY_INTERACTIVE_ERROR,
     resolveGracefulNudge,
+    resolveYesDeployOpts,
     shouldResolveUserSigner,
 } from "./index.js";
+import { DEFAULT_BUILD_DIR } from "../../config.js";
 import type { DeployOutcome } from "../../utils/deploy/run.js";
 
 describe("shouldResolveUserSigner", () => {
@@ -61,6 +64,53 @@ describe("isFullySpecified", () => {
 
     it("allows headless deploy when contracts are explicitly skipped", () => {
         expect(isFullySpecified({ ...fullySpecified, contracts: false })).toBe(true);
+    });
+});
+
+describe("resolveYesDeployOpts", () => {
+    it("requires a domain (--yes is non-interactive, the TUI prompt can't run)", () => {
+        expect(() => resolveYesDeployOpts({})).toThrow(/--domain/);
+    });
+
+    it("rejects a blank/whitespace domain", () => {
+        expect(() => resolveYesDeployOpts({ domain: "   " })).toThrow(/--domain/);
+    });
+
+    it("defaults the signer to dev when omitted", () => {
+        expect(resolveYesDeployOpts({ domain: "my-app" }).signer).toBe("dev");
+    });
+
+    it("preserves an explicit signer", () => {
+        expect(resolveYesDeployOpts({ domain: "my-app", signer: "phone" }).signer).toBe("phone");
+    });
+
+    it("defaults the build directory when omitted", () => {
+        expect(resolveYesDeployOpts({ domain: "my-app" }).buildDir).toBe(DEFAULT_BUILD_DIR);
+    });
+
+    it("preserves an explicit build directory", () => {
+        expect(resolveYesDeployOpts({ domain: "my-app", buildDir: "out" }).buildDir).toBe("out");
+    });
+
+    it("passes the domain through and leaves other flags untouched", () => {
+        const resolved = resolveYesDeployOpts({
+            domain: "my-app",
+            playground: true,
+            private: true,
+        });
+        expect(resolved.domain).toBe("my-app");
+        expect(resolved.playground).toBe(true);
+        expect(resolved.private).toBe(true);
+    });
+});
+
+describe("NON_TTY_INTERACTIVE_ERROR", () => {
+    it("tells the user how to run non-interactively", () => {
+        // The P0: this message must replace the opaque Ink "Raw mode is not
+        // supported" crash. It has to name --yes and --domain so an agent/CI
+        // caller knows the escape hatch.
+        expect(NON_TTY_INTERACTIVE_ERROR).toMatch(/--yes/);
+        expect(NON_TTY_INTERACTIVE_ERROR).toMatch(/--domain/);
     });
 });
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -78,6 +78,12 @@ interface DeployOpts {
     env?: Env;
     /** Project root. Hidden — defaults to cwd. */
     dir?: string;
+    /**
+     * Run non-interactively using defaults instead of the Ink TUI. Required for
+     * agent/CI/piped (non-TTY) callers, where the interactive prompts can't read
+     * keystrokes. Needs `--domain`; `--signer` defaults to `dev`.
+     */
+    yes?: boolean;
 }
 
 export const deployCommand = new Command("deploy")
@@ -122,6 +128,10 @@ export const deployCommand = new Command("deploy")
             .default(DEFAULT_ENV),
     )
     .option("--dir <path>", "Project directory", process.cwd())
+    .option(
+        "-y, --yes",
+        "Run non-interactively using defaults (for agents/CI/piped input). Requires --domain; --signer defaults to dev.",
+    )
     .action(async (opts: DeployOpts) =>
         runCliCommand("deploy", { watchdog: true, hardExit: true }, async () => {
             const projectDir = resolve(opts.dir ?? process.cwd());
@@ -147,6 +157,20 @@ export const deployCommand = new Command("deploy")
             })();
             onProcessShutdown(cleanupOnce);
 
+            // `--yes` fills the fields the TUI would prompt for (signer ⇒ dev,
+            // buildDir ⇒ default) and requires --domain. Resolve it BEFORE
+            // preflight so the signer-resolution path sees the dev default and a
+            // missing domain fails fast with a clear message.
+            let effectiveOpts = opts;
+            try {
+                if (opts.yes) effectiveOpts = resolveYesDeployOpts(opts);
+            } catch (err) {
+                process.stderr.write(`\n✖ ${errorMessage(err)}\n`);
+                cleanupOnce();
+                process.exitCode = 1;
+                throw err;
+            }
+
             try {
                 userSigner = await withSpan(
                     "cli.deploy.preflight",
@@ -155,9 +179,9 @@ export const deployCommand = new Command("deploy")
                     () =>
                         preflight({
                             env,
-                            suri: opts.suri,
-                            mode: opts.signer,
-                            publishToPlayground: opts.playground === true,
+                            suri: effectiveOpts.suri,
+                            mode: effectiveOpts.signer,
+                            publishToPlayground: effectiveOpts.playground === true,
                         }),
                 );
             } catch (err) {
@@ -178,12 +202,19 @@ export const deployCommand = new Command("deploy")
             destroyConnection();
 
             try {
-                const nonInteractive = isFullySpecified(opts);
+                const nonInteractive =
+                    effectiveOpts.yes === true || isFullySpecified(effectiveOpts);
 
                 if (nonInteractive) {
-                    await runHeadless({ projectDir, env, userSigner, opts });
+                    await runHeadless({ projectDir, env, userSigner, opts: effectiveOpts });
+                } else if (!process.stdin.isTTY) {
+                    // The interactive Ink TUI calls `useInput`, which throws
+                    // "Raw mode is not supported on the current process.stdin"
+                    // when stdin isn't a TTY (agent/CI/piped). Fail with an
+                    // actionable message pointing at --yes instead of that crash.
+                    throw new Error(NON_TTY_INTERACTIVE_ERROR);
                 } else {
-                    await runInteractive({ projectDir, env, userSigner, opts });
+                    await runInteractive({ projectDir, env, userSigner, opts: effectiveOpts });
                 }
             } catch (err) {
                 process.stderr.write(`\n✖ ${errorMessage(err)}\n`);
@@ -310,6 +341,38 @@ export function isFullySpecified(opts: DeployOpts): boolean {
         typeof opts.playground === "boolean" &&
         typeof opts.contracts === "boolean"
     );
+}
+
+/**
+ * Shown instead of the opaque Ink "Raw mode is not supported on the current
+ * process.stdin" crash when an interactive deploy is attempted without a TTY
+ * (agent/CI/piped stdin) and `--yes` was not passed. Names the two escape
+ * hatches so a non-interactive caller knows how to proceed.
+ */
+export const NON_TTY_INTERACTIVE_ERROR =
+    "playground deploy needs an interactive terminal for its prompts. " +
+    "Re-run with --yes to use defaults (requires --domain; --signer defaults to dev), " +
+    "or pass the flags explicitly (--signer, --domain, --buildDir, --playground, --contracts).";
+
+/**
+ * Resolve the deploy options for a non-interactive (`--yes`) run by filling the
+ * fields the TUI would otherwise prompt for. `--domain` has no safe default and
+ * is required; `--signer` defaults to `dev` and `--buildDir` to
+ * {@link DEFAULT_BUILD_DIR}. Everything else keeps the defaults `runHeadless`
+ * already applies (`playground`/`contracts` ⇒ false, `build` ⇒ true). Pure +
+ * exported so the contract is unit-testable without rendering the TUI.
+ */
+export function resolveYesDeployOpts(opts: DeployOpts): DeployOpts {
+    if (typeof opts.domain !== "string" || opts.domain.trim() === "") {
+        throw new Error(
+            "playground deploy --yes is non-interactive and needs a domain. Pass --domain <name>.",
+        );
+    }
+    return {
+        ...opts,
+        signer: opts.signer ?? "dev",
+        buildDir: opts.buildDir ?? DEFAULT_BUILD_DIR,
+    };
 }
 
 export type DeployDoneDisposition = "success" | "graceful-cancel" | "failure";

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -202,19 +202,19 @@ export const deployCommand = new Command("deploy")
             destroyConnection();
 
             try {
-                const nonInteractive =
-                    effectiveOpts.yes === true || isFullySpecified(effectiveOpts);
-
-                if (nonInteractive) {
-                    await runHeadless({ projectDir, env, userSigner, opts: effectiveOpts });
-                } else if (!process.stdin.isTTY) {
-                    // The interactive Ink TUI calls `useInput`, which throws
-                    // "Raw mode is not supported on the current process.stdin"
-                    // when stdin isn't a TTY (agent/CI/piped). Fail with an
-                    // actionable message pointing at --yes instead of that crash.
-                    throw new Error(NON_TTY_INTERACTIVE_ERROR);
-                } else {
-                    await runInteractive({ projectDir, env, userSigner, opts: effectiveOpts });
+                switch (chooseDeployDispatch(effectiveOpts, Boolean(process.stdin.isTTY))) {
+                    case "headless":
+                        await runHeadless({ projectDir, env, userSigner, opts: effectiveOpts });
+                        break;
+                    case "non-tty-error":
+                        // The interactive Ink TUI calls `useInput`, which throws
+                        // "Raw mode is not supported on the current process.stdin"
+                        // when stdin isn't a TTY (agent/CI/piped). Fail with an
+                        // actionable message pointing at --yes instead of that crash.
+                        throw new Error(NON_TTY_INTERACTIVE_ERROR);
+                    case "interactive":
+                        await runInteractive({ projectDir, env, userSigner, opts: effectiveOpts });
+                        break;
                 }
             } catch (err) {
                 process.stderr.write(`\n✖ ${errorMessage(err)}\n`);
@@ -353,6 +353,23 @@ export const NON_TTY_INTERACTIVE_ERROR =
     "playground deploy needs an interactive terminal for its prompts. " +
     "Re-run with --yes to use defaults (requires --domain; --signer defaults to dev), " +
     "or pass the flags explicitly (--signer, --domain, --buildDir, --playground, --contracts).";
+
+export type DeployDispatch = "headless" | "non-tty-error" | "interactive";
+
+/**
+ * Decide how a deploy should run. The interactive Ink TUI (`runInteractive`)
+ * calls `useInput`, which enables raw mode on mount and throws when stdin isn't
+ * a TTY — so it must NEVER be chosen without a TTY. Headless wins when `--yes`
+ * is set or every prompt-able flag was supplied; otherwise a TTY gets the TUI
+ * and a non-TTY gets a clear error ({@link NON_TTY_INTERACTIVE_ERROR}) instead
+ * of the raw-mode crash. Pure (takes `isTty` rather than reading
+ * `process.stdin`) so the crash-or-not decision is unit-testable without Ink.
+ */
+export function chooseDeployDispatch(opts: DeployOpts, isTty: boolean): DeployDispatch {
+    if (opts.yes === true || isFullySpecified(opts)) return "headless";
+    if (!isTty) return "non-tty-error";
+    return "interactive";
+}
 
 /**
  * Resolve the deploy options for a non-interactive (`--yes`) run by filling the


### PR DESCRIPTION
## Summary

Fixes #320 (P0). `playground deploy` rendered an interactive Ink TUI whenever the deploy flags weren't fully specified. Ink's `useInput` enables raw mode on mount, which throws `Raw mode is not supported on the current process.stdin` the instant the TUI renders without a TTY (agents, CI, piped stdin) — the command died with that opaque internal error before it could ship anything.

## Changes

- **New `-y, --yes` flag** (mirrors `playground login`): runs the deploy non-interactively using defaults.
  - `resolveYesDeployOpts` fills the fields the TUI would prompt for: `--signer` defaults to `dev`, `--buildDir` to the standard build dir. `playground`/`contracts`/`build` keep the defaults `runHeadless` already applies.
  - `--domain` is **required** — it has no safe default. Missing it fails fast with `playground deploy --yes is non-interactive and needs a domain. Pass --domain <name>.`
  - Resolved **before preflight**, so the dev signer is used for signer resolution and the dev-publish-under-Alice warning still fires (the dev default isn't silent).
- **Non-TTY guard:** when prompts are needed but stdin is not a TTY and `--yes` was not passed, the command throws `NON_TTY_INTERACTIVE_ERROR` (names `--yes` and `--domain`) instead of letting Ink throw the raw-mode error. A real terminal still gets the interactive TUI, unchanged.
- Dispatch: `nonInteractive = --yes || isFullySpecified` → headless; else non-TTY → clear error; else interactive.

Per the agreed design, this does **not** auto-run-with-defaults on non-TTY — `--yes` is the explicit opt-in; a bare non-TTY deploy gets the clear error.

## Behavior

Before (non-TTY):
```
ERROR Raw mode is not supported on the current process.stdin, which Ink uses
     as input stream by default.
```

After:
| Invocation | Result |
| --- | --- |
| `echo "" \| pg deploy --signer dev` (non-TTY) | `✖ playground deploy needs an interactive terminal for its prompts. Re-run with --yes …` — exit 1 |
| `pg deploy --yes` (no domain) | `✖ playground deploy --yes is non-interactive and needs a domain. Pass --domain <name>.` |
| `echo "" \| pg deploy --yes --domain x` (non-TTY) | routes headless, reaches "Checking availability" — signer defaults to dev |

## Testing

- New unit tests (`index.test.ts`): `resolveYesDeployOpts` (domain required incl. whitespace, signer/buildDir defaults, explicit values preserved, pass-through) and the `NON_TTY_INTERACTIVE_ERROR` contract.
- Live-verified the three scenarios above (no Raw mode crash; exit 1 on the guard).
- `pnpm format:check`, `lint:license`, `typecheck`, and the full test suite (865 tests) all pass.