### PR TITLE
login: print pairing deeplink alongside the QR

### DIFF
--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -45,6 +45,18 @@ export const loginCommand = new Command("login")
                         login = result.login;
                         console.log("  Scan with the Polkadot mobile app to log in:\n");
                         console.log(result.qrCode);
+                        // On the same device as the app (e.g. a browser terminal on a
+                        // phone) you can't scan a QR on your own screen, so also print
+                        // a link. Browser terminals (ttyd/xterm.js) only make http(s)
+                        // tappable — not custom schemes — so when PG_LOGIN_LINK_BASE is
+                        // set, print an https link that redirects to the deeplink;
+                        // otherwise print the raw polkadotapp:// deeplink.
+                        const linkBase = process.env.PG_LOGIN_LINK_BASE?.replace(/\/+$/, "");
+                        const openUrl = linkBase
+                            ? `${linkBase}/?d=${encodeURIComponent(result.link)}`
+                            : result.link;
+                        console.log("\n  or open this link to log in on this device:\n");
+                        console.log(`  ${openUrl}\n`);
                     }
                 } catch (err) {
                     const msg = errorMessage(err);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -197,7 +197,7 @@ function sessionLogoutAddress(session: UserSession): string {
 
 export type ConnectResult =
     | { kind: "existing"; address: string; addresses: SessionAddresses }
-    | { kind: "qr"; qrCode: string; login: LoginHandle };
+    | { kind: "qr"; qrCode: string; link: string; login: LoginHandle };
 
 export type LoginStatus =
     | { step: "waiting" }
@@ -275,15 +275,18 @@ export async function connect(): Promise<ConnectResult> {
 
     // Wait for the QR payload (with timeout)
     try {
-        const qrCode = await Promise.race([
-            new Promise<string>((resolve) => {
+        const { qrCode, link } = await Promise.race([
+            new Promise<{ qrCode: string; link: string }>((resolve) => {
                 let done = false;
                 let unsub: (() => void) | undefined;
                 unsub = adapter.sso.pairingStatus.subscribe(async (status: PairingStatus) => {
                     if (status.step === "pairing" && !done) {
                         done = true;
                         unsub?.();
-                        resolve(await renderQrCode(status.payload));
+                        // `status.payload` is the pairing deeplink
+                        // (polkadotapp://pair?handshake=…); expose it raw so the
+                        // command layer can offer a scan-free, single-device login.
+                        resolve({ qrCode: await renderQrCode(status.payload), link: status.payload });
                     }
                 });
             }),
@@ -302,7 +305,7 @@ export async function connect(): Promise<ConnectResult> {
             ),
         ]);
 
-        return { kind: "qr", qrCode, login: { adapter, authPromise } };
+        return { kind: "qr", qrCode, link, login: { adapter, authPromise } };
     } catch (err) {
         // Release the WebSocket so we don't leak on the error path. SDK's
         // destroy() returns Promise<void>; `.catch()` swallows the


### PR DESCRIPTION
The login QR encodes a polkadotapp://pair?handshake=… deeplink. Surface it as text (OSC 8 hyperlink) so a user can paste/tap it on the same phone: e.g. when the terminal runs in a mobile browser and the QR can't be scanned from the same screen. Purely additive; same data the QR already shows.