### PR TITLE
test(e2e): fix two stale CLI output expectations

### DIFF
--- a/e2e/cli/build.test.ts
+++ b/e2e/cli/build.test.ts
@@ -81,14 +81,16 @@ describe("dot build", () => {
 		expect(output).toContain("Compile error: unexpected token");
 	});
 
-	test("exits non-zero when no build strategy can be detected", async () => {
+	test("exits non-zero when there's nothing to build", async () => {
 		const project = stage("contracts-only");
 		const result = await dot(["build", "--dir", project]);
 		expect(result.exitCode).not.toBe(0);
-		// Exact wording from src/utils/build/detect.ts:
-		//   `No build strategy detected. Add a "build" script to package.json,
-		//    or install vite/next/typescript.`
+		// The contracts-only fixture has only foundry.toml and no package.json,
+		// so the detector reports the more specific "No package.json found"
+		// guidance (src/utils/build/detect.ts handles a missing package.json
+		// before the generic no-strategy hint, to steer users who ran the
+		// command a directory above their project).
 		const output = result.stdout + result.stderr;
-		expect(output).toContain("No build strategy detected");
+		expect(output).toContain("No package.json found");
 	});
 });

--- a/e2e/cli/mod.test.ts
+++ b/e2e/cli/mod.test.ts
@@ -114,18 +114,21 @@ describe("dot mod — clone", () => {
 			expect(gitignore).toContain(".dot-mod-source.log");
 
 			// ── Step 3 (run setup.sh) ──────────────────────────────────────
-			// The script's first line of substantive output is
-			// `echo "[setup] Rock Paper Scissors tutorial"`. If the log file
-			// exists with that prefix, setup.sh actually ran. (We can't
-			// assert exit 0 of the script here — exit-code propagation is
-			// already covered by the outer `result.exitCode` check above.)
+			// The template's setup.sh prints its progress on `==>`-prefixed
+			// lines (e.g. `==> Installing npm dependencies...`). If the log file
+			// exists with that prefix, setup.sh actually ran. (We can't assert
+			// exit 0 of the script here — exit-code propagation is already
+			// covered by the outer `result.exitCode` check above.) We match the
+			// `==>` prefix rather than a specific message so the test is robust
+			// to the upstream template (paritytech/Rock-Paper-Scissors) tweaking
+			// its setup steps.
 			const setupLog = join(projectDir, ".dot-mod-setup.log");
 			expect(
 				existsSync(setupLog),
 				`setup.sh log not found — step 3 did not run.\n${result.stdout}\n${result.stderr}`,
 			).toBe(true);
 			const setupLogContent = readFileSync(setupLog, "utf-8");
-			expect(setupLogContent).toContain("[setup]");
+			expect(setupLogContent).toContain("==>");
 		},
 	);
 


### PR DESCRIPTION
## What

Fixes two E2E assertions that drifted from current behavior and were failing independently of any feature work (red on `main`, e.g. the #401 merge run).

### 1. `mod.test.ts` — `dot mod — clone`
The template repo (`paritytech/Rock-Paper-Scissors`) updated its `setup.sh`: it no longer prints `[setup] Rock Paper Scissors tutorial`. Its progress lines are now `==>`-prefixed (e.g. `==> Installing npm dependencies...`).

```
expected '==> Installing npm dependencies...' to contain '[setup]'
```

Now asserts the `==>` prefix — robust to the upstream template tweaking its individual step messages, while still proving `setup.sh` ran and produced output.

### 2. `build.test.ts` — no build strategy
The `contracts-only` fixture has only `foundry.toml` (no `package.json`). `src/utils/build/detect.ts` checks for a missing `package.json` *before* the generic no-strategy hint, so it emits the more specific, more helpful message:

```
expected '✖ No package.json found in /tmp/dot…' to contain 'No build strategy detected'
```

Now asserts `No package.json found` (the message that fixture actually produces). Renamed the test to "exits non-zero when there's nothing to build" to match.

## Why these are correct (not guesses)

- The `==>` output was verified against the live `setup.sh` on the template repo's default branch.
- The `No package.json found` message was verified against `src/utils/build/detect.ts` and the `contracts-only` fixture (only `foundry.toml`, no `package.json`). The unit test `src/utils/build/detect.test.ts` already asserts both branches.

## Notes

- Test-only change; no changeset (per repo convention).
- These E2E cells require testnet to run, so the assertions were matched to verified current output rather than re-run locally.