### PR TITLE
fix: print shell reload hint after fresh install (#317)

### DIFF
--- a/.changeset/install-path-reload-hint.md
+++ b/.changeset/install-path-reload-hint.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+install.sh now prints a shell-specific reload hint (`source ~/.zshrc` / `~/.bashrc` / fish config, or open a new terminal) on a fresh install, so users aren't left with a `playground`/`pg` command that isn't found until they manually reload their shell.

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,16 @@ ALIAS="pg"
 # saved locally under $CMD, so the old `dot` command name is gone.
 ASSET_PREFIX="dot"
 
+# Record whether the command ALREADY resolves on the caller's PATH (re-install /
+# upgrade) before we touch anything. We install into BOTH $INSTALL_DIR/bin and
+# ~/.local/bin (the symlinks below); ~/.local/bin is already on PATH by default
+# on Debian/Ubuntu, so a "fresh" install there resolves immediately. Check both
+# dirs so the reload hint is suppressed whenever the command already works.
+case ":$PATH:" in
+  *":$INSTALL_DIR/bin:"*|*":$HOME/.local/bin:"*) ALREADY_ON_PATH=1 ;;
+  *) ALREADY_ON_PATH=0 ;;
+esac
+
 # 1) Detect platform. Git Bash / MSYS / Cygwin report MINGW*/MSYS*/CYGWIN* —
 # point Windows users at WSL instead of a bare "Unsupported OS".
 OS=$(uname -s); case "$OS" in Linux) OS=linux;; Darwin) OS=darwin;; MINGW*|MSYS*|CYGWIN*) echo "Windows is not supported natively. Install WSL (https://learn.microsoft.com/windows/wsl/install) and re-run this command inside it."; exit 1;; *) echo "Unsupported OS: $OS"; exit 1;; esac
@@ -138,3 +148,16 @@ echo -e "${Y}│${R}                                        ${Y}│${R}"
 echo -e "${Y}│${R}   ${B}$CMD login${R}                     ${Y}│${R}"
 echo -e "${Y}╰────────────────────────────────────────╯${R}"
 echo -e "${D}  Tip: ${ALIAS} is a short alias for ${CMD}.${R}"
+
+# This script runs in a child process, so it CANNOT add $CMD to the caller's
+# live PATH — sourcing an rc file here would only touch this dying process, not
+# the parent shell. On a fresh install the command therefore won't resolve until
+# the caller's shell reloads, so print the exact reload command for their shell.
+if [ "$ALREADY_ON_PATH" = "0" ]; then
+  case "$(basename "${SHELL:-bash}")" in
+    zsh)  RC="$HOME/.zshrc" ;;
+    fish) RC="$HOME/.config/fish/config.fish" ;;
+    *)    RC="$HOME/.bashrc" ;;
+  esac
+  echo -e "${D}  First run \033[1msource ${RC/#$HOME/\$HOME}${R}${D} (or open a new terminal) to use ${CMD}.${R}"
+fi


### PR DESCRIPTION
## Problem

Fixes #317. After a `curl … | bash` install, the `playground` / `pg` command isn't found until the user reloads their shell.

`install.sh` runs in a **child process**: it appends the PATH export to the rc files and exports PATH for its own process (so its own `login --yes` works via the full binary path), but it cannot mutate the **parent** interactive shell's environment. So when the user then types the suggested `playground login`, the command isn't on PATH yet.

The issue suggests `source ~/.bashrc` at the end of install — but that can't work for this case: sourcing inside the install script only affects the script's own (dying) process, not the parent shell. The honest fix is to tell the user exactly how to make the command available now.

## Change

1. **Detect re-installs up front** — capture whether `$INSTALL_DIR/bin` is already on the caller's PATH *before* we modify anything. On an upgrade the command already resolves, so the hint is suppressed (no noise).
2. **Print an exact reload hint on fresh installs** — resolve the rc file from `$SHELL` (`~/.zshrc` / `~/.bashrc` / fish config) and tell the user to `source` it or open a new terminal. The path prints as a portable `$HOME` literal so it's copy-pasteable.

A code comment documents *why* we don't try to `source` anything, so it isn't "helpfully" re-added later as a no-op.

## Verification

- `bash -n install.sh` passes.
- Hint renders correctly for zsh and fish (verified manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)