### PR TITLE
fix(mod): always show the Next steps footer after a successful mod

### DIFF
--- a/.changeset/mod-footer-always-shows.md
+++ b/.changeset/mod-footer-always-shows.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+`playground mod` now always prints the "Next steps" footer for a successful mod. It was previously hidden whenever the app shipped a `setup.sh`, which left apps whose setup script does not print its own next-steps guidance (e.g. the tutorial app) with no footer at all.

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -148,7 +148,7 @@ async function runModCommand(rawDomain: string | undefined): Promise<void> {
         );
         if (!targetDir) return;
 
-        const { ok, setupRan } = await withSpan("cli.mod.setup", "download and setup mod", () =>
+        const { ok } = await withSpan("cli.mod.setup", "download and setup mod", () =>
             runSetup({
                 domain,
                 metadata: metadata
@@ -172,7 +172,13 @@ async function runModCommand(rawDomain: string | undefined): Promise<void> {
         );
 
         console.log();
-        if (ok && !setupRan) {
+        // The generic "Next steps" footer prints for every successful mod.
+        // We used to suppress it when `setup.sh` ran (on the assumption the
+        // script printed its own footer), but not every app's setup.sh does —
+        // e.g. playground-tutorial-v-two's ends after fetching skills — which
+        // left those mods with no footer at all. `setupRan` now only drives the
+        // "full setup log" Hint, not this block.
+        if (ok) {
             console.log("  Next steps:");
             console.log(`  1. cd ${targetDir}`);
             console.log(editWithClaudeStep(shouldShowTutorialPrompt({ domain, startedTutorial })));


### PR DESCRIPTION
## What

`playground mod` now always prints the **Next steps** footer for a successful mod.

## Why

The footer was gated `if (ok && !setupRan)` — suppressed whenever an app shipped a `setup.sh`. That gate (added in `f6e5adf`) assumed every `setup.sh` prints its own next-steps guidance. Not every one does: `playground-tutorial-v-two`'s `setup.sh` ends after fetching skills and prints no footer, so modding it left the user with **no footer at all**. The older `playground-tutorial` had no `setup.sh`, which is why the footer used to appear and "suddenly" stopped.

## Change

- Footer now prints on every successful mod (`if (ok)`).
- `setupRan` no longer gates the footer; it still drives the "full setup log" hint inside `SetupScreen`.
- Removed the now-unused `setupRan` destructure.
- Added a changeset.

Tradeoff: apps whose `setup.sh` does print its own next-steps (e.g. Rock-Paper-Scissors) will now show both that tail and the generic 3-line footer. Acceptable given the footer should appear for all mods.

## Verification

- `mod` tests: 24/24 pass
- `biome format` on the changed file: clean
- `lint:license`: passes
- `typecheck`: no new errors from this change

Note: there is a pre-existing `tsc` error on `main` (`src/utils/deploy/playground.ts:419`, `publishDev`, from PR #392) that is unrelated to this change.