### PR TITLE
feat: add `playground status` and fix native token decimals (10, not 12)

### DIFF
--- a/.changeset/status-command.md
+++ b/.changeset/status-command.md
@@ -1,0 +1,7 @@
+---
+"playground-cli": minor
+---
+
+Add `playground status`: show your signed-in product account (SS58 + H160), native and PGAS balances, Bulletin authorization validity (with a time estimate), and how recently you paired your phone — all read-only, with no phone interaction.
+
+Fix the native token decimal scale: PAS/SUM are 10 decimals (verified live against the chain), not 12. This corrects every balance display (amounts were under-shown 100x) and makes `playground drip` transfer the documented 1 PAS per run (10 PAS cap) instead of 100 PAS (1000 PAS cap). PGAS is shown at the same 10-decimal scale.

--- a/src/commands/status/StatusScreen.tsx
+++ b/src/commands/status/StatusScreen.tsx
@@ -1,0 +1,211 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import { Header, Section, Row, Callout } from "../../utils/ui/theme/index.js";
+import { VERSION_LABEL } from "../../utils/version.js";
+import { getNetworkLabel } from "../../config.js";
+import { getSessionSigner } from "../../utils/auth.js";
+import { getConnection, destroyConnection } from "../../utils/connection.js";
+import { formatPas, PAS_DECIMALS } from "../../utils/account/drip.js";
+import { formatTokenAmount } from "../../utils/account/pgas.js";
+import { humanizeDuration } from "../../utils/account/attestation.js";
+import { staleSessionWarning } from "../../utils/loginStamp.js";
+import { buildStatusReport, type StatusReport, type FieldResult } from "./gather.js";
+
+/** Only `error` is a hard failure (exit 1); `needLogin` is a soft outcome. */
+export type StatusOutcome = "ok" | "needLogin" | "error";
+
+type Phase =
+    | { kind: "loading" }
+    | { kind: "ready"; report: StatusReport }
+    | { kind: "needLogin" }
+    | { kind: "error"; message: string };
+
+export function StatusScreen({ onDone }: { onDone: (outcome: StatusOutcome) => void }) {
+    const [phase, setPhase] = useState<Phase>({ kind: "loading" });
+
+    useEffect(() => {
+        let cancelled = false;
+        const describe = (err: unknown): string =>
+            err instanceof Error ? err.message : String(err);
+
+        (async () => {
+            let handle: Awaited<ReturnType<typeof getSessionSigner>>;
+            try {
+                handle = await getSessionSigner();
+            } catch (err) {
+                if (cancelled) return;
+                setPhase({ kind: "error", message: describe(err) });
+                onDone("error");
+                return;
+            }
+            if (cancelled) {
+                handle?.destroy();
+                return;
+            }
+            if (!handle) {
+                setPhase({ kind: "needLogin" });
+                onDone("needLogin");
+                return;
+            }
+
+            // The connection is best-effort: a failure still lets us show the
+            // locally-derived addresses + login stamp (graceful degradation).
+            let client: Awaited<ReturnType<typeof getConnection>> | null = null;
+            try {
+                client = await getConnection();
+            } catch {
+                client = null;
+            }
+            if (cancelled) {
+                handle.destroy();
+                return;
+            }
+
+            try {
+                const report = await buildStatusReport(handle, client);
+                if (cancelled) return;
+                setPhase({ kind: "ready", report });
+                onDone("ok");
+            } catch (err) {
+                if (cancelled) return;
+                setPhase({ kind: "error", message: describe(err) });
+                onDone("error");
+            } finally {
+                // We only read the session addresses + cached slot key; the
+                // adapter's WebSocket is no longer needed. Release it so the
+                // event loop can drain.
+                handle.destroy();
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+            destroyConnection();
+        };
+    }, [onDone]);
+
+    return (
+        <Box flexDirection="column">
+            <Header
+                cmd="playground status"
+                subtitle="polkadot playground"
+                network={getNetworkLabel()}
+                right={VERSION_LABEL}
+            />
+            <Body phase={phase} />
+        </Box>
+    );
+}
+
+function fieldText<T>(result: FieldResult<T>, render: (value: T) => string): string {
+    return result.ok ? render(result.value) : "unavailable";
+}
+
+function Body({ phase }: { phase: Phase }) {
+    switch (phase.kind) {
+        case "loading":
+            return (
+                <Section gapBelow={false}>
+                    <Row mark="run" label="status" value="gathering…" tone="muted" />
+                </Section>
+            );
+
+        case "needLogin":
+            return (
+                <Callout tone="warning" title="Log in first">
+                    <Text>
+                        {"`playground status`"} reports on the account paired with your phone, so
+                        you need to be signed in.
+                    </Text>
+                    <Text> </Text>
+                    <Text>
+                        Run <Text bold>playground login</Text> and scan the QR code with your
+                        Polkadot mobile app, then try again.
+                    </Text>
+                </Callout>
+            );
+
+        case "error":
+            return (
+                <Callout tone="danger" title="Couldn't read your status">
+                    <Text>{phase.message}</Text>
+                    <Text> </Text>
+                    <Text>Check your internet connection and try again.</Text>
+                </Callout>
+            );
+
+        case "ready":
+            return <ReadyBody report={phase.report} />;
+    }
+}
+
+function ReadyBody({ report }: { report: StatusReport }) {
+    const { addresses, nativeBalance, pgas, bulletin, loginStampMs } = report;
+
+    const bulletinTone = bulletin.ok && bulletin.value ? bulletin.value.tone : "muted";
+    const bulletinValue = bulletin.ok
+        ? bulletin.value
+            ? bulletin.value.text
+            : "not granted"
+        : "unavailable";
+
+    const now = Date.now();
+    const sessionAge = loginStampMs === null ? null : humanizeDuration(now - loginStampMs);
+    const staleWarning = loginStampMs === null ? null : staleSessionWarning(loginStampMs, now);
+
+    return (
+        <Box flexDirection="column">
+            <Section>
+                <Row mark="ok" label="product" value={addresses.productAddress} />
+                <Row label="H160" value={addresses.productH160} />
+            </Section>
+            <Section>
+                <Row
+                    label="balance"
+                    value={fieldText(nativeBalance, (b) => formatPas(b))}
+                    tone={nativeBalance.ok ? "default" : "muted"}
+                />
+                <Row
+                    label="PGAS"
+                    value={fieldText(pgas, (b) => formatTokenAmount(b, PAS_DECIMALS, "PGAS"))}
+                    tone={pgas.ok ? "default" : "muted"}
+                />
+                <Row
+                    label="bulletin"
+                    value={bulletinValue}
+                    tone={bulletinTone}
+                    hint={
+                        bulletin.ok && bulletin.value === null
+                            ? "run `playground login` to grant Bulletin storage"
+                            : undefined
+                    }
+                />
+            </Section>
+            {sessionAge && (
+                <Section gapBelow={!staleWarning}>
+                    <Row label="session" value={`paired ${sessionAge} ago`} tone="muted" />
+                </Section>
+            )}
+            {staleWarning && (
+                <Callout tone="warning" title="Session may be stale">
+                    <Text>{staleWarning}</Text>
+                </Callout>
+            )}
+        </Box>
+    );
+}

--- a/src/commands/status/gather.test.ts
+++ b/src/commands/status/gather.test.ts
@@ -1,0 +1,93 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { buildStatusReport, type StatusReaders } from "./gather.js";
+
+const ADDRESSES = {
+    rootAddress: "5Root",
+    productAddress: "5Product",
+    productH160: "0xabc" as `0x${string}`,
+};
+
+// Minimal fakes — buildStatusReport never inspects these beyond passing them to
+// the readers, so opaque sentinels are enough.
+const handle = { addresses: ADDRESSES, adapter: {} } as never;
+const client = {} as never;
+
+function readers(overrides: Partial<StatusReaders> = {}): StatusReaders {
+    return {
+        readNativeBalance: async () => 7n,
+        readPgas: async () => 50n,
+        readBulletinAuth: async () => ({ text: "~2d 3h  ·  #1,234,567", tone: "default" }),
+        readLoginStampMs: async () => 1_700_000_000_000,
+        ...overrides,
+    };
+}
+
+describe("buildStatusReport", () => {
+    it("collects every field when all reads succeed", async () => {
+        const report = await buildStatusReport(handle, client, readers());
+        expect(report.addresses).toBe(ADDRESSES);
+        expect(report.nativeBalance).toEqual({ ok: true, value: 7n });
+        expect(report.pgas).toEqual({ ok: true, value: 50n });
+        expect(report.bulletin).toEqual({
+            ok: true,
+            value: { text: "~2d 3h  ·  #1,234,567", tone: "default" },
+        });
+        expect(report.loginStampMs).toBe(1_700_000_000_000);
+    });
+
+    it("marks a field unavailable when its read throws", async () => {
+        const report = await buildStatusReport(
+            handle,
+            client,
+            readers({
+                readPgas: async () => {
+                    throw new Error("ws down");
+                },
+            }),
+        );
+        expect(report.pgas).toEqual({ ok: false });
+        expect(report.nativeBalance).toEqual({ ok: true, value: 7n });
+    });
+
+    it("represents not-granted Bulletin as ok:true with null value", async () => {
+        const report = await buildStatusReport(
+            handle,
+            client,
+            readers({ readBulletinAuth: async () => null }),
+        );
+        expect(report.bulletin).toEqual({ ok: true, value: null });
+    });
+
+    it("marks every chain field unavailable when the client is null", async () => {
+        const report = await buildStatusReport(handle, null, readers());
+        expect(report.nativeBalance).toEqual({ ok: false });
+        expect(report.pgas).toEqual({ ok: false });
+        expect(report.bulletin).toEqual({ ok: false });
+        expect(report.loginStampMs).toBe(1_700_000_000_000);
+    });
+
+    it("tolerates a null login stamp", async () => {
+        const report = await buildStatusReport(
+            handle,
+            client,
+            readers({ readLoginStampMs: async () => null }),
+        );
+        expect(report.loginStampMs).toBeNull();
+    });
+
+    it("never rejects when the login stamp read throws", async () => {
+        const report = await buildStatusReport(
+            handle,
+            client,
+            readers({
+                readLoginStampMs: async () => {
+                    throw new Error("fs error");
+                },
+            }),
+        );
+        expect(report.loginStampMs).toBeNull();
+    });
+});

--- a/src/commands/status/gather.ts
+++ b/src/commands/status/gather.ts
@@ -1,0 +1,112 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { SessionHandle, SessionAddresses } from "../../utils/auth.js";
+import type { PaseoClient } from "../../utils/connection.js";
+import {
+    checkAttestation,
+    getBulletinBlockTimeMs,
+    formatAttestation,
+    type FormattedAttestation,
+} from "../../utils/account/attestation.js";
+import { readPgasBalance } from "../../utils/account/pgas.js";
+import { getCachedBulletinSlotAddress } from "../../utils/allowances/bulletin.js";
+import { readLoginStampMs } from "../../utils/loginStamp.js";
+
+const AT_BEST = { at: "best" } as const;
+
+/** A chain-dependent field: `ok:false` means the read failed (rendered "unavailable"). */
+export type FieldResult<T> = { ok: true; value: T } | { ok: false };
+
+/**
+ * Injectable I/O seam so `buildStatusReport` is unit-testable without mocking
+ * polkadot-api primitives. Production code uses `defaultReaders`.
+ */
+export interface StatusReaders {
+    readNativeBalance(client: PaseoClient, address: string): Promise<bigint>;
+    /** PGAS balance in planck (formatted at the PAS decimal scale by the screen). */
+    readPgas(client: PaseoClient, address: string): Promise<bigint>;
+    /** Returns null when the Bulletin allowance was never granted on this machine. */
+    readBulletinAuth(
+        client: PaseoClient,
+        adapter: SessionHandle["adapter"],
+    ): Promise<FormattedAttestation | null>;
+    readLoginStampMs(): Promise<number | null>;
+}
+
+export interface StatusReport {
+    addresses: SessionAddresses;
+    nativeBalance: FieldResult<bigint>;
+    pgas: FieldResult<bigint>;
+    /** `value: null` inside an ok result = allowance not granted yet. */
+    bulletin: FieldResult<FormattedAttestation | null>;
+    loginStampMs: number | null;
+}
+
+async function field<T>(read: () => Promise<T>): Promise<FieldResult<T>> {
+    try {
+        return { ok: true, value: await read() };
+    } catch {
+        return { ok: false };
+    }
+}
+
+export const defaultReaders: StatusReaders = {
+    async readNativeBalance(client, address) {
+        const account = await client.assetHub.query.System.Account.getValue(address, AT_BEST);
+        return account.data.free;
+    },
+    readPgas: readPgasBalance,
+    async readBulletinAuth(client, adapter) {
+        const slotAddress = await getCachedBulletinSlotAddress(adapter);
+        if (!slotAddress) return null;
+        const [status, blockTimeMs] = await Promise.all([
+            checkAttestation(client, slotAddress),
+            getBulletinBlockTimeMs(client),
+        ]);
+        return formatAttestation(status, blockTimeMs);
+    },
+    readLoginStampMs,
+};
+
+/**
+ * Assemble the status report from a resolved session handle and a (possibly
+ * null) chain client. Chain reads degrade independently — a single RPC failure
+ * marks only its own field unavailable. When `client` is null (connection
+ * failed), every chain field is unavailable but the locally-derived addresses
+ * and login stamp still render.
+ */
+export async function buildStatusReport(
+    handle: SessionHandle,
+    client: PaseoClient | null,
+    readers: StatusReaders = defaultReaders,
+): Promise<StatusReport> {
+    const { addresses } = handle;
+
+    const [nativeBalance, pgas, bulletin, loginStampMs] = await Promise.all([
+        client
+            ? field(() => readers.readNativeBalance(client, addresses.productAddress))
+            : Promise.resolve<FieldResult<bigint>>({ ok: false }),
+        client
+            ? field(() => readers.readPgas(client, addresses.productAddress))
+            : Promise.resolve<FieldResult<bigint>>({ ok: false }),
+        client
+            ? field(() => readers.readBulletinAuth(client, handle.adapter))
+            : Promise.resolve<FieldResult<FormattedAttestation | null>>({ ok: false }),
+        readers.readLoginStampMs().catch(() => null),
+    ]);
+
+    return { addresses, nativeBalance, pgas, bulletin, loginStampMs };
+}

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -1,0 +1,49 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import { Command } from "commander";
+import { render } from "ink";
+import { withSpan } from "../../telemetry.js";
+import { runCliCommand } from "../../cli-runtime.js";
+import { StatusScreen, type StatusOutcome } from "./StatusScreen.js";
+
+export const statusCommand = new Command("status")
+    .description("Show your signed-in product account, balances, and allowance status")
+    .action(async () =>
+        runCliCommand("status", {}, async () => {
+            console.log();
+
+            const outcome = await withSpan("cli.status.tui", "show status", async () => {
+                let result: StatusOutcome = "error";
+                const app = render(
+                    React.createElement(StatusScreen, {
+                        onDone: (o: StatusOutcome) => {
+                            result = o;
+                            app.unmount();
+                        },
+                    }),
+                );
+                await app.waitUntilExit();
+                return result;
+            });
+
+            console.log();
+
+            // "needLogin" is an expected, actionable soft outcome (the user just
+            // read a friendly box); only a genuine failure exits non-zero.
+            if (outcome === "error") process.exitCode = 1;
+        }),
+    );

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -37,9 +37,19 @@
 import { describe, expect, it } from "vitest";
 import { loadEnvironments } from "@parity/polkadot-app-deploy";
 import { getRegistryAddress } from "@parity/cdm-env";
-import { CONFIGS, DEFAULT_ENV, type ChainConfig, type Env } from "./config.js";
+import { CONFIGS, DEFAULT_ENV, getPgasAssetId, type ChainConfig, type Env } from "./config.js";
 
 const { doc } = await loadEnvironments();
+
+describe("getPgasAssetId", () => {
+    it("returns the paseo-next-v2 PGAS asset id by default", () => {
+        expect(getPgasAssetId("paseo-next-v2")).toBe(2_000_000_000);
+    });
+
+    it("returns a number for every wired env", () => {
+        expect(typeof getPgasAssetId("summit")).toBe("number");
+    });
+});
 
 /** First (primary) wss endpoint declared for a chain on an env, or undefined. */
 function upstreamEndpoint(chainId: string, envId: string): string | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,9 @@ export interface ChainConfig {
      * Native token symbol for display only (balances, drip amounts) — never used
      * for on-chain math. Read it via `getTokenSymbol()` / threaded through
      * `formatPas` so flipping `ACTIVE_TESTNET_ENV` re-labels the whole CLI in one
-     * place. All wired envs use 12-decimal planck regardless of symbol.
+     * place. All wired envs use 10-decimal planck regardless of symbol (PAS and
+     * SUM are both 10 decimals — verified live against the chain, see
+     * `PAS_DECIMALS` in `account/drip.ts`).
      */
     tokenSymbol: string;
     /** Relay chain RPC (mostly informational; product-sdk talks to system chains directly). */
@@ -104,6 +106,15 @@ export interface ChainConfig {
      * stored here — see `src/utils/registry.ts` and CLAUDE.md.
      */
     cdmEnvName: string;
+    /**
+     * Asset id of PGAS (the smart-contract gas token, a `sufficient` asset) on
+     * this env's Asset Hub. Display-only — read via `getPgasAssetId()` to show a
+     * balance in `playground status`. Like `tokenSymbol`, it is NOT present in
+     * polkadot-app-deploy's `environments.json`, so the `config.test.ts`
+     * divergence guard does not cross-check it; set it from the chain's own asset
+     * registry.
+     */
+    pgasAssetId: number;
 }
 
 // Paseo Next v2 — the active env. DotNS contracts are owned by
@@ -121,6 +132,7 @@ const PASEO_NEXT_V2: ChainConfig = {
     autoAccountMapping: true,
     faucetUrl: "https://faucet.polkadot.io/?network=pah",
     cdmEnvName: "paseo-next-v2",
+    pgasAssetId: 2_000_000_000,
 };
 
 // Web3 Summit network. Every endpoint/network value mirrors polkadot-app-deploy's
@@ -141,6 +153,7 @@ const SUMMIT: ChainConfig = {
     autoAccountMapping: true,
     faucetUrl: null,
     cdmEnvName: "w3s",
+    pgasAssetId: 2_000_000_000,
 };
 
 /**
@@ -221,6 +234,15 @@ export function getNetworkLabel(env: Env = DEFAULT_ENV): string {
  */
 export function getTokenSymbol(env: Env = DEFAULT_ENV): string {
     return getChainConfig(env).tokenSymbol;
+}
+
+/**
+ * Asset id of PGAS on the given env's Asset Hub (defaults to the active env).
+ * Display only — used by `playground status` to read the product account's PGAS
+ * balance. See `ChainConfig.pgasAssetId`.
+ */
+export function getPgasAssetId(env: Env = DEFAULT_ENV): number {
+    return getChainConfig(env).pgasAssetId;
 }
 
 /** Identifier the terminal adapter reports during SSO. Kept stable so mobile pairings persist across releases. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { Command } from "commander";
 import pkg from "../package.json" with { type: "json" };
 import { loginCommand } from "./commands/login/index.js";
 import { dripCommand } from "./commands/drip/index.js";
+import { statusCommand } from "./commands/status/index.js";
 import { modCommand } from "./commands/mod/index.js";
 import { buildCommand } from "./commands/build.js";
 import { contractCommand } from "./commands/contract.js";
@@ -132,6 +133,7 @@ const program = new Command()
 
 program.addCommand(loginCommand);
 program.addCommand(dripCommand);
+program.addCommand(statusCommand);
 program.addCommand(modCommand);
 program.addCommand(buildCommand);
 program.addCommand(contractCommand);

--- a/src/telemetry-config.ts
+++ b/src/telemetry-config.ts
@@ -49,6 +49,7 @@ export interface InternalContextSignals {
 export type CliCommandName =
     | "login"
     | "drip"
+    | "status"
     | "deploy"
     | "deploy-all"
     | "contract"

--- a/src/utils/account/drip.test.ts
+++ b/src/utils/account/drip.test.ts
@@ -40,7 +40,10 @@ const RECIPIENT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 // SS58 of the bare-master account derived from the standard dev mnemonic with
 // empty derivation; see the pubkey assertion at the bottom of the file.
 const DEV_FUNDER = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
-const ONE_PAS = 1_000_000_000_000n;
+// Mirrors the production scale (PAS_DECIMALS = 10). Must match the module's
+// ONE_PAS so `transferred: ONE_PAS` / funder-balance assertions line up with the
+// imported DRIP_AMOUNT / SOURCE_BUFFER.
+const ONE_PAS = 10_000_000_000n;
 const SOURCE_BUFFER = ONE_PAS;
 const FUNDER_REQUIRED = DRIP_AMOUNT + SOURCE_BUFFER;
 // Plenty of headroom so the preflight balance check passes in tests that
@@ -185,7 +188,7 @@ describe("formatPas", () => {
 
     it("trims trailing zeros and caps at 4 fractional digits", () => {
         expect(formatPas(ONE_PAS + ONE_PAS / 2n)).toBe("1.5 PAS");
-        // 0.123456 PAS -> truncated to 4 dp
-        expect(formatPas(123_456_000_000n)).toBe("0.1234 PAS");
+        // 0.123456 PAS (1_234_560_000 planck at 10 decimals) -> truncated to 4 dp
+        expect(formatPas(1_234_560_000n)).toBe("0.1234 PAS");
     });
 });

--- a/src/utils/account/drip.ts
+++ b/src/utils/account/drip.ts
@@ -69,8 +69,18 @@ function getDevAccount(): ReturnType<typeof seedToAccount> {
     return cachedDevAccount;
 }
 
-/** 1 PAS in planck. Asset Hub Paseo uses 12 decimals. */
-const ONE_PAS = 1_000_000_000_000n;
+/**
+ * Decimal places for the native token (PAS) on Asset Hub Paseo. Verified live
+ * against the chain (2026-06-16): `system_properties.tokenDecimals` is 10 on
+ * both the asset hub and people chains, and `Balances.ExistentialDeposit`
+ * (100_000_000 planck) is the canonical 0.01 PAS only at 10 decimals. PGAS is
+ * 1:1 with PAS, so `playground status` formats PGAS balances at this same scale
+ * (see `account/pgas.ts`).
+ */
+export const PAS_DECIMALS = 10;
+
+/** 1 PAS in planck. */
+const ONE_PAS = 10n ** BigInt(PAS_DECIMALS);
 
 /** Amount sent per `playground drip` invocation. */
 export const DRIP_AMOUNT = ONE_PAS;
@@ -170,9 +180,9 @@ export async function dripToProductAccount(
 }
 
 /**
- * Format a planck amount (12-decimal) as a short human string, e.g. `"3.5 PAS"`
- * (or `"3.5 SUM"` on Summit). The token symbol comes from the active env's
- * `tokenSymbol` (see `getTokenSymbol`), so flipping `ACTIVE_TESTNET_ENV`
+ * Format a planck amount (`PAS_DECIMALS`-decimal) as a short human string, e.g.
+ * `"3.5 PAS"` (or `"3.5 SUM"` on Summit). The token symbol comes from the active
+ * env's `tokenSymbol` (see `getTokenSymbol`), so flipping `ACTIVE_TESTNET_ENV`
  * re-labels every amount. Trims trailing zeros and caps at 4 fractional digits —
  * display-only, never used for on-chain math.
  */
@@ -182,6 +192,6 @@ export function formatPas(planck: bigint): string {
     const whole = planck / base;
     const frac = planck % base;
     if (frac === 0n) return `${whole} ${symbol}`;
-    const fracStr = frac.toString().padStart(12, "0").slice(0, 4).replace(/0+$/, "");
+    const fracStr = frac.toString().padStart(PAS_DECIMALS, "0").slice(0, 4).replace(/0+$/, "");
     return fracStr ? `${whole}.${fracStr} ${symbol}` : `${whole} ${symbol}`;
 }

--- a/src/utils/account/pgas.test.ts
+++ b/src/utils/account/pgas.test.ts
@@ -1,0 +1,55 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { formatTokenAmount } from "./pgas.js";
+
+describe("formatTokenAmount", () => {
+    it("formats whole units with the symbol", () => {
+        expect(formatTokenAmount(50_000_000_000n, 9, "PGAS")).toBe("50 PGAS");
+    });
+
+    it("trims trailing fractional zeros", () => {
+        expect(formatTokenAmount(1_500_000_000n, 9, "PGAS")).toBe("1.5 PGAS");
+    });
+
+    it("renders zero cleanly", () => {
+        expect(formatTokenAmount(0n, 9, "PGAS")).toBe("0 PGAS");
+    });
+
+    it("handles 0 decimals (integer asset)", () => {
+        expect(formatTokenAmount(42n, 0, "PGAS")).toBe("42 PGAS");
+    });
+
+    it("keeps significant fractional digits", () => {
+        expect(formatTokenAmount(1_234_500_000n, 9, "PGAS")).toBe("1.2345 PGAS");
+    });
+
+    it("omits the suffix when symbol is empty", () => {
+        expect(formatTokenAmount(5_000_000_000n, 9, "")).toBe("5");
+    });
+
+    it("groups large integer (0-decimal) amounts with thousands separators", () => {
+        expect(formatTokenAmount(354_793_859_857n, 0, "")).toBe("354,793,859,857");
+    });
+
+    it("groups the integer part of fractional amounts", () => {
+        expect(formatTokenAmount(1_234_567_500_000_000n, 9, "PGAS")).toBe("1,234,567.5 PGAS");
+    });
+
+    // PGAS is 1:1 with PAS (PAS_DECIMALS = 10) — the scale `playground status`
+    // actually uses. 354_793_859_857 planck is the real on-chain balance observed
+    // on paseo-next-v2, which renders ~35.4793 PGAS at 10 decimals (capped 4 dp).
+    it("formats the real PGAS balance at the 10-decimal PAS scale, capped at 4 dp", () => {
+        expect(formatTokenAmount(354_793_859_857n, 10, "PGAS")).toBe("35.4793 PGAS");
+    });
+
+    it("caps the fraction at 4 digits (truncates, not rounds)", () => {
+        expect(formatTokenAmount(199_999_000_000n, 10, "PGAS")).toBe("19.9999 PGAS");
+    });
+
+    it("drops the fraction entirely when it rounds below the 4-digit window", () => {
+        // 1.00000001 at 10 decimals -> first 4 fractional digits are all zero
+        expect(formatTokenAmount(10_000_000_100n, 10, "PGAS")).toBe("1 PGAS");
+    });
+});

--- a/src/utils/account/pgas.ts
+++ b/src/utils/account/pgas.ts
@@ -1,0 +1,75 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getPgasAssetId } from "../../config.js";
+import type { PaseoClient } from "../connection.js";
+
+const AT_BEST = { at: "best" } as const;
+
+/**
+ * Read an account's PGAS balance in planck. PGAS is a `sufficient` asset in the
+ * `Assets` pallet (NOT the native token), keyed by `[assetId, who]`; the storage
+ * entry is Option-typed, so an absent entry means a zero balance. Uses
+ * `{ at: "best" }` (not finalized) because product-account reads must reflect
+ * the best head — finalization lags ~13-14 blocks on paseo-next-v2 (same
+ * rationale as `account/mapping.ts`).
+ *
+ * The asset carries no on-chain metadata on paseo-next-v2, so decimals/symbol
+ * are NOT read here — PGAS is 1:1 with PAS and the caller formats it at the
+ * shared `PAS_DECIMALS` scale (see `account/drip.ts`).
+ */
+export async function readPgasBalance(client: PaseoClient, address: string): Promise<bigint> {
+    const assetId = getPgasAssetId();
+    const account = await client.assetHub.query.Assets.Account.getValue(assetId, address, AT_BEST);
+    return account?.balance ?? 0n;
+}
+
+/**
+ * Max fractional digits shown. Matches `formatPas` (`account/drip.ts`) so the
+ * native PAS row and the 1:1 PGAS row render at the same precision instead of
+ * one showing 4 digits and the other all 12.
+ */
+const MAX_FRACTION_DIGITS = 4;
+
+/**
+ * Render a planck-style integer amount with `decimals` fractional places and a
+ * symbol suffix, grouping the integer part with thousands separators and
+ * capping the fraction at `MAX_FRACTION_DIGITS` (trailing zeros trimmed) — e.g.
+ * `1.5 PGAS`, `50 PGAS`, `354,793,859,857`. An empty symbol omits the suffix
+ * (the caller's row label carries the unit). With `decimals <= 0` the value
+ * renders as a grouped integer in the asset's base units. Mirrors `formatPas`'s
+ * formatting so PAS and the 1:1 PGAS balance read consistently.
+ */
+export function formatTokenAmount(value: bigint, decimals: number, symbol: string): string {
+    const label = symbol.length > 0 ? ` ${symbol}` : "";
+    if (decimals <= 0) return `${group(value)}${label}`;
+
+    const base = 10n ** BigInt(decimals);
+    const whole = value / base;
+    const frac = value % base;
+    if (frac === 0n) return `${group(whole)}${label}`;
+
+    const fracStr = frac
+        .toString()
+        .padStart(decimals, "0")
+        .slice(0, MAX_FRACTION_DIGITS)
+        .replace(/0+$/, "");
+    return fracStr ? `${group(whole)}.${fracStr}${label}` : `${group(whole)}${label}`;
+}
+
+/** Thousands-separated decimal string for a non-negative bigint. */
+function group(value: bigint): string {
+    return value.toLocaleString("en-US");
+}

--- a/src/utils/allowances/bulletin.ts
+++ b/src/utils/allowances/bulletin.ts
@@ -169,6 +169,22 @@ export async function cachedBulletinSlotAuthorization(
     return getBulletinSlotAuthorization(bulletinApi, slotSigner);
 }
 
+/**
+ * SS58 of the CACHED Bulletin slot account, or null when no slot key is cached
+ * locally yet (user never granted, or the cache was cleared). Pure local read —
+ * no chain query, no phone interaction. `playground status` reads the on-chain
+ * authorization against this address.
+ */
+export async function getCachedBulletinSlotAddress(
+    adapter: NonNullable<ResolvedSigner["adapter"]>,
+): Promise<string | null> {
+    const slotSigner = await createSlotAccountSigner(
+        productScopedAdapter(adapter),
+        BULLETIN_RESOURCE,
+    );
+    return slotSigner ? ss58Encode(slotSigner.publicKey) : null;
+}
+
 function requireSession(publishSigner: ResolvedSigner) {
     const { userSession, adapter } = publishSigner;
     if (!userSession || !adapter) {


### PR DESCRIPTION
## Summary

Adds a read-only `playground status` command and fixes a pre-existing native-token decimal bug surfaced while building it.

### `playground status`
A no-phone-interaction snapshot of the signed-in account:
- **Product account** SS58 + H160 (from the persisted session, no phone tap)
- **Native balance** (PAS/SUM) and **PGAS balance**
- **Bulletin authorization** valid-until block with a humanized time estimate (`~9d 12h · #690,349`), read against the slot account the authorization is keyed to — reuses the existing `checkAttestation`/`getBulletinBlockTimeMs`/`formatAttestation` helpers
- **Login freshness** (with the stale-session warning when >2 days)

Each chain-dependent field degrades independently to `unavailable`; addresses + login stamp still render if the chain is unreachable. Exits 0 on soft outcomes (not-logged-in), 1 only on unexpected errors — mirrors `playground drip`.

### Native token decimal fix (10, not 12)
The repo hardcoded PAS as 12 decimals; it is **10**. Verified live against paseo-next-v2:

| Source | Result |
|---|---|
| Asset Hub `system_properties.tokenDecimals` | `10` |
| People chain `system_properties.tokenDecimals` | `10` |
| `Balances.ExistentialDeposit` = `100000000` planck | `0.01 PAS` only at 10 decimals (canonical Polkadot ED) |

Impact of the fix:
- Balance displays were under-shown 100x — now correct (e.g. `220.5 PAS`, not `2.205`).
- **`playground drip` behavior change:** it now transfers the documented **1 PAS** per run (10 PAS cap) instead of **100 PAS** (1000 PAS cap). `DRIP_AMOUNT = ONE_PAS`, and `ONE_PAS` went from `1e12` to `1e10`.
- PGAS carries no on-chain metadata (`decimals = 0`) and is 1:1 with PAS, so it renders at the same 10-decimal scale (`35.4793 PGAS`). SUM (summit) is also 10 decimals — covered by the single `PAS_DECIMALS` constant.

## Files
- `src/commands/status/` — `index.ts` (command), `StatusScreen.tsx` (Ink UI), `gather.ts` + `gather.test.ts` (React-free, testable orchestrator)
- `src/utils/account/pgas.ts` (+ test) — PGAS balance reader and grouped token formatter (caps at 4 fractional digits to match `formatPas`)
- `src/utils/allowances/bulletin.ts` — `getCachedBulletinSlotAddress` (local cache read, no phone)
- `src/config.ts` (+ test) — per-env `pgasAssetId` + `getPgasAssetId()`
- `src/utils/account/drip.ts` (+ test) — `PAS_DECIMALS = 10`, `formatPas` parametrized
- `src/index.ts`, `src/telemetry-config.ts` — command registration + `CliCommandName`

## Verification
- `pnpm typecheck` — clean
- `pnpm format:check` — clean
- `pnpm lint:license` — clean
- `pnpm test` — 935 passed
- Live `pg status` renders correctly and exits 0