### PR TITLE
fix(install): preserve existing ~/.profile chain for bash users

### DIFF
--- a/.changeset/install-bash-profile-preserve.md
+++ b/.changeset/install-bash-profile-preserve.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`install.sh` no longer shadows an existing `~/.profile` (or `~/.bash_login`) for bash users. The installer creates a `~/.bash_profile` bridge so the `~/.bashrc` PATH entry loads in login shells (every macOS terminal tab). Previously, creating that file from scratch silently took precedence over a pre-existing `~/.profile`/`~/.bash_login` — which login bash reads only as the first existing of `~/.bash_profile` → `~/.bash_login` → `~/.profile` — so the user's login-shell config stopped loading. When the installer now has to create `~/.bash_profile`, it first carries forward a sourcing line for the file bash would otherwise have read. An already-existing `~/.bash_profile` is left untouched apart from appending the `~/.bashrc` source line.

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,28 @@ append_once() {
 }
 if command -v bash >/dev/null 2>&1; then
   append_once "$HOME/.bashrc" 'export PATH="$HOME/.polkadot/bin:$HOME/.local/bin:$PATH"'
+  # Login bash shells (every macOS terminal tab) read only the FIRST existing of
+  # ~/.bash_profile, ~/.bash_login, ~/.profile and never auto-source ~/.bashrc.
+  # We need a ~/.bash_profile bridge so the PATH line above is loaded. But
+  # CREATING ~/.bash_profile from scratch would shadow a pre-existing
+  # ~/.bash_login / ~/.profile and silently drop the user's login-shell config.
+  # So when we have to create the bridge, carry the file bash would otherwise
+  # have read forward first. (If ~/.bash_profile already exists we leave its
+  # precedence untouched and only append the bashrc source below.)
+  if [ ! -e "$HOME/.bash_profile" ]; then
+    for legacy in .bash_login .profile; do
+      if [ -f "$HOME/$legacy" ]; then
+        printf '[ -f "$HOME/%s" ] && . "$HOME/%s"\n' "$legacy" "$legacy" >> "$HOME/.bash_profile"
+        break
+      fi
+    done
+  fi
+  # NB: if the carried-forward file itself sources ~/.bashrc (e.g. Debian's
+  # default ~/.profile does), a login shell sources ~/.bashrc twice. That is
+  # harmless for the idempotent PATH export above and not worth a runtime guard;
+  # sourcing ~/.bashrc exactly once across both that case and a macOS ~/.profile
+  # (which does NOT source it, so this line is required) would need a marker var
+  # coupling the two files. Double-sourcing beats silently dropping the config.
   append_once "$HOME/.bash_profile" '[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"'
 fi
 if command -v zsh >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

A user reported that running the installer corrupted their bash setup. Confirmed in the source.

Login bash shells (every macOS terminal tab) read only the **first existing** file among `~/.bash_profile` → `~/.bash_login` → `~/.profile`, then stop. The installer needs a `~/.bash_profile` bridge because login bash does **not** auto-source `~/.bashrc`, where the CLI's PATH entry is written.

The old code created `~/.bash_profile` from scratch (containing only a line that sources `~/.bashrc`) whenever none existed. For a user who previously had only `~/.profile`, that new file then **shadowed** `~/.profile`, so all their login-shell config (PATH additions, env vars) silently stopped loading. This block has existed since the repo's initial commit, so it affected every install to date. It's the well-known rustup/nvm `.bash_profile`-shadowing footgun.

## Fix

When the installer has to **create** `~/.bash_profile`, it first carries forward a sourcing line for the file bash would otherwise have read — honoring the native `.bash_login` > `.profile` precedence (`break` on first match). An already-existing `~/.bash_profile` is left untouched apart from appending the `~/.bashrc` source line, so there is no regression for users who already had one.

Only the bash branch is affected: zsh writes to `~/.zshrc` (always read by interactive zsh, no shadowing) and fish uses `fish_add_path` — neither has this class of bug.

## Verification

Ran the real extracted block against sandboxed `HOME`s for every pre-existing-file combination, then launched a login shell (`bash -l`) to observe the result:

| Pre-existing files | `~/.polkadot/bin` on PATH | Prior config |
|---|---|---|
| only `~/.profile` (reported bug) | yes | `~/.profile` loads ✓ |
| pre-existing `~/.bash_profile` | yes | untouched, not clobbered ✓ |
| `~/.bash_login` present | yes | `.bash_login` carried forward (correct precedence) ✓ |
| clean machine | yes | n/a ✓ |

- Idempotent across 3 repeated runs — no duplicate lines, no re-shadow.
- `set -e` safe and `bash -n` clean; every case exits 0.

### Known benign edge

On distros whose default `~/.profile` itself sources `~/.bashrc` (e.g. Debian/Ubuntu), a login shell will source `~/.bashrc` twice. This is harmless for the idempotent PATH export and is documented inline. Sourcing `~/.bashrc` exactly once across that case *and* a macOS `~/.profile` (which does not source it, so the line is required) would need a marker variable coupling the two files — disproportionate to a cosmetic double-source that is strictly better than the original silent config loss.