### PR TITLE
fix(build): distinguish wrong cwd from missing build strategy

### DIFF
--- a/.changeset/wrong-cwd-build-error.md
+++ b/.changeset/wrong-cwd-build-error.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Distinguish a wrong working directory from a genuinely unrecognised project in `dot build` / `dot deploy`. When no `package.json` is found, the error now points at the current directory ("Are you in your project directory? cd into it first, or point the command at it with --dir <path>.") instead of the misleading "No build strategy detected" message that suggested editing a package.json that isn't there.

--- a/src/utils/build/detect.test.ts
+++ b/src/utils/build/detect.test.ts
@@ -141,6 +141,45 @@ describe("detectBuildConfig", () => {
             ),
         ).toThrow(BuildDetectError);
     });
+
+    it("throws a wrong-directory error when package.json is missing entirely", () => {
+        // A missing package.json almost always means the user is one level
+        // above their project (e.g. ran `dot mod` then `dot build` from the
+        // parent). Point them at the cwd, not at editing a package.json that
+        // isn't there.
+        expect(() => detectBuildConfig(input({ packageJson: null }))).toThrow(BuildDetectError);
+        expect(() => detectBuildConfig(input({ packageJson: null }))).toThrow(
+            /No package\.json found/,
+        );
+    });
+
+    it("names the project directory in the missing-package.json error", () => {
+        expect(() =>
+            detectBuildConfig(input({ packageJson: null, projectDir: "/home/me" })),
+        ).toThrow(/\/home\/me/);
+    });
+
+    it("renders the missing-package.json error cleanly when no projectDir is known", () => {
+        // The dir name is optional, so the fallback must not leak `undefined`
+        // or a dangling space before the sentence-ending period.
+        let message = "";
+        try {
+            detectBuildConfig(input({ packageJson: null }));
+        } catch (err) {
+            message = (err as Error).message;
+        }
+        expect(message).toContain("No package.json found.");
+        expect(message).not.toMatch(/undefined/);
+        expect(message).not.toMatch(/ {2}/);
+    });
+
+    it("keeps the generic build-strategy error when package.json exists but is unrecognised", () => {
+        // package.json IS present — the user is in the right place, we just
+        // can't infer a build. Keep the original guidance.
+        expect(() => detectBuildConfig(input({ packageJson: { scripts: {} } }))).toThrow(
+            /No build strategy detected/,
+        );
+    });
 });
 
 describe("detectInstallConfig", () => {

--- a/src/utils/build/detect.ts
+++ b/src/utils/build/detect.ts
@@ -61,6 +61,12 @@ export interface DetectInput {
     lockfiles: Set<string>;
     /** Set of additional config-file basenames (e.g. vite.config.ts). */
     configFiles: Set<string>;
+    /**
+     * Absolute project root the snapshot was taken from, used only to name the
+     * directory in the missing-package.json error. Optional so unit tests can
+     * build inputs without a real path.
+     */
+    projectDir?: string;
 }
 
 export class BuildDetectError extends Error {
@@ -195,6 +201,19 @@ export function detectBuildConfig(input: DetectInput): BuildConfig {
                 defaultOutputDir: hint.defaultOutputDir,
             };
         }
+    }
+
+    // No package.json at all almost always means the user is a level above
+    // their project (e.g. ran `dot mod`, then `dot build` from the parent dir).
+    // Point them at the directory rather than at editing a package.json that
+    // isn't there — the generic "add a build script" message sends them to the
+    // wrong fix.
+    if (!input.packageJson) {
+        const where = input.projectDir ? ` in ${input.projectDir}` : "";
+        throw new BuildDetectError(
+            `No package.json found${where}. Are you in your project directory? ` +
+                "cd into it first, or point the command at it with --dir <path>.",
+        );
     }
 
     throw new BuildDetectError(

--- a/src/utils/build/runner.ts
+++ b/src/utils/build/runner.ts
@@ -68,6 +68,7 @@ export function loadDetectInput(projectDir: string): DetectInput {
         packageJson,
         lockfiles,
         configFiles,
+        projectDir: root,
     };
 }
 


### PR DESCRIPTION
## What

`dot build` / `dot deploy` threw the same error — `No build strategy detected. Add a "build" script to package.json, or install vite/next/typescript.` — in two unrelated situations:

1. The cwd has **no `package.json` at all** (user is one directory above their project, e.g. ran `dot mod` then `dot build` from the parent).
2. The cwd **has a `package.json`** but no recognised build strategy.

Case 1 is the common real-world failure (it generated false "app is missing a build script" bug reports), and the message pointed at the wrong fix — editing a `package.json` that isn't there.

## Change

`detectBuildConfig` now splits the two cases:

- **No `package.json`:** `No package.json found in <dir>. Are you in your project directory? cd into it first, or point the command at it with --dir <path>.`
- **`package.json` present but unrecognised:** unchanged.

To name the directory while keeping `src/utils/build/detect.ts` pure (no I/O), an optional `projectDir` is threaded through `DetectInput` and populated by `loadDetectInput` — so both `dot build` and `dot deploy` get the named-directory message for free. The message references the existing `--dir <path>` flag (the positional-arg suggestion from the issue, #3, is intentionally out of scope here).

## Scope

This addresses suggestion **#1** of #191. Suggestions #2 (`dot mod` next-step footer) and the audit's `--quest` hint are already shipped on `main`; #3 (positional arg) is deliberately not included.

## Tests

- New: wrong-directory error on missing `package.json`, directory name interpolated into the message, clean fallback when no `projectDir` is known (no leaked `undefined` / double space), and a regression lock that the present-but-unrecognised case keeps the original message.
- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck`, `pnpm test` (945 passing) all green.

Refs #191