### PR TITLE
fix: polish deploy and mod prompt copy

### DIFF
--- a/.changeset/quiet-build-prompt.md
+++ b/.changeset/quiet-build-prompt.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Polish the deploy and mod prompt copy: the mod next-step text now refers to your AI agent generically, and the deploy build prompt explains that pressing enter keeps the default rebuild choice.

--- a/src/commands/deploy/DeployScreen.tsx
+++ b/src/commands/deploy/DeployScreen.tsx
@@ -71,6 +71,7 @@ import {
 } from "./signerNotice.js";
 import {
     BUILD_HELP,
+    BUILD_HINT,
     CONTRACTS_HELP,
     SIGNER_HELP,
     PUBLISH_HELP,
@@ -152,7 +153,7 @@ interface Resolved {
  * `promptHelp.ts`. The `accent` tone marks it as informational (distinct from
  * the yellow `warning` notices).
  */
-/** One-line dim hint above a trivial text input (domain, build directory). */
+/** One-line dim hint above a lightweight prompt. */
 function PromptHint({ text }: { text: string }) {
     return (
         <Box marginLeft={2} marginBottom={1}>
@@ -311,6 +312,7 @@ export function DeployScreen({
             {stage.kind === "prompt-build" && (
                 <Box flexDirection="column">
                     <PromptInfo box={BUILD_HELP} />
+                    <PromptHint text={BUILD_HINT} />
                     <Select<boolean>
                         label="build before deploy?"
                         options={[

--- a/src/commands/deploy/promptHelp.test.ts
+++ b/src/commands/deploy/promptHelp.test.ts
@@ -22,6 +22,7 @@ import {
     MODDABLE_HELP,
     TAGS_HELP,
     DOMAIN_HELP,
+    BUILD_HINT,
     BUILD_DIR_HINT,
     DOMAIN_HINT,
     CONTRACTS_RENAME_NOTICE_TITLE,
@@ -112,11 +113,17 @@ describe("contract-redeploy rename notice", () => {
     });
 });
 
-describe("trivial-input hints", () => {
+describe("lightweight prompt hints", () => {
     it("are one-line, non-empty strings", () => {
-        for (const [name, hint] of Object.entries({ BUILD_DIR_HINT, DOMAIN_HINT })) {
+        for (const [name, hint] of Object.entries({ BUILD_HINT, BUILD_DIR_HINT, DOMAIN_HINT })) {
             expect(hint.trim(), name).not.toBe("");
             expect(hint, name).not.toContain("\n");
         }
+    });
+
+    it("tells users enter accepts the build prompt default", () => {
+        const hint = BUILD_HINT.toLowerCase();
+        expect(hint).toContain("enter");
+        expect(hint).toContain("rebuild");
     });
 });

--- a/src/commands/deploy/promptHelp.ts
+++ b/src/commands/deploy/promptHelp.ts
@@ -24,10 +24,9 @@
  * gating are intentionally unchanged (contracts must run before the frontend
  * build, so it stays first); this module only owns the words.
  *
- * Boxed prompts (conceptual choices) get a `{ title, body }`; the two trivial
- * text inputs (domain, build directory) get a single dim hint line instead of
- * a full bordered box. Keep bodies short enough to read at a glance; the test
- * enforces a soft length cap.
+ * Boxed prompts (conceptual choices) get a `{ title, body }`; lightweight
+ * nudges get a single dim hint line instead of a full bordered box. Keep bodies
+ * short enough to read at a glance; the test enforces a soft length cap.
  */
 
 export interface PromptBox {
@@ -41,6 +40,9 @@ export const BUILD_HELP: PromptBox = {
         "Compiles your latest code into the files we upload. Choose Yes to " +
         "rebuild now, or No to redeploy the build that's already in your build folder.",
 };
+
+export const BUILD_HINT =
+    "Press enter to rebuild now. Change this only if you want to redeploy an existing build.";
 
 export const CONTRACTS_HELP: PromptBox = {
     title: "Smart contracts · your app's on-chain backend",
@@ -116,7 +118,7 @@ export const CONTRACTS_RENAME_NOTICE_BODY =
 
 export const CONTRACTS_RENAME_NOTICE_HINT = "enter to continue · esc to exit and rename";
 
-/** One-line hints for the trivial text inputs (no bordered box). */
+/** One-line hints for lightweight prompts (no bordered box). */
 export const BUILD_DIR_HINT =
     "The folder holding your built site (the files we upload). The default fits most projects.";
 

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -27,7 +27,7 @@ import { defaultRepoName } from "../../utils/git/repoName.js";
 import { runCliCommand } from "../../cli-runtime.js";
 import { parseGitHubRepoUrl, type GitHubRepoRef } from "../../utils/mod/source.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
-import { editWithClaudeStep } from "./nextSteps.js";
+import { editWithAgentStep } from "./nextSteps.js";
 import { shouldShowTutorialPrompt } from "./tutorialPromptHint.js";
 
 interface FetchedAppMetadata {
@@ -181,7 +181,7 @@ async function runModCommand(rawDomain: string | undefined): Promise<void> {
         if (ok) {
             console.log("  Next steps:");
             console.log(`  1. cd ${targetDir}`);
-            console.log(editWithClaudeStep(shouldShowTutorialPrompt({ domain, startedTutorial })));
+            console.log(editWithAgentStep(shouldShowTutorialPrompt({ domain, startedTutorial })));
             console.log("  3. playground deploy --playground");
         }
         if (!ok) process.exitCode = 1;

--- a/src/commands/mod/nextSteps.test.ts
+++ b/src/commands/mod/nextSteps.test.ts
@@ -14,14 +14,16 @@
 // limitations under the License.
 
 import { describe, expect, it } from "vitest";
-import { editWithClaudeStep } from "./nextSteps.js";
+import { editWithAgentStep } from "./nextSteps.js";
 
-describe("editWithClaudeStep", () => {
+describe("editWithAgentStep", () => {
     it("nudges toward the tutorial prompt when a quest track was started", () => {
-        expect(editWithClaudeStep(true)).toBe('  2. edit with claude (prompt: "start tutorial")');
+        expect(editWithAgentStep(true)).toBe(
+            '  2. edit with your AI agent (prompt: "start tutorial")',
+        );
     });
 
     it("stays generic for a plain mod (no tutorial started)", () => {
-        expect(editWithClaudeStep(false)).toBe("  2. edit with claude");
+        expect(editWithAgentStep(false)).toBe("  2. edit with your AI agent");
     });
 });

--- a/src/commands/mod/nextSteps.ts
+++ b/src/commands/mod/nextSteps.ts
@@ -14,13 +14,13 @@
 // limitations under the License.
 
 /**
- * The "edit with claude" line of the post-clone "Next steps" block. For a quest
+ * The "edit with your AI agent" line of the post-clone "Next steps" block. For a quest
  * track the user actually started, it nudges them toward the prepopulated AI
  * prompt that kicks off the guided tutorial; a plain mod has no such entry
  * point, so it stays generic.
  */
-export function editWithClaudeStep(startedTutorial: boolean): string {
+export function editWithAgentStep(startedTutorial: boolean): string {
     return startedTutorial
-        ? '  2. edit with claude (prompt: "start tutorial")'
-        : "  2. edit with claude";
+        ? '  2. edit with your AI agent (prompt: "start tutorial")'
+        : "  2. edit with your AI agent";
 }

--- a/src/commands/mod/tutorialPromptHint.ts
+++ b/src/commands/mod/tutorialPromptHint.ts
@@ -20,7 +20,7 @@
  *
  * Kept in its own module so it can be removed in one go if we decide against
  * it: delete this file and pass `startedTutorial` straight to
- * `editWithClaudeStep` at the `playground mod` call site to revert to the
+ * `editWithAgentStep` at the `playground mod` call site to revert to the
  * quest-track behaviour.
  */
 const TUTORIAL_APP_DOMAIN = "playground-tutorial.dot";


### PR DESCRIPTION
## Summary
- Reword pg mod next steps to say "your AI agent" instead of naming a specific tool.
- Add a dim build prompt hint that Enter accepts the default rebuild choice.
- Add a patch changeset for the user-facing copy polish.

## Tests
- pnpm format:check
- pnpm lint:license
- pnpm typecheck
- pnpm test

Closes #389