### PR TITLE
feat(mod): gate tutorial-prompt nudge on the playground-tutorial.dot app

### DIFF
--- a/.changeset/tutorial-prompt-hint.md
+++ b/.changeset/tutorial-prompt-hint.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+The post-mod "Next steps" block now nudges toward the prepopulated `(prompt: "start tutorial")` AI prompt only when modding the `playground-tutorial.dot` app, rather than whenever a quest track was started.

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -28,6 +28,7 @@ import { runCliCommand } from "../../cli-runtime.js";
 import { parseGitHubRepoUrl, type GitHubRepoRef } from "../../utils/mod/source.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
 import { editWithClaudeStep } from "./nextSteps.js";
+import { shouldShowTutorialPrompt } from "./tutorialPromptHint.js";
 
 interface FetchedAppMetadata {
     name?: string;
@@ -174,7 +175,7 @@ async function runModCommand(rawDomain: string | undefined): Promise<void> {
         if (ok && !setupRan) {
             console.log("  Next steps:");
             console.log(`  1. cd ${targetDir}`);
-            console.log(editWithClaudeStep(startedTutorial));
+            console.log(editWithClaudeStep(shouldShowTutorialPrompt({ domain, startedTutorial })));
             console.log("  3. playground deploy --playground");
         }
         if (!ok) process.exitCode = 1;

--- a/src/commands/mod/tutorialPromptHint.test.ts
+++ b/src/commands/mod/tutorialPromptHint.test.ts
@@ -1,0 +1,38 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { shouldShowTutorialPrompt } from "./tutorialPromptHint.js";
+
+describe("shouldShowTutorialPrompt", () => {
+    it("shows the prompt for the hardcoded tutorial app domain", () => {
+        expect(
+            shouldShowTutorialPrompt({ domain: "playground-tutorial.dot", startedTutorial: false }),
+        ).toBe(true);
+    });
+
+    it("ignores startedTutorial; gates purely on the domain", () => {
+        // A quest track started on some other app must NOT surface the nudge.
+        expect(
+            shouldShowTutorialPrompt({ domain: "some-other-app.dot", startedTutorial: true }),
+        ).toBe(false);
+    });
+
+    it("stays generic for any other app", () => {
+        expect(shouldShowTutorialPrompt({ domain: "cool-app.dot", startedTutorial: false })).toBe(
+            false,
+        );
+    });
+});

--- a/src/commands/mod/tutorialPromptHint.ts
+++ b/src/commands/mod/tutorialPromptHint.ts
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * HARDCODED, TEMPORARY: gates the `(prompt: "start tutorial")` nudge in the
+ * post-mod "Next steps" block on a single hardcoded app domain, rather than on
+ * whether the user started a quest track.
+ *
+ * Kept in its own module so it can be removed in one go if we decide against
+ * it: delete this file and pass `startedTutorial` straight to
+ * `editWithClaudeStep` at the `playground mod` call site to revert to the
+ * quest-track behaviour.
+ */
+const TUTORIAL_APP_DOMAIN = "playground-tutorial.dot";
+
+/**
+ * Whether the post-mod next steps should nudge toward the prepopulated
+ * "start tutorial" AI prompt. `startedTutorial` is accepted (and currently
+ * ignored) so the call site keeps threading it through; that is the value to
+ * fall back to once this hardcode is removed.
+ */
+export function shouldShowTutorialPrompt(args: {
+    domain: string;
+    startedTutorial: boolean;
+}): boolean {
+    return args.domain === TUTORIAL_APP_DOMAIN;
+}


### PR DESCRIPTION
## What

The post-mod **Next steps** block prints a step 2 of the form:

```
2. edit with claude (prompt: "start tutorial")
```

Previously the `(prompt: "start tutorial")` bracket appeared whenever the user started a quest track. This PR hardcodes it to appear **only when modding `playground-tutorial.dot`**.

## How

- New self-contained module `src/commands/mod/tutorialPromptHint.ts` holds the hardcoded `playground-tutorial.dot` domain and exports `shouldShowTutorialPrompt({ domain, startedTutorial })` (returns true only for that domain; `startedTutorial` is accepted but ignored so the call site keeps threading it through).
- `src/commands/mod/index.ts` feeds `editWithClaudeStep` from `shouldShowTutorialPrompt(...)` instead of `startedTutorial`.
- Unit tests in `tutorialPromptHint.test.ts`.

The hardcode is deliberately isolated so it can be reverted in one step: delete the module + test and pass `startedTutorial` straight to `editWithClaudeStep`.

## Verification

`pnpm typecheck`, `pnpm format:check`, `pnpm lint:license`, and the mod tests all pass. Changeset included.