### PR TITLE
feat(deploy): warn to rename contracts before redeploy

### DIFF
--- a/.changeset/deploy-contract-rename-warning.md
+++ b/.changeset/deploy-contract-rename-warning.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+deploy: warn before redeploying contracts that CDM package names are owned by their first deployer. When you choose "yes, I changed contracts", `playground deploy` now shows an acknowledgement explaining that if the app is a mod (or you edited contracts someone else authored), the names in `cdm.json` belong to the original author and the deploy will fail unless you rename them first. Press Enter to continue or Esc to exit and rename.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -79,6 +79,9 @@ import {
     DOMAIN_HELP,
     BUILD_DIR_HINT,
     DOMAIN_HINT,
+    CONTRACTS_RENAME_NOTICE_TITLE,
+    CONTRACTS_RENAME_NOTICE_BODY,
+    CONTRACTS_RENAME_NOTICE_HINT,
 } from "./promptHelp.js";
 import { ContractPipelineStatusAdapter } from "../contractPipelineStatus.js";
 import { ContractDeployStatusView, precomputeContractDeployDisplay } from "../contractDeployUi.js";
@@ -117,6 +120,7 @@ export type Stage =
     | { kind: "prompt-build" }
     | { kind: "prompt-signer" }
     | { kind: "prompt-contracts" }
+    | { kind: "prompt-contracts-notice" }
     | { kind: "prompt-buildDir" }
     | { kind: "prompt-domain" }
     | { kind: "validate-domain"; domain: string }
@@ -367,12 +371,25 @@ export function DeployScreen({
                         initialIndex={0}
                         onSelect={(yes) => {
                             setDeployContracts(yes);
-                            const nextSkipBuild = yes ? false : skipBuild;
                             if (yes) setSkipBuild(false);
-                            advance(nextSkipBuild, mode, yes);
+                            // Redeploying contracts is when the CDM-name ownership
+                            // footgun bites (a mod ships names the signer doesn't
+                            // own). Gate "yes" on an explicit rename ack; "no"
+                            // skips straight ahead. The notice lives outside
+                            // pickNextStage, so the headless --contracts path
+                            // never hits it.
+                            if (yes) setStage({ kind: "prompt-contracts-notice" });
+                            else advance(skipBuild, mode, false);
                         }}
                     />
                 </Box>
+            )}
+
+            {stage.kind === "prompt-contracts-notice" && (
+                <ContractsRenameNotice
+                    onContinue={() => advance(false, mode, true)}
+                    onExit={() => onDone(null, { graceful: true })}
+                />
             )}
 
             {stage.kind === "prompt-buildDir" && (
@@ -665,6 +682,35 @@ function AckStage({ onContinue, onExit }: { onContinue: () => void; onExit: () =
             </Callout>
             <Box marginTop={1}>
                 <Hint>{"enter to continue · esc to exit and edit"}</Hint>
+            </Box>
+        </Box>
+    );
+}
+
+/**
+ * Interstitial shown when the user opts to redeploy contracts. Warns that CDM
+ * package names are owned by their first deployer, so a mod (or any project that
+ * edited someone else's contracts) must rename before publishing or the deploy
+ * fails late. Enter continues; Esc exits the flow gracefully so they can rename.
+ */
+function ContractsRenameNotice({
+    onContinue,
+    onExit,
+}: {
+    onContinue: () => void;
+    onExit: () => void;
+}) {
+    useInput((_input, key) => {
+        if (key.return) onContinue();
+        else if (key.escape) onExit();
+    });
+    return (
+        <Box flexDirection="column">
+            <Callout tone="warning" title={CONTRACTS_RENAME_NOTICE_TITLE}>
+                <Text>{CONTRACTS_RENAME_NOTICE_BODY}</Text>
+            </Callout>
+            <Box marginTop={1}>
+                <Hint>{CONTRACTS_RENAME_NOTICE_HINT}</Hint>
             </Box>
         </Box>
     );

--- a/src/commands/deploy/promptHelp.test.ts
+++ b/src/commands/deploy/promptHelp.test.ts
@@ -24,6 +24,9 @@ import {
     DOMAIN_HELP,
     BUILD_DIR_HINT,
     DOMAIN_HINT,
+    CONTRACTS_RENAME_NOTICE_TITLE,
+    CONTRACTS_RENAME_NOTICE_BODY,
+    CONTRACTS_RENAME_NOTICE_HINT,
     type PromptBox,
 } from "./promptHelp.js";
 
@@ -80,6 +83,32 @@ describe("plain-language anchors (the prompts the feedback called out)", () => {
         expect(body).toContain("personhood");
         // Per product wording: say "personhood check", never "identity check".
         expect(body).not.toContain("identity");
+    });
+});
+
+describe("contract-redeploy rename notice", () => {
+    it("has a non-empty title, body, and hint", () => {
+        expect(CONTRACTS_RENAME_NOTICE_TITLE.trim()).not.toBe("");
+        expect(CONTRACTS_RENAME_NOTICE_BODY.trim()).not.toBe("");
+        expect(CONTRACTS_RENAME_NOTICE_HINT.trim()).not.toBe("");
+    });
+
+    it("scopes the warning to mods / others' contracts and points at the files to rename", () => {
+        const body = CONTRACTS_RENAME_NOTICE_BODY.toLowerCase();
+        // The qualifier the user asked for: it only matters for a mod or when
+        // you edited contracts someone else authored.
+        expect(body).toContain("mod");
+        // Concrete remediation: rename, and the files that hold the name.
+        expect(body).toContain("rename");
+        expect(body).toContain("cdm.json");
+        expect(body).toContain("cargo.toml");
+    });
+
+    it("offers enter-to-continue and esc-to-exit on one line", () => {
+        expect(CONTRACTS_RENAME_NOTICE_HINT).not.toContain("\n");
+        const hint = CONTRACTS_RENAME_NOTICE_HINT.toLowerCase();
+        expect(hint).toContain("enter");
+        expect(hint).toContain("esc");
     });
 });
 

--- a/src/commands/deploy/promptHelp.ts
+++ b/src/commands/deploy/promptHelp.ts
@@ -92,6 +92,30 @@ export const DOMAIN_HELP: PromptBox = {
         "names of 5 or fewer are reserved.",
 };
 
+/**
+ * Warning shown after the user confirms they changed contracts (and we're about
+ * to redeploy them). CDM package names are globally first-deploy-wins: a modded
+ * fork (or any project that edited contracts someone else authored) ships
+ * names the current signer does not own, so the publish fails late, after a
+ * funded, ownership-binding deploy (paritytech/playground-app#320,
+ * paritytech/playground-cli#341). We surface it up front and gate on an explicit
+ * ack so the user can rename first. Kept as plain strings (not a `PromptBox`) so
+ * it renders as a `warning` Callout and isn't bound by the info-box length cap.
+ */
+export const CONTRACTS_RENAME_NOTICE_TITLE = "Check your contract names before redeploying";
+
+export const CONTRACTS_RENAME_NOTICE_BODY =
+    "Each smart-contract package name is claimed on-chain by the first account to " +
+    "deploy it, and only that account can redeploy under it. If you wrote these " +
+    "contracts yourself, you already own the names, so just continue. But if this " +
+    "app is a mod, or you edited contracts that someone else originally wrote, the " +
+    "names in cdm.json still belong to them and your deploy will fail. To publish " +
+    "under your own account, first rename each contract to a name you own: update " +
+    "its package name in cdm.json, in the contract's Cargo.toml, and anywhere your " +
+    "frontend code refers to it.";
+
+export const CONTRACTS_RENAME_NOTICE_HINT = "enter to continue · esc to exit and rename";
+
 /** One-line hints for the trivial text inputs (no bordered box). */
 export const BUILD_DIR_HINT =
     "The folder holding your built site (the files we upload). The default fits most projects.";


### PR DESCRIPTION
## What

When a user runs `playground deploy` and interactively selects **"yes, I changed contracts"**, the flow now pauses on an acknowledgement before redeploying.

CDM smart-contract package names are claimed on-chain by the first account to deploy them (globally first-deploy-wins). A modded/cloned app ships names the current signer does not own, so redeploying its contracts fails *late* — after a funded, ownership-binding deploy — with `CDM package "@…/leaderboard" is already owned by 0x…`. This surfaces that footgun up front and gates on an explicit ack so the user can rename first.

## The warning

> **Check your contract names before redeploying**
>
> Each smart-contract package name is claimed on-chain by the first account to deploy it, and only that account can redeploy under it. If you wrote these contracts yourself, you already own the names, so just continue. But if this app is a mod, or you edited contracts that someone else originally wrote, the names in cdm.json still belong to them and your deploy will fail. To publish under your own account, first rename each contract to a name you own: update its package name in cdm.json, in the contract's Cargo.toml, and anywhere your frontend code refers to it.
>
> `enter to continue · esc to exit and rename`

`Enter` continues into the normal flow; `Esc` exits the deploy flow gracefully so the user can go rename. The wording deliberately reassures original authors (who own their names) that they can just continue.

## Design notes

- The notice lives **outside `pickNextStage`** (mirroring the existing README `AckStage`), reachable only via the interactive contracts `Select`. The headless `--contracts` flag path provably cannot reach it (it skips the `prompt-contracts` stage entirely), and the state machine is otherwise unchanged.
- The `yes`/`no` paths are behaviour-equivalent to the prior code; `yes` just interposes the ack.
- It fires unconditionally on interactive "yes" because the CLI cannot yet query on-chain ownership (registry `getOwner` is unbuilt — tracked in playground-cli#322), so the author-vs-mod distinction lives in the copy rather than the tooling.
- Copy is lifted into `promptHelp.ts` as plain string constants with unit tests; React interaction isn't unit-testable (vitest only picks up `.test.ts`).

## Testing

- `pnpm typecheck`, `pnpm format:check`, `pnpm lint:license` clean.
- `pnpm test` — 942/942 pass (including the unchanged `pickNextStage` transition tests and new copy tests).

## Issues

- Closes paritytech/playground-app#320
- Addresses part of paritytech/playground-cli#341 (the rename-warning ask)