### PR TITLE
fix(mod): hide the setup.sh step when an app has none

### DIFF
--- a/.changeset/mod-hide-missing-setup.md
+++ b/.changeset/mod-hide-missing-setup.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground mod`: stop showing a warning when an app has no `setup.sh`. Apps without a setup script are the common case, and surfacing it as a yellow warning row alarmed users. The step is now skipped silently and the usual "Next steps" footer is printed as before.

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -154,7 +154,11 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
             run: async (log) => {
                 const setupPath = resolve(targetDir, "setup.sh");
                 if (!existsSync(setupPath)) {
-                    throw new StepWarning("no setup.sh found");
+                    // Most moddable apps have no setup.sh, and that's normal —
+                    // surfacing it as a warning row alarmed users. Skip the step
+                    // silently so nothing is shown; the parent still prints the
+                    // generic "Next steps" footer because `setupRan` stays false.
+                    throw new SilentSkip("no setup.sh found");
                 }
                 const missing = await findUnsatisfiedPackageManagers(
                     readFileSync(setupPath, "utf8"),
@@ -216,10 +220,17 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
     );
 }
 
-class StepWarning extends Error {
-    isWarning = true;
+/**
+ * Thrown inside a StepRunner step to remove its row from the UI entirely
+ * (StepRunner duck-types the `isSilentSkip` flag). Execution continues and the
+ * run still reports `ok: true`. Used when an optional step has nothing to do
+ * and its absence is a non-event the user shouldn't see.
+ */
+class SilentSkip extends Error {
+    readonly isSilentSkip = true;
     constructor(message: string) {
         super(message);
+        this.name = "SilentSkip";
     }
 }
 

--- a/src/utils/ui/components/StepRunner.tsx
+++ b/src/utils/ui/components/StepRunner.tsx
@@ -23,6 +23,10 @@
  * STOP execution, but report `ok: false` with no `error` — for cases the
  * parent wants to present gently (its own Callout) rather than as a red
  * failure row, while still skipping any success-only output.
+ * Silent skips (`isSilentSkip = true`) remove the step's row from the UI
+ * entirely and don't stop execution (`ok` is preserved) — for optional steps
+ * whose absence is a non-event the user shouldn't see (e.g. an app with no
+ * `setup.sh` to run).
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -46,7 +50,7 @@ export interface Step {
     keepLogOnSuccess?: boolean;
 }
 
-type StepStatus = "pending" | "running" | "ok" | "failed" | "warning";
+type StepStatus = "pending" | "running" | "ok" | "failed" | "warning" | "skipped";
 
 interface StepState {
     name: string;
@@ -144,7 +148,14 @@ export function StepRunner({ title, steps, onDone }: Props) {
                     const isWarning = err instanceof Error && (err as any).isWarning === true;
                     const haltAsWarning =
                         err instanceof Error && (err as any).haltAsWarning === true;
+                    const isSilentSkip = err instanceof Error && (err as any).isSilentSkip === true;
 
+                    if (isSilentSkip) {
+                        setStates((prev) =>
+                            prev.map((s, j) => (j === i ? { ...s, status: "skipped" } : s)),
+                        );
+                        continue;
+                    }
                     if (haltAsWarning) {
                         setStates((prev) =>
                             prev.map((s, j) =>
@@ -188,21 +199,26 @@ export function StepRunner({ title, steps, onDone }: Props) {
 
     return (
         <Section title={title}>
-            {states.map((step) => (
-                <Box key={step.name} flexDirection="column">
-                    <Row
-                        mark={toMark(step.status)}
-                        label={step.name}
-                        value={step.message}
-                        tone={step.status === "failed" ? "danger" : "muted"}
-                    />
-                    {step.retainedLog && step.retainedLog.length > 0 && (
-                        <Box marginTop={1} marginBottom={1}>
-                            <LogTail lines={step.retainedLog} height={step.retainedLog.length} />
-                        </Box>
-                    )}
-                </Box>
-            ))}
+            {states
+                .filter((step) => step.status !== "skipped")
+                .map((step) => (
+                    <Box key={step.name} flexDirection="column">
+                        <Row
+                            mark={toMark(step.status)}
+                            label={step.name}
+                            value={step.message}
+                            tone={step.status === "failed" ? "danger" : "muted"}
+                        />
+                        {step.retainedLog && step.retainedLog.length > 0 && (
+                            <Box marginTop={1} marginBottom={1}>
+                                <LogTail
+                                    lines={step.retainedLog}
+                                    height={step.retainedLog.length}
+                                />
+                            </Box>
+                        )}
+                    </Box>
+                ))}
             {running && liveOutput.length > 0 && (
                 <Box marginTop={1}>
                     <LogTail lines={liveOutput} height={LIVE_LOG_LINES} />


### PR DESCRIPTION
## Problem

When users run `playground mod` on an app with no `setup.sh`, the "run setup.sh" step threw a `StepWarning("no setup.sh found")`, which `StepRunner` rendered as a yellow ⚠ warning row. Apps without a setup script are the common case, so this looked like something had gone wrong and alarmed users.

## Fix

- **`StepRunner`**: added a silent-skip mechanism. A step that throws an error carrying `isSilentSkip = true` is marked `skipped`, execution continues, `ok` is preserved, and the row is filtered out of the rendered list entirely (nothing shows). This mirrors the existing duck-typed `isWarning` / `haltAsWarning` flags.
- **`SetupScreen`**: replaced the now-unused `StepWarning` with a `SilentSkip` class, thrown when `setup.sh` is absent.

`setupRan` still stays `false` on this path, so the generic "Next steps" footer prints exactly as before — only the scary warning row is gone.

## Verification

All four CI checks pass locally: `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (84 files, 942 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)