### PR TITLE
fix(deploy): route --env through the registry-publish leg

### DIFF
--- a/src/commands/decentralize/index.ts
+++ b/src/commands/decentralize/index.ts
@@ -38,7 +38,13 @@ import React from "react";
 import { render } from "ink";
 import { runCliCommand } from "../../cli-runtime.js";
 import { errorMessage, withSpan } from "../../telemetry.js";
-import { DEFAULT_ENV, ENV_FLAG_CHOICES, type Env, resolveLegacyEnv } from "../../config.js";
+import {
+    DEFAULT_ENV,
+    ENV_FLAG_CHOICES,
+    type Env,
+    resolveLegacyEnv,
+    setActiveEnv,
+} from "../../config.js";
 import { resolveSigner, type ResolvedSigner, SignerNotAvailableError } from "../../utils/signer.js";
 import { resolveDomain } from "../../utils/decentralize/domain.js";
 import { prepareLocalDirectory } from "../../utils/decentralize/local.js";
@@ -147,6 +153,8 @@ export const decentralizeCommand = new Command("decentralize")
     .action(async (opts: DecentralizeOpts) =>
         runCliCommand("decentralize", { hardExit: true }, async () => {
             const env: Env = resolveLegacyEnv(opts.env);
+            // Make --env active before any chain access (see deploy/index.ts + config.ts).
+            setActiveEnv(env);
             if (opts.site || opts.path) {
                 await runHeadless({ env, opts });
             } else {

--- a/src/commands/deploy-all/index.ts
+++ b/src/commands/deploy-all/index.ts
@@ -53,6 +53,7 @@ import {
     ENV_FLAG_CHOICES,
     type Env,
     resolveLegacyEnv,
+    setActiveEnv,
 } from "../../config.js";
 import { NO_SESSION_HEADLESS_ERROR } from "../deploy/signerNotice.js";
 import { parseManifest, type ManifestApp } from "./manifest.js";
@@ -114,6 +115,8 @@ export const deployAllCommand = new Command("deploy-all")
 
 async function runDeployAll(opts: DeployAllOpts): Promise<void> {
     const env: Env = resolveLegacyEnv(opts.env ?? DEFAULT_ENV);
+    // Make --env active before any chain access (see deploy/index.ts + config.ts).
+    setActiveEnv(env);
     const mode = opts.signer;
     if (mode !== "dev" && mode !== "phone") {
         throw new Error("deploy-all requires --signer dev or --signer phone.");

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -49,6 +49,7 @@ import {
     ENV_FLAG_CHOICES,
     type Env,
     resolveLegacyEnv,
+    setActiveEnv,
 } from "../../config.js";
 import { ensureGitInstalled, resolveRepositoryUrl } from "../../utils/deploy/moddable.js";
 import { assertBuildDirExists } from "../../utils/deploy/buildDir.js";
@@ -136,6 +137,10 @@ export const deployCommand = new Command("deploy")
         runCliCommand("deploy", { watchdog: true, hardExit: true }, async () => {
             const projectDir = resolve(opts.dir ?? process.cwd());
             const env: Env = resolveLegacyEnv(opts.env ?? DEFAULT_ENV);
+            // Make --env the process-wide active env BEFORE any chain access, so
+            // the no-arg getConnection()/getChainConfig() paths (registry publish,
+            // account mapping) follow it instead of defaulting to Paseo.
+            setActiveEnv(env);
 
             let userSigner: ResolvedSigner | null = null;
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -34,10 +34,18 @@
  * be non-empty, so nobody can ship a default whose registry isn't deployed yet.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { loadEnvironments } from "@parity/polkadot-app-deploy";
 import { getRegistryAddress } from "@parity/cdm-env";
-import { CONFIGS, DEFAULT_ENV, type ChainConfig, type Env } from "./config.js";
+import {
+    CONFIGS,
+    DEFAULT_ENV,
+    getActiveEnv,
+    getChainConfig,
+    setActiveEnv,
+    type ChainConfig,
+    type Env,
+} from "./config.js";
 
 const { doc } = await loadEnvironments();
 
@@ -94,5 +102,33 @@ describe("config ↔ polkadot-app-deploy environments.json (divergence guard)", 
         // getRegistryAddress("") / unknown name returns "" — switching the default
         // to an env whose registry isn't deployed yet must fail here, not at runtime.
         expect(getRegistryAddress(cfg!.cdmEnvName)).not.toBe("");
+    });
+});
+
+describe("active env (setActiveEnv / getChainConfig default)", () => {
+    // setActiveEnv mutates process-wide state; reset after each test so other
+    // suites keep the DEFAULT_ENV baseline.
+    afterEach(() => setActiveEnv(DEFAULT_ENV));
+
+    it("defaults to DEFAULT_ENV when unset", () => {
+        expect(getActiveEnv()).toBe(DEFAULT_ENV);
+        expect(getChainConfig().env).toBe(DEFAULT_ENV);
+    });
+
+    it("makes the no-arg getChainConfig() follow the active env", () => {
+        // Regression for the --env summit --playground bug: the registry-publish
+        // leg resolves the chain + CDM meta-registry through the no-arg
+        // getChainConfig() default, so it must follow --env, not DEFAULT_ENV.
+        setActiveEnv("summit");
+        expect(getActiveEnv()).toBe("summit");
+        const cfg = getChainConfig();
+        expect(cfg.env).toBe("summit");
+        expect(cfg.assetHubRpc).toBe(CONFIGS.summit!.assetHubRpc);
+        expect(cfg.cdmEnvName).toBe("w3s");
+    });
+
+    it("does not override an explicitly-passed env", () => {
+        setActiveEnv("summit");
+        expect(getChainConfig("paseo-next-v2").env).toBe("paseo-next-v2");
     });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,29 @@ export const ENV_FLAG_CHOICES: readonly string[] = [...ENV_IDS, ...LEGACY_ENV_AL
 export const ACTIVE_TESTNET_ENV: Env = "paseo-next-v2";
 export const DEFAULT_ENV: Env = ACTIVE_TESTNET_ENV;
 
+/**
+ * Process-wide active environment.
+ *
+ * `--env` is parsed per-command, but the connection singleton (`getConnection`)
+ * and the registry / CDM meta-registry resolution (`liveManager`) read the env
+ * through the *no-arg* `getChainConfig()` default. If a command doesn't make its
+ * chosen env the active one, those paths silently fall back to `DEFAULT_ENV`
+ * (paseo-next-v2) even under `--env summit` — which is exactly how
+ * `deploy --env summit --playground` published the registry entry to Paseo while
+ * storage/DotNS (env threaded explicitly via polkadot-app-deploy) went to Summit.
+ *
+ * A command that accepts `--env` MUST call `setActiveEnv(env)` once, before any
+ * chain access, so every no-arg `getChainConfig()` / `getConnection()` follows it.
+ * When unset (tests, library use) it stays `DEFAULT_ENV` — fully backwards-compatible.
+ */
+let _activeEnv: Env | null = null;
+export function setActiveEnv(env: Env): void {
+    _activeEnv = env;
+}
+export function getActiveEnv(): Env {
+    return _activeEnv ?? DEFAULT_ENV;
+}
+
 export interface ChainConfig {
     /** Env identifier — passes straight through to polkadot-app-deploy's `deploy({ env })`. */
     env: Env;
@@ -155,7 +178,7 @@ export const CONFIGS: Partial<Record<Env, ChainConfig>> = {
     // Other envs are not wired yet — getChainConfig() throws below.
 };
 
-export function getChainConfig(env: Env = DEFAULT_ENV): ChainConfig {
+export function getChainConfig(env: Env = getActiveEnv()): ChainConfig {
     const cfg = CONFIGS[env];
     if (!cfg) {
         throw new Error(
@@ -195,7 +218,7 @@ export function resolveLegacyEnv(input: string): Env {
  * Human-readable network label for the Header bread-crumb. Lower-cased to
  * match the existing visual style ("paseo", "polkadot").
  */
-export function getNetworkLabel(env: Env = DEFAULT_ENV): string {
+export function getNetworkLabel(env: Env = getActiveEnv()): string {
     switch (env) {
         case "paseo-next-v2":
             return "paseo next v2";


### PR DESCRIPTION
## The bug

`deploy --env <net> --playground` uploads the app + registers the DotNS name on `<net>`, but publishes the **playground-registry / Apps-grid entry to `DEFAULT_ENV`** instead. So a deploy to a non-default network has working content + `.dot` name, but the app never appears in that network's playground Apps grid.

## Why

The deploy runs in legs. Storage (Bulletin) + DotNS thread `--env` explicitly through `polkadot-app-deploy`, so they hit the right chain. But the `--playground` publish leg — and every other no-arg `getConnection()` / `getChainConfig()` path (account mapping, username lookups) — resolves the chain **and the CDM meta-registry** through `getChainConfig()`'s `DEFAULT_ENV` default. `getConnection()` → `connectPaseo()` → `getChainConfig()` (no arg); `liveManager()` likewise. So `registry.publish.tx(...)` lands on the `DEFAULT_ENV` registry regardless of `--env`.

## The fix

Introduce a process-wide **active env** (`setActiveEnv` / `getActiveEnv`) that `getChainConfig()` and `getNetworkLabel()` default to, and set it from `--env` at the start of `deploy`, `deploy-all`, and `decentralize` — before any chain access. Every no-arg `getChainConfig()`/`getConnection()` now follows `--env`. When unset (tests, library use) it stays `DEFAULT_ENV` — fully backwards-compatible.

## Verification

- New regression tests in `config.test.ts` (active env flips `getChainConfig()`; an explicitly-passed env still wins; default unchanged when unset).
- `pnpm typecheck` ✓ · `pnpm test` **919 passed** ✓ · `pnpm format:check` ✓

Found while deploying to a non-default network: the app's content + name were on the target chain but it never showed in that network's Apps grid; `mod <domain>` (default env) resolved it on the default network, confirming the registry write went there.