### PR TITLE
Route dev playground publishes through publishDev

### DIFF
--- a/cdm.json
+++ b/cdm.json
@@ -5,13 +5,38 @@
   },
   "contracts": {
     "@w3s/playground-registry": {
-      "version": 7,
-      "address": "0xeB814656e2466b5A8e613F8121D57c75F684A35D",
+      "version": 11,
+      "address": "0xBa606EC33a32B51DeDe246372975a956f1A3f9D7",
       "abi": [
         {
           "type": "constructor",
           "inputs": [],
           "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "spikeVerify",
+          "inputs": [
+            {
+              "name": "signature",
+              "type": "uint8[]"
+            },
+            {
+              "name": "message",
+              "type": "uint8[]"
+            },
+            {
+              "name": "public_key",
+              "type": "bytes32"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "view"
         },
         {
           "type": "function",
@@ -53,6 +78,48 @@
             },
             {
               "name": "is_dev_signer",
+              "type": "bool"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "publishDev",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "metadata_uri",
+              "type": "string"
+            },
+            {
+              "name": "visibility",
+              "type": "uint8"
+            },
+            {
+              "name": "owner",
+              "type": "tuple",
+              "components": [
+                {
+                  "name": "isSome",
+                  "type": "bool"
+                },
+                {
+                  "name": "value",
+                  "type": "address"
+                }
+              ]
+            },
+            {
+              "name": "modded_from",
+              "type": "string"
+            },
+            {
+              "name": "is_moddable",
               "type": "bool"
             }
           ],
@@ -110,18 +177,6 @@
         {
           "type": "function",
           "name": "star",
-          "inputs": [
-            {
-              "name": "domain",
-              "type": "string"
-            }
-          ],
-          "outputs": [],
-          "stateMutability": "nonpayable"
-        },
-        {
-          "type": "function",
-          "name": "unstar",
           "inputs": [
             {
               "name": "domain",
@@ -282,6 +337,42 @@
             }
           ],
           "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "adminSetDeployAwardCount",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "name": "count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "adminSetAppSocialCounts",
+          "inputs": [
+            {
+              "name": "domain",
+              "type": "string"
+            },
+            {
+              "name": "star_count",
+              "type": "uint32"
+            },
+            {
+              "name": "mod_count",
+              "type": "uint32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
         },
         {
           "type": "function",
@@ -1021,7 +1112,7 @@
         },
         {
           "type": "function",
-          "name": "importUsernames",
+          "name": "importIdentities",
           "inputs": [
             {
               "name": "entries",
@@ -1032,8 +1123,8 @@
                   "type": "address"
                 },
                 {
-                  "name": "name",
-                  "type": "string"
+                  "name": "root_pubkey",
+                  "type": "bytes32"
                 }
               ]
             }
@@ -1043,11 +1134,15 @@
         },
         {
           "type": "function",
-          "name": "setUsername",
+          "name": "setIdentity",
           "inputs": [
             {
-              "name": "name",
-              "type": "string"
+              "name": "root_pubkey",
+              "type": "bytes32"
+            },
+            {
+              "name": "signature",
+              "type": "uint8[]"
             }
           ],
           "outputs": [],
@@ -1055,14 +1150,14 @@
         },
         {
           "type": "function",
-          "name": "clearUsername",
+          "name": "clearIdentity",
           "inputs": [],
           "outputs": [],
           "stateMutability": "nonpayable"
         },
         {
           "type": "function",
-          "name": "getUsername",
+          "name": "getRootAccount",
           "inputs": [
             {
               "name": "account",
@@ -1072,14 +1167,14 @@
           "outputs": [
             {
               "name": "",
-              "type": "string"
+              "type": "bytes32"
             }
           ],
           "stateMutability": "view"
         },
         {
           "type": "function",
-          "name": "getUsernames",
+          "name": "getRootAccounts",
           "inputs": [
             {
               "name": "accounts",
@@ -1089,51 +1184,41 @@
           "outputs": [
             {
               "name": "",
-              "type": "string[]"
+              "type": "bytes32[]"
             }
           ],
           "stateMutability": "view"
         },
         {
           "type": "function",
-          "name": "getUsernameOwner",
+          "name": "adminSetIdentity",
           "inputs": [
             {
-              "name": "name",
-              "type": "string"
-            }
-          ],
-          "outputs": [
-            {
-              "name": "",
+              "name": "account",
               "type": "address"
-            }
-          ],
-          "stateMutability": "view"
-        },
-        {
-          "type": "function",
-          "name": "isUsernameAvailable",
-          "inputs": [
-            {
-              "name": "name",
-              "type": "string"
             },
             {
-              "name": "prospective_caller",
+              "name": "root_pubkey",
+              "type": "bytes32"
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "adminClearIdentity",
+          "inputs": [
+            {
+              "name": "account",
               "type": "address"
             }
           ],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bool"
-            }
-          ],
-          "stateMutability": "view"
+          "outputs": [],
+          "stateMutability": "nonpayable"
         }
       ],
-      "metadataCid": "bafk2bzaceavewu2aczp237db4dtzgej4tkjavhwfczp3jgaottwzzgpzuadry"
+      "metadataCid": "bafk2bzaceaanuqhbybkuhzk3de7pzv37g7mnvgj7inrpsisi3kxsg36xdh7f6"
     }
   }
 }

--- a/src/utils/deploy/playground.test.ts
+++ b/src/utils/deploy/playground.test.ts
@@ -29,7 +29,7 @@ const { captureWarningMock, withSpanMock, bulletinStorageSigner, getBulletinAllo
     }));
 
 // Mock the metadata upload path so we never actually touch the network.
-// The mock returns a fake CID that publish() treats as the metadata CID.
+// The mock returns a fake CID that registry publishing treats as the metadata CID.
 vi.mock("@parity/product-sdk-cloud-storage", () => ({
     calculateCid: vi.fn(async () => ({ toString: (): string => "bafymeta" })),
 }));
@@ -62,12 +62,14 @@ vi.mock("polkadot-api/ws", () => ({
 // Likewise stub the connection + registry helpers. We capture the publish
 // arguments so we can assert on them.
 const publishTx = vi.fn(async () => ({ ok: true, txHash: "0xdead" }));
+const publishDevTx = vi.fn(async () => ({ ok: true, txHash: "0xfeed" }));
 vi.mock("../connection.js", () => ({
     getConnection: vi.fn(async () => ({ raw: { assetHub: {} } })),
 }));
 vi.mock("../registry.js", () => ({
     getRegistryContract: vi.fn(async () => ({
         publish: { tx: publishTx },
+        publishDev: { tx: publishDevTx },
     })),
 }));
 vi.mock("../../telemetry.js", () => ({
@@ -103,6 +105,8 @@ const fakeSigner: ResolvedSigner = {
 beforeEach(() => {
     publishTx.mockClear();
     publishTx.mockImplementation(async () => ({ ok: true, txHash: "0xdead" }));
+    publishDevTx.mockClear();
+    publishDevTx.mockImplementation(async () => ({ ok: true, txHash: "0xfeed" }));
     captureWarningMock.mockClear();
     withSpanMock.mockClear();
     getBulletinAllowanceSignerMock.mockClear();
@@ -518,6 +522,7 @@ describe("publishToPlayground", () => {
                 false,
                 false,
             );
+            expect(publishDevTx).not.toHaveBeenCalled();
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -579,15 +584,17 @@ describe("publishToPlayground", () => {
         }
     });
 
-    it("passes claimedOwnerH160 through as the registry.publish owner argument", async () => {
+    it("passes claimedOwnerH160 through as the registry.publishDev owner argument", async () => {
         await publishToPlayground({
             domain: "claimed-app",
             publishSigner: fakeSigner,
             repositoryUrl: null,
             cwd: "/definitely/not/a/repo",
             claimedOwnerH160: "0x1234567890abcdef1234567890abcdef12345678",
+            isDevSigner: true,
         });
-        expect(publishTx).toHaveBeenCalledWith(
+        expect(publishTx).not.toHaveBeenCalled();
+        expect(publishDevTx).toHaveBeenCalledWith(
             "claimed-app.dot",
             "bafymeta",
             1,
@@ -596,7 +603,6 @@ describe("publishToPlayground", () => {
                 value: "0x1234567890abcdef1234567890abcdef12345678",
             },
             "",
-            false,
             false,
         );
     });
@@ -623,7 +629,7 @@ describe("publishToPlayground", () => {
         );
     });
 
-    it("forwards isModdable and isDevSigner to registry.publish", async () => {
+    it("routes dev signer publishes through registry.publishDev", async () => {
         await publishToPlayground({
             domain: "modded-by-dev",
             publishSigner: fakeSigner,
@@ -632,7 +638,8 @@ describe("publishToPlayground", () => {
             isModdable: true,
             isDevSigner: true,
         });
-        expect(publishTx).toHaveBeenCalledWith(
+        expect(publishTx).not.toHaveBeenCalled();
+        expect(publishDevTx).toHaveBeenCalledWith(
             "modded-by-dev.dot",
             "bafymeta",
             1,
@@ -641,7 +648,6 @@ describe("publishToPlayground", () => {
                 value: "0x0000000000000000000000000000000000000000",
             },
             "",
-            true,
             true,
         );
     });

--- a/src/utils/deploy/playground.ts
+++ b/src/utils/deploy/playground.ts
@@ -18,11 +18,11 @@
  *
  * We upload the metadata JSON through Bulletin `TransactionStorage.store`
  * with the product-scoped RFC-0010 Bulletin allowance account, then call
- * `registry.publish(domain, metadataCid, visibility, owner)` ourselves via
+ * `registry.publish(...)` / `registry.publishDev(...)` ourselves via
  * `getRegistryContract()`.
- * Publishing is always signed by the user's product account so the contract's
- * `env::caller()` matches their address — that's what drives the playground-app
- * "myApps" view.
+ * Phone publishing is signed by the user's product account so the contract's
+ * `env::caller()` matches their address. Dev publishing is signed by the dev
+ * account and may pass a claimed owner for the playground-app "myApps" view.
  *
  * We deliberately do NOT use `polkadot-app-deploy.deploy()` for the metadata
  * upload: `deploy()` unconditionally runs a DotNS `register()` +
@@ -61,10 +61,10 @@ export interface PublishToPlaygroundOptions {
     /** The DotNS label (with or without `.dot`). */
     domain: string;
     /**
-     * Signer that submits the `registry.publish(...)` tx. In phone mode
-     * this is the user's session signer (caller becomes owner). In dev
-     * mode this is a dev signer (Alice / `--suri`), and `claimedOwnerH160`
-     * carries the H160 to record as owner.
+     * Signer that submits the registry publish tx. In phone mode this is the
+     * user's session signer and calls `publish(...)` (caller becomes owner).
+     * In dev mode this is a dev signer (Alice / `--suri`) and calls
+     * `publishDev(...)`; `claimedOwnerH160` carries the H160 to record as owner.
      */
     publishSigner: ResolvedSigner;
     /**
@@ -130,9 +130,9 @@ export interface PublishToPlaygroundOptions {
     moddedFrom?: string;
     /**
      * True when the publish is signed by the dev signer (Alice / `--suri`)
-     * rather than the user's session. The contract surfaces this bit on each
-     * `AppInfo` so the playground-app can distinguish phone-published apps
-     * from dev-published throwaways.
+     * rather than the user's session. Dev publishes use the ungated
+     * `publishDev(...)` contract path, which records the app without awarding
+     * deploy XP or source-app mod XP.
      */
     isDevSigner?: boolean;
 }
@@ -415,15 +415,24 @@ export async function publishToPlayground(
                     const moddedFromArg = moddedFrom ?? "";
                     const isModdable = options.isModdable ?? false;
                     const isDevSigner = options.isDevSigner ?? false;
-                    const result = await registry.publish.tx(
-                        fullDomain,
-                        metadataCid,
-                        visibility,
-                        owner,
-                        moddedFromArg,
-                        isModdable,
-                        isDevSigner,
-                    );
+                    const result = isDevSigner
+                        ? await registry.publishDev.tx(
+                              fullDomain,
+                              metadataCid,
+                              visibility,
+                              owner,
+                              moddedFromArg,
+                              isModdable,
+                          )
+                        : await registry.publish.tx(
+                              fullDomain,
+                              metadataCid,
+                              visibility,
+                              owner,
+                              moddedFromArg,
+                              isModdable,
+                              false,
+                          );
                     if (result && result.ok === false) {
                         throw new Error("Registry publish transaction reverted");
                     }

--- a/src/utils/deploy/signerMode.ts
+++ b/src/utils/deploy/signerMode.ts
@@ -134,7 +134,7 @@ export interface DeploySignerSetup {
     bulletinDeployAuthOptions: Pick<DeployOptions, "signer" | "signerAddress" | "mnemonic">;
 
     /**
-     * Signer used to call `registry.publish()` for the playground step.
+     * Signer used to call the registry publish method for the playground step.
      *
      * - Phone mode: the user's session signer — caller becomes owner.
      * - Dev mode: the dev signer (Alice or `--suri`) — caller becomes
@@ -146,7 +146,7 @@ export interface DeploySignerSetup {
     publishSigner: ResolvedSigner | null;
 
     /**
-     * The H160 to pass as the `owner` argument of `registry.publish(...)`.
+     * The H160 to pass as the `owner` argument of the registry publish method.
      * Non-null only in dev mode WITH an active phone session — the dev
      * account signs the tx but the user's H160 is recorded as owner so the
      * app shows in their MyApps view. `null` ⇒ contract defaults to

--- a/src/utils/deploy/signingGate.ts
+++ b/src/utils/deploy/signingGate.ts
@@ -20,7 +20,7 @@
  *
  * Every on-chain extrinsic in a deploy — polkadot-app-deploy's DotNS
  * register/setContenthash and Bulletin chunk `store()` calls, plus our own
- * `registry.publish()` and metadata `store()` — derives its nonce by reading
+ * registry publish call and metadata `store()` — derives its nonce by reading
  * the account's *current* on-chain next-index at submission time
  * (`system_accountNextIndex` inside polkadot-app-deploy; polkadot-api's
  * `signSubmitAndWatch` for the publish path). None of these accept a

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -107,7 +107,7 @@ async function liveManager(
 
 /**
  * Get a typed handle to the playground registry contract for SIGNED writes
- * (e.g. `registry.publish.tx(...)`). Caller is responsible for providing a
+ * (e.g. registry publish transactions). Caller is responsible for providing a
  * funded + mapped user signer.
  */
 export async function getRegistryContract(rawClient: PolkadotClient, signer: ResolvedSigner) {


### PR DESCRIPTION
## Summary
- route dev-signed Playground publishes through publishDev
- keep mobile/session publishes on the regular publish path
- refresh cdm.json for the deployed registry ABI

## Testing
- pnpm test src/utils/deploy/playground.test.ts src/utils/deploy/run.test.ts src/utils/decentralize/run.test.ts
- pnpm typecheck
- pnpm format:check