### PR TITLE
feat(login): "try this next" command box + silence benign post-login log

### DIFF
--- a/.changeset/login-next-steps.md
+++ b/.changeset/login-next-steps.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": minor
+---
+
+`playground login` now ends with a "Try one of these next" box suggesting the commands to run after signing in (`pg decentralize`, `pg mod`, `pg deploy`), each with a short description, so newly paired users know where to go next.

--- a/.changeset/login-not-connected-log.md
+++ b/.changeset/login-not-connected-log.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground login` no longer prints a "Statement subscription error: … Not connected" stack trace after a successful sign-in. When the login adapter is destroyed, an in-flight statement-store subscription can surface a bare `Error: Not connected` from the just-closed websocket. That benign teardown artifact was already swallowed as an unhandled rejection, but the statement-store package also logs it directly from its subscription error callback; the local patch that silences that log now matches the bare "Not connected" shape in addition to `DestroyedError`, mirroring `isBenignUnsubscriptionError`.

--- a/patches/@novasamatech__statement-store@0.8.7.patch
+++ b/patches/@novasamatech__statement-store@0.8.7.patch
@@ -1,21 +1,30 @@
 diff --git a/dist/adapter/rpc.js b/dist/adapter/rpc.js
-index b6574289d0b6300e1d54a686bc747e0487635920..f212b2ca5c88c83c45d3cfd3590f98068b736cf5 100644
+index b6574289d0b6300e1d54a686bc747e0487635920..7c937441d90b7ec9a921874368db6f74e742b9b3 100644
 --- a/dist/adapter/rpc.js
 +++ b/dist/adapter/rpc.js
-@@ -69,6 +69,17 @@ export function createPapiStatementStoreAdapter(lazyClient) {
+@@ -69,6 +69,26 @@ export function createPapiStatementStoreAdapter(lazyClient) {
                          setTimeout(flush, 0);
                      }
                  }, error => {
-+                    // PATCH(playground-cli): a DestroyedError here is the
-+                    // expected artifact of destroying the websocket client
-+                    // while subscriptions are live — not a real subscription
-+                    // failure. Logging it prints a scary stack right after
-+                    // successful commands. Real errors still log. The match
-+                    // mirrors process-guard's isBenignUnsubscriptionError
-+                    // (name AND message) so the two filters stay consistent.
-+                    // Remove when upstream gates its logging.
++                    // PATCH(playground-cli): a DestroyedError, or a bare
++                    // Error("Not connected"), here is the expected artifact of
++                    // destroying the websocket client while subscriptions are
++                    // live, not a real subscription failure. Logging it prints
++                    // a scary stack right after successful commands (observed on
++                    // `pg login`: setup completes, the login adapter's destroy
++                    // races an in-flight statement-store call, the raw client
++                    // throws "Not connected", and this callback logged it). Real
++                    // errors still log. The match mirrors process-guard's
++                    // isBenignUnsubscriptionError (name AND message, sections 1
++                    // and 3: the bare-"Not connected" message must match exactly so a
++                    // contextual mid-work failure still escalates) so the two
++                    // filters stay consistent. Remove when upstream gates its
++                    // logging.
 +                    if (error?.name === 'DestroyedError' &&
 +                        /client destroyed/i.test(error?.message ?? ''))
++                        return;
++                    if (error?.name === 'Error' &&
++                        /^not connected$/i.test((error?.message ?? '').trim()))
 +                        return;
                      console.error('Statement subscription error:', error);
                  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 
 patchedDependencies:
   '@novasamatech/sdk-statement@0.6.0': 8c3ebcafda8bbcab4b31fddc74f035a5a1724c0f72eac32a0b46f51a5771e334
-  '@novasamatech/statement-store@0.8.7': 358590dbf3a34d270ca50463bb1a5c5ea665c539c70806c05f4daac390436fd3
+  '@novasamatech/statement-store@0.8.7': 214e0c2859afdec395fa98c68c3e5a05e01f2a4ddca8164b8f780b22cccded8d
 
 importers:
 
@@ -6137,7 +6137,7 @@ snapshots:
       '@noble/hashes': 2.2.0
       '@novasamatech/host-api': 0.8.7
       '@novasamatech/scale': 0.8.7
-      '@novasamatech/statement-store': 0.8.7(patch_hash=358590dbf3a34d270ca50463bb1a5c5ea665c539c70806c05f4daac390436fd3)(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.8.7(patch_hash=214e0c2859afdec395fa98c68c3e5a05e01f2a4ddca8164b8f780b22cccded8d)(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.8.7
       '@polkadot-api/utils': 0.4.0
       '@polkadot-labs/hdkd-helpers': 0.0.30
@@ -6170,7 +6170,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novasamatech/statement-store@0.8.7(patch_hash=358590dbf3a34d270ca50463bb1a5c5ea665c539c70806c05f4daac390436fd3)(esbuild@0.27.7)(rxjs@7.8.2)':
+  '@novasamatech/statement-store@0.8.7(patch_hash=214e0c2859afdec395fa98c68c3e5a05e01f2a4ddca8164b8f780b22cccded8d)(esbuild@0.27.7)(rxjs@7.8.2)':
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
@@ -6929,7 +6929,7 @@ snapshots:
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/host-papp': 0.8.7(esbuild@0.27.7)
-      '@novasamatech/statement-store': 0.8.7(patch_hash=358590dbf3a34d270ca50463bb1a5c5ea665c539c70806c05f4daac390436fd3)(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.8.7(patch_hash=214e0c2859afdec395fa98c68c3e5a05e01f2a4ddca8164b8f780b22cccded8d)(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.8.7
       '@parity/product-sdk-logger': 0.1.1
       '@polkadot-api/substrate-bindings': 0.20.3
@@ -6954,7 +6954,7 @@ snapshots:
       '@noble/curves': 2.2.0
       '@noble/hashes': 2.2.0
       '@novasamatech/host-papp': 0.8.7(esbuild@0.27.7)
-      '@novasamatech/statement-store': 0.8.7(patch_hash=358590dbf3a34d270ca50463bb1a5c5ea665c539c70806c05f4daac390436fd3)(esbuild@0.27.7)(rxjs@7.8.2)
+      '@novasamatech/statement-store': 0.8.7(patch_hash=214e0c2859afdec395fa98c68c3e5a05e01f2a4ddca8164b8f780b22cccded8d)(esbuild@0.27.7)(rxjs@7.8.2)
       '@novasamatech/storage-adapter': 0.8.7
       '@parity/product-sdk-logger': 0.1.1
       '@polkadot-api/substrate-bindings': 0.20.3

--- a/src/commands/login/LoginScreen.tsx
+++ b/src/commands/login/LoginScreen.tsx
@@ -21,6 +21,7 @@ import { IdentityLines } from "./IdentityLines.js";
 import { QrLogin } from "./QrLogin.js";
 import { AccountSetup } from "./AccountSetup.js";
 import { UsernamePrompt } from "./UsernamePrompt.js";
+import { NextSteps } from "./NextStepsCallout.js";
 import { computeAllDone } from "./completion.js";
 import { VERSION_LABEL } from "../../utils/version.js";
 import { getNetworkLabel } from "../../config.js";
@@ -120,6 +121,8 @@ export function LoginScreen({
                     />
                 </Section>
             )}
+
+            {allDone && <NextSteps />}
         </Box>
     );
 }

--- a/src/commands/login/NextStepsCallout.tsx
+++ b/src/commands/login/NextStepsCallout.tsx
@@ -1,0 +1,38 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Box, Text } from "ink";
+import { Callout, COLOR } from "../../utils/ui/theme/index.js";
+import { NEXT_STEPS } from "./nextSteps.js";
+
+/**
+ * Bordered "try this next" box rendered at the end of a successful login, so a
+ * freshly-paired user knows what to run next. Data lives in `nextSteps.ts`;
+ * this is a thin map over it.
+ */
+export function NextSteps() {
+    return (
+        <Callout tone="accent" title="Try one of these next:">
+            {NEXT_STEPS.map((step) => (
+                <Box key={step.cmd} flexDirection="column" marginTop={1}>
+                    <Text color={COLOR.accent} bold>
+                        {step.cmd}
+                    </Text>
+                    <Text dimColor>{`  ${step.description}`}</Text>
+                </Box>
+            ))}
+        </Callout>
+    );
+}

--- a/src/commands/login/nextSteps.test.ts
+++ b/src/commands/login/nextSteps.test.ts
@@ -1,0 +1,37 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { NEXT_STEPS } from "./nextSteps.js";
+
+describe("NEXT_STEPS", () => {
+    it("lists the three creative entry-point commands", () => {
+        expect(NEXT_STEPS.map((s) => s.cmd)).toEqual(["pg decentralize", "pg mod", "pg deploy"]);
+    });
+
+    it("uses the `pg` prefix and a non-empty description for every entry", () => {
+        for (const step of NEXT_STEPS) {
+            expect(step.cmd.startsWith("pg ")).toBe(true);
+            expect(step.description.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("contains no em dashes (house style)", () => {
+        for (const step of NEXT_STEPS) {
+            expect(step.cmd).not.toContain("—");
+            expect(step.description).not.toContain("—");
+        }
+    });
+});

--- a/src/commands/login/nextSteps.ts
+++ b/src/commands/login/nextSteps.ts
@@ -1,0 +1,41 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * "Try this next" suggestions shown in a bordered Callout at the end of a
+ * successful `pg login`. Kept in its own data file (no React/Ink) so the list
+ * stays testable and the rendering component stays a thin map over it.
+ */
+export interface NextStep {
+    /** Full command the user can copy-paste, e.g. `pg decentralize`. */
+    cmd: string;
+    /** One-line description of what the command does. */
+    description: string;
+}
+
+export const NEXT_STEPS: NextStep[] = [
+    {
+        cmd: "pg decentralize",
+        description: "Take any static website and deploy it to a .dot domain. Fully web3.",
+    },
+    {
+        cmd: "pg mod",
+        description: "Browse available community apps and mod them to make them your own.",
+    },
+    {
+        cmd: "pg deploy",
+        description: "Built an app already? Deploy it to a .dot domain on Playground.",
+    },
+];


### PR DESCRIPTION
## What

Two changes that improve the end of the `pg login` flow.

### 1. "Try one of these next" box (feature)

After a successful login, users often don't know what to run next. The login screen now ends with a bordered information box suggesting the creative entry-point commands:

- `pg decentralize` — take any static website and deploy it to a .dot domain
- `pg mod` — browse community apps and mod them
- `pg deploy` — deploy an app you've already built

The command list lives in a pure-data sibling (`nextSteps.ts`, no React) so it stays testable; `NextStepsCallout.tsx` is a thin map over it, rendered via the existing shared `Callout`. The box shows on every successful login, after the "setup complete" row.

### 2. Silence benign "Not connected" log after sign-in (fix)

On login completion the session adapter is destroyed, and a still-live statement-store subscription can surface a bare `Error("Not connected")` from the just-closed websocket. That teardown artifact was already swallowed as an unhandled rejection, but `@novasamatech/statement-store` *also* logs it directly from its subscription error callback, printing a scary stack right after a successful login:

```
Statement subscription error: ... error: Not connected
    at request2 ... at subscribeStatements ... at ensureStoreSubscription
```

The local pnpm patch silencing that callback only matched `DestroyedError`. This extends it to also early-return on a bare `Error` whose message is exactly `not connected` (trimmed, case-insensitive), mirroring `isBenignUnsubscriptionError` in `process-guard.ts` — so a contextual mid-work failure still escalates. Regenerated via `pnpm patch` / `patch-commit`, so the lockfile patch hash is updated in lockstep.

## Testing

- New `nextSteps.test.ts` locks the three commands, the `pg` prefix, and no-em-dash house style.
- The patch logic mirrors `isBenignUnsubscriptionError`, which is itself pinned by `process-guard.test.ts` (exact-match passes, contextual messages escalate).
- All four gates pass: `format:check`, `lint:license`, `typecheck`, `test` (873 passed).

## Changesets

- `login-next-steps.md` (minor) — the next-steps box
- `login-not-connected-log.md` (patch) — the log suppression