### PR TITLE
feat: auto-install the project's package manager during mod/deploy

### DIFF
--- a/.changeset/mod-package-manager-autoinstall.md
+++ b/.changeset/mod-package-manager-autoinstall.md
@@ -2,7 +2,9 @@
 "playground-cli": minor
 ---
 
-`playground mod` and deploy now detect the package manager a project uses
-(pnpm/yarn/bun/npm) and offer to install it — plus Node.js when needed — instead
-of failing with a confusing error when it's missing. macOS and Linux are
-supported; non-interactive runs auto-install.
+`playground mod` now detects the package manager a project uses (pnpm/yarn/bun/npm)
+and, when it (or Node.js) is missing, offers to install it with one confirmation
+before running the project's setup, instead of failing with a confusing error.
+`playground deploy` and `playground build` install a missing manager automatically
+as part of the build step. macOS and Linux are supported; non-interactive runs
+install without prompting.

--- a/.changeset/mod-package-manager-autoinstall.md
+++ b/.changeset/mod-package-manager-autoinstall.md
@@ -1,0 +1,8 @@
+---
+"playground-cli": minor
+---
+
+`playground mod` and deploy now detect the package manager a project uses
+(pnpm/yarn/bun/npm) and offer to install it — plus Node.js when needed — instead
+of failing with a confusing error when it's missing. macOS and Linux are
+supported; non-interactive runs auto-install.

--- a/src/commands/mod/SetupScreen.tsx
+++ b/src/commands/mod/SetupScreen.tsx
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Box, Text } from "ink";
 import { existsSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -31,9 +31,12 @@ import { runCommand } from "../../utils/git.js";
 import { createOptionalGitBaseline } from "../../utils/mod/git-baseline.js";
 import { downloadGitHubTarball, parseGitHubRepoUrl } from "../../utils/mod/source.js";
 import {
-    findUnsatisfiedPackageManagers,
-    missingPackageManagerMessage,
-} from "../../utils/mod/packageManager.js";
+    ensurePackageManager,
+    planPackageManager,
+    type InstallPlan,
+} from "../../utils/packageManagers.js";
+import { decidePmPhase, pmConfirmLabel } from "./setupFlow.js";
+import { Select } from "../../utils/ui/theme/Select.js";
 import { VERSION_LABEL } from "../../utils/version.js";
 import { getNetworkLabel } from "../../config.js";
 import { fetchBulletinJson, getBulletinGateway } from "../../utils/bulletinGateway.js";
@@ -71,10 +74,18 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
     // sourceUnavailable.ts) — the publisher made the repo private/deleted it
     // after publishing, which we can't undo and the user can't fix.
     const [unavailable, setUnavailable] = useState(false);
+    // Package-manager-aware phase machine. After the source is downloaded we
+    // detect the project's PM and, when it (or Node) is missing, ask once to
+    // install it before running setup.sh. See setupFlow.ts for the decision.
+    const [phase, setPhase] = useState<"pre" | "confirm" | "install" | "post" | "halt">("pre");
+    const [pmPlan, setPmPlan] = useState<InstallPlan | null>(null);
     const setupLogFile = resolve(targetDir, ".dot-mod-setup.log");
     const sourceLogFile = resolve(targetDir, ".dot-mod-source.log");
 
-    const steps: Step[] = [
+    // Steps that always run first: fetch metadata + download source. `meta` is
+    // populated by the first step and read by the second, so they must stay
+    // together in this array (StepRunner runs them sequentially).
+    const preSteps: Step[] = [
         {
             name: "fetch app metadata",
             run: async (log) => {
@@ -148,32 +159,43 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
                 ignoreModLogs(targetDir);
             },
         },
-        {
-            name: "run setup.sh",
-            keepLogOnSuccess: true,
-            run: async (log) => {
-                const setupPath = resolve(targetDir, "setup.sh");
-                if (!existsSync(setupPath)) {
-                    // Most moddable apps have no setup.sh, and that's normal —
-                    // surfacing it as a warning row alarmed users. Skip the step
-                    // silently so nothing is shown; the parent still prints the
-                    // generic "Next steps" footer because `setupRan` stays false.
-                    throw new SilentSkip("no setup.sh found");
-                }
-                const missing = await findUnsatisfiedPackageManagers(
-                    readFileSync(setupPath, "utf8"),
-                );
-                if (missing.length > 0) {
-                    throw new Error(missingPackageManagerMessage(missing));
-                }
-                await runCommand("bash setup.sh", { cwd: targetDir, log, logFile: setupLogFile });
-                setupRanRef.current = true;
-                setSetupRanVisible(true);
-            },
-        },
     ];
 
+    // Final on-disk work: run the app's setup.sh. The package manager is
+    // guaranteed present by the install phase that runs before this, so the
+    // old "missing package manager" gate is gone.
+    const runSetupSh: Step = {
+        name: "run setup.sh",
+        keepLogOnSuccess: true,
+        run: async (log) => {
+            const setupPath = resolve(targetDir, "setup.sh");
+            if (!existsSync(setupPath)) {
+                // Most moddable apps have no setup.sh, and that's normal —
+                // surfacing it as a warning row alarmed users. Skip the step
+                // silently so nothing is shown; the parent still prints the
+                // generic "Next steps" footer because `setupRan` stays false.
+                throw new SilentSkip("no setup.sh found");
+            }
+            await runCommand("bash setup.sh", { cwd: targetDir, log, logFile: setupLogFile });
+            setupRanRef.current = true;
+            setSetupRanVisible(true);
+        },
+    };
+
     const [error, setError] = useState<string | null>(null);
+
+    // Declining the install (or having no installable PM path) is a SOFT
+    // outcome: exit cleanly with `setupRan: false` and let the halt Callout
+    // explain the manual remedy. Fire `onDone` exactly once on entering halt.
+    const haltReportedRef = useRef(false);
+    useEffect(() => {
+        if (phase === "halt" && !haltReportedRef.current) {
+            haltReportedRef.current = true;
+            onDone({ ok: true, setupRan: false });
+        }
+        // onDone is captured once on mount by the parent; gate purely on phase.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [phase]);
 
     return (
         <Box flexDirection="column">
@@ -193,14 +215,93 @@ export function SetupScreen({ domain, metadata: initial, registry, targetDir, on
                 </Callout>
             )}
 
-            <StepRunner
-                title={`modding ${domain}`}
-                steps={steps}
-                onDone={(result) => {
-                    if (result.error) setError(result.error);
-                    onDone({ ok: result.ok, setupRan: setupRanRef.current });
-                }}
-            />
+            {phase === "pre" && (
+                <StepRunner
+                    title={`modding ${domain}`}
+                    steps={preSteps}
+                    onDone={async (result) => {
+                        if (!result.ok) {
+                            if (result.error) setError(result.error);
+                            onDone({ ok: false, setupRan: false });
+                            return;
+                        }
+                        // Planning is best-effort: if PM detection throws, fall
+                        // through to setup.sh and let any real failure surface
+                        // there rather than blocking the mod on a probe error.
+                        // This callback is fire-and-forget (StepRunner doesn't
+                        // await it), but the success path only ever advances the
+                        // phase — it never calls the terminal onDone — so the
+                        // component stays mounted and the post-await setState
+                        // lands on a live component.
+                        try {
+                            const plan = await planPackageManager(targetDir);
+                            setPmPlan(plan);
+                            const next = decidePmPhase({
+                                missing: plan.toolsToInstall,
+                                isTTY: Boolean(process.stdin.isTTY),
+                            });
+                            setPhase(next === "setup" ? "post" : next);
+                        } catch {
+                            setPhase("post");
+                        }
+                    }}
+                />
+            )}
+
+            {phase === "confirm" && pmPlan && (
+                <Select
+                    label={pmConfirmLabel(pmPlan.pm, pmPlan.toolsToInstall)}
+                    options={[
+                        { value: "yes", label: "Install now" },
+                        { value: "no", label: "Cancel — I'll install it myself" },
+                    ]}
+                    onSelect={(v) => setPhase(v === "yes" ? "install" : "halt")}
+                />
+            )}
+
+            {phase === "install" && (
+                <StepRunner
+                    title="installing package manager"
+                    steps={[
+                        {
+                            name: `install ${pmPlan?.pm ?? "package manager"}`,
+                            run: async (log) => {
+                                // `confirm` omitted on purpose — the user already
+                                // confirmed (TTY) or we auto-proceed (non-TTY).
+                                await ensurePackageManager(targetDir, { onData: log });
+                            },
+                        },
+                    ]}
+                    onDone={(result) => {
+                        if (!result.ok) {
+                            setError(result.error ?? "package manager install failed");
+                            onDone({ ok: false, setupRan: false });
+                            return;
+                        }
+                        setPhase("post");
+                    }}
+                />
+            )}
+
+            {phase === "post" && (
+                <StepRunner
+                    title={`finishing ${domain}`}
+                    steps={[runSetupSh]}
+                    onDone={(result) => {
+                        if (result.error) setError(result.error);
+                        onDone({ ok: result.ok, setupRan: setupRanRef.current });
+                    }}
+                />
+            )}
+
+            {phase === "halt" && pmPlan && (
+                <Callout tone="warning" title="package manager not installed">
+                    <Text>
+                        This project uses {pmPlan.pm}. Install it, then re-run playground mod (or
+                        the build).
+                    </Text>
+                </Callout>
+            )}
 
             {!unavailable && <Hint>→ {targetDir}</Hint>}
             {setupRanVisible && <Hint>full setup log: {setupLogFile}</Hint>}

--- a/src/commands/mod/setupFlow.test.ts
+++ b/src/commands/mod/setupFlow.test.ts
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { decidePmPhase, pmConfirmLabel } from "./setupFlow.js";
+
+describe("decidePmPhase", () => {
+    it("goes straight to setup when nothing is missing", () => {
+        expect(decidePmPhase({ missing: [], isTTY: true })).toBe("setup");
+    });
+
+    it("prompts for confirmation in a TTY when tools are missing", () => {
+        expect(decidePmPhase({ missing: ["Node.js", "pnpm"], isTTY: true })).toBe("confirm");
+    });
+
+    it("auto-installs without a prompt when there is no TTY", () => {
+        expect(decidePmPhase({ missing: ["bun"], isTTY: false })).toBe("install");
+    });
+});
+
+describe("pmConfirmLabel", () => {
+    it("names the PM and exactly what will be installed", () => {
+        expect(pmConfirmLabel("pnpm", ["Node.js", "pnpm"])).toBe(
+            "This project uses pnpm, which isn't installed. Install it now? (Node.js + pnpm)",
+        );
+    });
+});

--- a/src/commands/mod/setupFlow.ts
+++ b/src/commands/mod/setupFlow.ts
@@ -1,0 +1,31 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Pure decision + text helpers for SetupScreen's package-manager phase. */
+
+import type { PackageManager } from "../../utils/packageManagers.js";
+
+/** Phase to enter after the source has been downloaded and the PM planned. */
+export type PmPhase = "setup" | "confirm" | "install";
+
+export function decidePmPhase(opts: { missing: string[]; isTTY: boolean }): PmPhase {
+    if (opts.missing.length === 0) return "setup";
+    return opts.isTTY ? "confirm" : "install";
+}
+
+/** Confirmation prompt label, naming the PM and the exact tools to install. */
+export function pmConfirmLabel(pm: PackageManager, toolsToInstall: string[]): string {
+    return `This project uses ${pm}, which isn't installed. Install it now? (${toolsToInstall.join(" + ")})`;
+}

--- a/src/utils/build/detect.test.ts
+++ b/src/utils/build/detect.test.ts
@@ -49,6 +49,10 @@ describe("detectPackageManager", () => {
     it("picks bun when only bun.lockb is present", () => {
         expect(detectPackageManager(new Set(["bun.lockb"]))).toBe("bun");
     });
+
+    it("picks bun when only bun.lock (bun 1.2+ text lockfile) is present", () => {
+        expect(detectPackageManager(new Set(["bun.lock"]))).toBe("bun");
+    });
 });
 
 describe("detectBuildConfig", () => {

--- a/src/utils/build/detect.ts
+++ b/src/utils/build/detect.ts
@@ -24,13 +24,20 @@ import { DEFAULT_BUILD_DIR } from "../../config.js";
 
 export type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
 
-/** Files we inspect on disk to infer the package manager. */
+/** Canonical lockfile basename per package manager. */
 export const PM_LOCKFILES: Record<PackageManager, string> = {
     pnpm: "pnpm-lock.yaml",
     yarn: "yarn.lock",
     bun: "bun.lockb",
     npm: "package-lock.json",
 };
+
+// Bun 1.2+ defaults to a TEXT lockfile (`bun.lock`); older bun wrote the binary
+// `bun.lockb`. Detect either so modern bun projects aren't mis-detected as npm.
+const BUN_TEXT_LOCKFILE = "bun.lock";
+
+/** Every lockfile basename to probe on disk (some PMs have more than one). */
+export const PM_LOCKFILES_ALL: string[] = [...Object.values(PM_LOCKFILES), BUN_TEXT_LOCKFILE];
 
 export interface BuildConfig {
     /** Binary + args to spawn. */
@@ -80,7 +87,7 @@ export class BuildDetectError extends Error {
 export function detectPackageManager(lockfiles: Set<string>): PackageManager {
     if (lockfiles.has(PM_LOCKFILES.pnpm)) return "pnpm";
     if (lockfiles.has(PM_LOCKFILES.yarn)) return "yarn";
-    if (lockfiles.has(PM_LOCKFILES.bun)) return "bun";
+    if (lockfiles.has(PM_LOCKFILES.bun) || lockfiles.has(BUN_TEXT_LOCKFILE)) return "bun";
     return "npm";
 }
 

--- a/src/utils/build/runner.test.ts
+++ b/src/utils/build/runner.test.ts
@@ -1,0 +1,70 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ensureSpy = vi.fn();
+vi.mock("../packageManagers.js", () => ({
+    ensurePackageManager: (...args: unknown[]) => ensureSpy(...args),
+}));
+const runStreamedSpy = vi.fn(async (..._a: unknown[]) => {});
+vi.mock("../process.js", () => ({ runStreamed: (...a: unknown[]) => runStreamedSpy(...a) }));
+
+import { runBuild } from "./runner.js";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("runBuild ensures the package manager before installing", () => {
+    beforeEach(() => {
+        ensureSpy.mockReset();
+        runStreamedSpy.mockReset();
+    });
+
+    it("calls ensurePackageManager before the install step runs", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "pm-runner-"));
+        writeFileSync(
+            join(dir, "package.json"),
+            JSON.stringify({ scripts: { build: "echo built" }, dependencies: { left: "1" } }),
+        );
+        const order: string[] = [];
+        ensureSpy.mockImplementation(async () => {
+            order.push("ensure");
+        });
+        runStreamedSpy.mockImplementation(async () => {
+            order.push("run");
+        });
+
+        await runBuild({ cwd: dir });
+
+        expect(ensureSpy).toHaveBeenCalledTimes(1);
+        // ensure runs once, before both the install and build runStreamed calls.
+        expect(order).toEqual(["ensure", "run", "run"]);
+    });
+
+    it("does not ensure a package manager for a deps-free project", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "pm-runner-nodeps-"));
+        // No dependencies/devDependencies → detectInstallConfig returns null →
+        // no install step, so there is no PM to ensure.
+        writeFileSync(
+            join(dir, "package.json"),
+            JSON.stringify({ scripts: { build: "echo built" } }),
+        );
+
+        await runBuild({ cwd: dir });
+
+        expect(ensureSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/build/runner.ts
+++ b/src/utils/build/runner.ts
@@ -20,6 +20,7 @@
 
 import { readFileSync, statSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { ensurePackageManager, type InstallPlan } from "../packageManagers.js";
 import { runStreamed } from "../process.js";
 import {
     detectBuildConfig,
@@ -79,6 +80,11 @@ export interface RunBuildOptions {
     config?: BuildConfig;
     /** Per-line output callback (stdout + stderr). */
     onData?: (line: string) => void;
+    /**
+     * Asked once before installing a missing package manager. Return true to
+     * proceed. Omitted → auto-proceed (non-interactive posture).
+     */
+    confirm?: (plan: InstallPlan) => Promise<boolean>;
 }
 
 export interface RunBuildResult {
@@ -101,6 +107,9 @@ export async function runBuild(options: RunBuildOptions): Promise<RunBuildResult
 
     const install: InstallConfig | null = detectInstallConfig(input);
     if (install) {
+        // Make sure the detected PM (and Node, when it needs it) actually exists
+        // before we shell out to it — otherwise this is the "scary error" path.
+        await ensurePackageManager(cwd, { onData: options.onData, confirm: options.confirm });
         options.onData?.(`> ${install.description}`);
         await runStreamed({
             ...install,

--- a/src/utils/build/runner.ts
+++ b/src/utils/build/runner.ts
@@ -25,7 +25,7 @@ import { runStreamed } from "../process.js";
 import {
     detectBuildConfig,
     detectInstallConfig,
-    PM_LOCKFILES,
+    PM_LOCKFILES_ALL,
     type BuildConfig,
     type DetectInput,
     type InstallConfig,
@@ -56,7 +56,7 @@ export function loadDetectInput(projectDir: string): DetectInput {
         : null;
 
     const lockfiles = new Set<string>();
-    for (const name of Object.values(PM_LOCKFILES)) {
+    for (const name of PM_LOCKFILES_ALL) {
         if (existsSync(join(root, name))) lockfiles.add(name);
     }
 

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -144,4 +144,21 @@ describe("runCommand log-file tee", () => {
         expect(lines).toEqual(["a", "b"]);
         expect(readFileSync(logFile, "utf-8")).toBe("a\nb\n");
     });
+
+    it("reads PATH live, so a binary installed earlier this run is visible", async () => {
+        // The package-manager auto-install mutates process.env.PATH in-process
+        // (prependPath) and then runs setup.sh through runCommand. The child
+        // must see that live PATH — a module-load env snapshot would miss it and
+        // setup.sh would hit "command not found" for the just-installed PM.
+        const sentinel = join(dir, "freshly-installed-bin");
+        const original = process.env.PATH;
+        process.env.PATH = `${sentinel}:${original ?? ""}`;
+        try {
+            const lines: string[] = [];
+            await runCommand('printf "%s" "$PATH"', { cwd: dir, log: (l) => lines.push(l) });
+            expect(lines.join("")).toContain(sentinel);
+        } finally {
+            process.env.PATH = original;
+        }
+    });
 });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -30,8 +30,14 @@ function sanitize(s: string): string {
     return s.replace(ANSI_RE, "").replace(/\r/g, "");
 }
 
-/** Env vars that tell child processes to skip interactive/color output. */
-const PLAIN_ENV = { ...process.env, TERM: "dumb", NO_COLOR: "1", CI: "1" };
+/**
+ * Env vars that tell child processes to skip interactive/color output. Built
+ * per-call (not a module-load snapshot) so a binary installed earlier in the
+ * same run — e.g. the package-manager auto-install prepends its bin dir to
+ * `process.env.PATH` — is visible to the child. A snapshot would freeze a stale
+ * PATH and make `setup.sh` fail with "command not found" for the fresh PM.
+ */
+const plainEnv = () => ({ ...process.env, TERM: "dumb", NO_COLOR: "1", CI: "1" });
 
 /**
  * Run a shell command, streaming output to log.
@@ -47,7 +53,7 @@ export async function runCommand(
 ): Promise<void> {
     const { cwd, log, logFile } = options;
     return new Promise((resolve, reject) => {
-        const proc = exec(cmd, { cwd, env: PLAIN_ENV });
+        const proc = exec(cmd, { cwd, env: plainEnv() });
         let file: ReturnType<typeof createWriteStream> | null = null;
         if (logFile) {
             file = createWriteStream(logFile);

--- a/src/utils/mod/packageManager.test.ts
+++ b/src/utils/mod/packageManager.test.ts
@@ -13,16 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { commandExists } from "../toolchain.js";
-import {
-    detectReferencedPackageManagers,
-    findUnsatisfiedPackageManagers,
-    missingPackageManagerMessage,
-} from "./packageManager.js";
-
-vi.mock("../toolchain.js", () => ({ commandExists: vi.fn() }));
-const mockCommandExists = vi.mocked(commandExists);
+import { describe, expect, it } from "vitest";
+import { detectReferencedPackageManagers } from "./packageManager.js";
 
 describe("detectReferencedPackageManagers", () => {
     it("detects npm and npx", () => {
@@ -72,76 +64,5 @@ describe("detectReferencedPackageManagers", () => {
 
     it("returns empty for scripts with no package manager", () => {
         expect(detectReferencedPackageManagers("make build")).toEqual([]);
-    });
-});
-
-describe("findUnsatisfiedPackageManagers", () => {
-    beforeEach(() => mockCommandExists.mockReset());
-
-    it("returns empty when the script needs no package manager", async () => {
-        await expect(findUnsatisfiedPackageManagers("make build")).resolves.toEqual([]);
-        expect(mockCommandExists).not.toHaveBeenCalled();
-    });
-
-    it("returns empty when the single required manager is installed", async () => {
-        mockCommandExists.mockResolvedValue(true);
-        await expect(findUnsatisfiedPackageManagers("npm install")).resolves.toEqual([]);
-    });
-
-    it("flags the manager when it is the only one referenced and is missing", async () => {
-        mockCommandExists.mockResolvedValue(false);
-        await expect(findUnsatisfiedPackageManagers("npm install")).resolves.toEqual(["npm"]);
-    });
-
-    it("flags yarn when a yarn-only script has no yarn installed", async () => {
-        mockCommandExists.mockResolvedValue(false);
-        await expect(findUnsatisfiedPackageManagers("yarn install")).resolves.toEqual(["yarn"]);
-    });
-
-    it("is satisfied when ANY referenced manager from a fallback chain is present", async () => {
-        // setup.sh tries bun, else pnpm, else npm; only npm installed -> fine.
-        mockCommandExists.mockImplementation(async (bin: string) => bin === "npm");
-        const script =
-            "if command -v bun; then bun i; elif command -v pnpm; then pnpm i; else npm i; fi";
-        await expect(findUnsatisfiedPackageManagers(script)).resolves.toEqual([]);
-    });
-
-    it("flags all referenced managers only when none are installed", async () => {
-        mockCommandExists.mockResolvedValue(false);
-        const script =
-            "if command -v bun; then bun i; elif command -v pnpm; then pnpm i; else npm i; fi";
-        await expect(findUnsatisfiedPackageManagers(script)).resolves.toEqual([
-            "npm",
-            "pnpm",
-            "bun",
-        ]);
-    });
-
-    it("short-circuits once a present manager is found", async () => {
-        mockCommandExists.mockResolvedValue(true);
-        await findUnsatisfiedPackageManagers("npm i\npnpm i\nbun i");
-        expect(mockCommandExists).toHaveBeenCalledTimes(1);
-    });
-});
-
-describe("missingPackageManagerMessage", () => {
-    it("points npm users at Node.js", () => {
-        const msg = missingPackageManagerMessage(["npm"]);
-        expect(msg).toContain("npm");
-        expect(msg).toContain("none is installed");
-        expect(msg).toContain("nodejs.org");
-    });
-
-    it("uses a generic install hint for a single non-npm manager", () => {
-        const msg = missingPackageManagerMessage(["bun"]);
-        expect(msg).toContain("bun");
-        expect(msg).toContain("Install bun");
-        expect(msg).not.toContain("nodejs.org");
-    });
-
-    it("phrases a fallback chain as 'one of'", () => {
-        const msg = missingPackageManagerMessage(["npm", "pnpm", "bun"]);
-        expect(msg).toContain("one of: npm, pnpm, bun");
-        expect(msg).toContain("none is installed");
     });
 });

--- a/src/utils/mod/packageManager.ts
+++ b/src/utils/mod/packageManager.ts
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { commandExists } from "../toolchain.js";
-
 const MANAGERS: Array<{ bin: string; re: RegExp }> = [
     { bin: "npm", re: /(?:^|[\s;&|(])(?:npx|npm)(?:[\s;&|)]|$)/m },
     { bin: "pnpm", re: /(?:^|[\s;&|(])(?:pnpx|pnpm)(?:[\s;&|)]|$)/m },
@@ -33,32 +31,13 @@ function stripCommentsAndStrings(script: string): string {
         .replace(/'[^'\n]*'/g, "''");
 }
 
-/** Package managers the script invokes as commands (npm/npx, pnpm/pnpx, bun/bunx). */
+/**
+ * Package managers the script invokes as commands (npm/npx, pnpm/pnpx,
+ * bun/bunx, yarn/yarnpkg). Consumed by `src/utils/packageManagers.ts` as the
+ * lowest-precedence detection signal when there's no `packageManager` field or
+ * lockfile.
+ */
 export function detectReferencedPackageManagers(script: string): string[] {
     const code = stripCommentsAndStrings(script);
     return MANAGERS.filter((m) => m.re.test(code)).map((m) => m.bin);
-}
-
-/**
- * A `setup.sh` may reference several package managers in a fallback chain
- * (`command -v bun || ... || npm`) yet only need ONE of them. So this returns
- * the referenced managers ONLY when none of them are installed — the genuine
- * "can't run setup at all" case. An empty array means setup can proceed.
- */
-export async function findUnsatisfiedPackageManagers(script: string): Promise<string[]> {
-    const referenced = detectReferencedPackageManagers(script);
-    if (referenced.length === 0) return [];
-    for (const bin of referenced) {
-        if (await commandExists(bin)) return [];
-    }
-    return referenced;
-}
-
-export function missingPackageManagerMessage(referenced: string[]): string {
-    const list = referenced.join(", ");
-    const phrase = referenced.length > 1 ? `one of: ${list}` : list;
-    const hint = referenced.includes("npm")
-        ? "Install Node.js (which includes npm): https://nodejs.org"
-        : `Install ${referenced.join(" / ")} and try again`;
-    return `setup.sh needs ${phrase}, but none is installed. ${hint}`;
 }

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -1,0 +1,85 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from "vitest";
+import { detectProjectPackageManager, parsePackageManagerField } from "./packageManagers.js";
+
+describe("parsePackageManagerField", () => {
+    it("parses a name@version field", () => {
+        expect(parsePackageManagerField("pnpm@9.1.0")).toBe("pnpm");
+        expect(parsePackageManagerField("yarn@4.2.2")).toBe("yarn");
+        expect(parsePackageManagerField("npm@10.0.0")).toBe("npm");
+        expect(parsePackageManagerField("bun@1.1.0")).toBe("bun");
+    });
+
+    it("parses a bare name with no version", () => {
+        expect(parsePackageManagerField("pnpm")).toBe("pnpm");
+    });
+
+    it("returns null for unknown or malformed fields", () => {
+        expect(parsePackageManagerField("deno@1.0.0")).toBeNull();
+        expect(parsePackageManagerField("")).toBeNull();
+        expect(parsePackageManagerField(null)).toBeNull();
+    });
+});
+
+describe("detectProjectPackageManager precedence", () => {
+    it("prefers the packageManager field over everything", () => {
+        const pm = detectProjectPackageManager({
+            packageManagerField: "yarn@4.0.0",
+            lockfiles: new Set(["pnpm-lock.yaml"]),
+            setupScript: "npm install",
+        });
+        expect(pm).toBe("yarn");
+    });
+
+    it("falls back to the lockfile when no field", () => {
+        const pm = detectProjectPackageManager({
+            packageManagerField: null,
+            lockfiles: new Set(["pnpm-lock.yaml"]),
+            setupScript: "npm install",
+        });
+        expect(pm).toBe("pnpm");
+    });
+
+    it("falls back to the setup.sh reference when no field or lockfile", () => {
+        const pm = detectProjectPackageManager({
+            packageManagerField: null,
+            lockfiles: new Set(),
+            setupScript: "bun install && bun run build",
+        });
+        expect(pm).toBe("bun");
+    });
+
+    it("defaults to npm when nothing is detectable", () => {
+        const pm = detectProjectPackageManager({
+            packageManagerField: null,
+            lockfiles: new Set(),
+            setupScript: null,
+        });
+        expect(pm).toBe("npm");
+    });
+
+    it("breaks setup.sh ties by MANAGERS table order, not script order", () => {
+        // Script invokes pnpm first, then npm — but detectReferencedPackageManagers
+        // returns table order (npm before pnpm), so the first entry wins as npm.
+        const pm = detectProjectPackageManager({
+            packageManagerField: null,
+            lockfiles: new Set(),
+            setupScript: "pnpm install || npm install",
+        });
+        expect(pm).toBe("npm");
+    });
+});

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -125,9 +125,10 @@ describe("install command builders", () => {
         expect(bunInstallCommand()).toContain("bun.sh/install");
     });
 
-    it("installs yarn via corepack (its official path)", () => {
-        expect(yarnInstallCommand()).toContain("corepack");
-        expect(yarnInstallCommand()).toContain("yarn@stable");
+    it("installs yarn via corepack into a user-owned dir (avoids EACCES on Linux)", () => {
+        const cmd = yarnInstallCommand("/home/u/.corepack/bin");
+        expect(cmd).toContain('corepack enable --install-directory "/home/u/.corepack/bin"');
+        expect(cmd).toContain("yarn@stable");
     });
 });
 
@@ -147,12 +148,16 @@ describe("PM_TOOLS — which tools each PM needs", () => {
 });
 
 function fakeTool(label: string, installed: boolean, installSpy: string[]): PmTool {
+    // Models a real tool: `check()` flips to true once `install()` has run, so
+    // the orchestrator's post-install re-check passes.
+    let present = installed;
     return {
         name: label,
         label,
-        check: async () => installed,
+        check: async () => present,
         install: async () => {
             installSpy.push(label);
+            present = true;
         },
         manualHint: `install ${label}`,
     };
@@ -212,6 +217,52 @@ describe("ensurePackageManagerForTools", () => {
         ).rejects.toThrow("network down");
         // pnpm comes after the failed Node install, so it must not have run.
         expect(installed).toEqual([]);
+    });
+
+    it("throws when a tool is still missing after its install ran (PATH mismatch)", async () => {
+        const installed: string[] = [];
+        // install() "succeeds" but check() never flips — models an installer that
+        // wrote its binary somewhere not on PATH.
+        const stubborn: PmTool = {
+            name: "Node.js",
+            label: "Node.js",
+            check: async () => false,
+            install: async () => {
+                installed.push("Node.js");
+            },
+            manualHint: "https://nodejs.org/en/download",
+        };
+        await expect(ensurePackageManagerForTools("npm", [stubborn], {})).rejects.toThrow(
+            /still not on PATH/,
+        );
+        expect(installed).toEqual(["Node.js"]); // it did attempt the install
+    });
+
+    it("collapses concurrent installs of the same tool onto one run (single-flight)", async () => {
+        let installCount = 0;
+        let present = false;
+        let release!: () => void;
+        const gate = new Promise<void>((r) => {
+            release = r;
+        });
+        const make = (): PmTool => ({
+            name: "pnpm",
+            label: "pnpm",
+            check: async () => present,
+            install: async () => {
+                installCount++;
+                await gate;
+                present = true;
+            },
+            manualHint: "x",
+        });
+        // Two concurrent ensures racing the same missing tool (the deploy-all case).
+        const a = ensurePackageManagerForTools("pnpm", [make()], {});
+        const b = ensurePackageManagerForTools("pnpm", [make()], {});
+        await new Promise((r) => setTimeout(r, 10)); // let both reach the install
+        release();
+        await Promise.all([a, b]);
+        expect(installCount).toBe(1);
     });
 });
 

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -14,7 +14,14 @@
 // limitations under the License.
 
 import { describe, it, expect } from "vitest";
-import { detectProjectPackageManager, parsePackageManagerField } from "./packageManagers.js";
+import {
+    detectProjectPackageManager,
+    parsePackageManagerField,
+    nodeInstallCommand,
+    pnpmInstallCommand,
+    yarnInstallCommand,
+    bunInstallCommand,
+} from "./packageManagers.js";
 
 describe("parsePackageManagerField", () => {
     it("parses a name@version field", () => {
@@ -81,5 +88,40 @@ describe("detectProjectPackageManager precedence", () => {
             setupScript: "pnpm install || npm install",
         });
         expect(pm).toBe("npm");
+    });
+});
+
+describe("install command builders", () => {
+    it("installs Node via brew on macOS when brew is present", () => {
+        expect(nodeInstallCommand("darwin", true)).toBe("brew install node");
+    });
+
+    it("installs Node via NodeSource on Linux (avoids ancient apt node)", () => {
+        const cmd = nodeInstallCommand("linux", false);
+        expect(cmd).toContain("deb.nodesource.com/setup_lts.x");
+        expect(cmd).toContain("apt install -y nodejs");
+    });
+
+    it("chains the NodeSource setup and apt install (both privileged) with &&", () => {
+        const cmd = nodeInstallCommand("linux", false) ?? "";
+        // The setup script is piped into a privileged shell, then apt installs.
+        const prefix = process.getuid?.() === 0 ? "" : "sudo ";
+        expect(cmd).toContain(`| ${prefix}bash - && ${prefix}apt install -y nodejs`);
+    });
+
+    it("returns null for Node on unsupported platforms", () => {
+        expect(nodeInstallCommand("win32", false)).toBeNull();
+        // macOS without brew has no non-interactive path we control.
+        expect(nodeInstallCommand("darwin", false)).toBeNull();
+    });
+
+    it("uses the official standalone installers for pnpm and bun", () => {
+        expect(pnpmInstallCommand()).toContain("get.pnpm.io/install.sh");
+        expect(bunInstallCommand()).toContain("bun.sh/install");
+    });
+
+    it("installs yarn via corepack (its official path)", () => {
+        expect(yarnInstallCommand()).toContain("corepack");
+        expect(yarnInstallCommand()).toContain("yarn@stable");
     });
 });

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -21,6 +21,7 @@ import {
     pnpmInstallCommand,
     yarnInstallCommand,
     bunInstallCommand,
+    PM_TOOLS,
 } from "./packageManagers.js";
 
 describe("parsePackageManagerField", () => {
@@ -123,5 +124,20 @@ describe("install command builders", () => {
     it("installs yarn via corepack (its official path)", () => {
         expect(yarnInstallCommand()).toContain("corepack");
         expect(yarnInstallCommand()).toContain("yarn@stable");
+    });
+});
+
+describe("PM_TOOLS — which tools each PM needs", () => {
+    it("npm needs only Node (npm ships with it)", () => {
+        expect(PM_TOOLS.npm.map((t) => t.label)).toEqual(["Node.js"]);
+    });
+
+    it("pnpm and yarn need Node first, then themselves", () => {
+        expect(PM_TOOLS.pnpm.map((t) => t.label)).toEqual(["Node.js", "pnpm"]);
+        expect(PM_TOOLS.yarn.map((t) => t.label)).toEqual(["Node.js", "yarn"]);
+    });
+
+    it("bun is standalone — no Node", () => {
+        expect(PM_TOOLS.bun.map((t) => t.label)).toEqual(["bun"]);
     });
 });

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -22,6 +22,9 @@ import {
     yarnInstallCommand,
     bunInstallCommand,
     PM_TOOLS,
+    ensurePackageManagerForTools,
+    PackageManagerUnavailableError,
+    type PmTool,
 } from "./packageManagers.js";
 
 describe("parsePackageManagerField", () => {
@@ -139,5 +142,74 @@ describe("PM_TOOLS — which tools each PM needs", () => {
 
     it("bun is standalone — no Node", () => {
         expect(PM_TOOLS.bun.map((t) => t.label)).toEqual(["bun"]);
+    });
+});
+
+function fakeTool(label: string, installed: boolean, installSpy: string[]): PmTool {
+    return {
+        name: label,
+        label,
+        check: async () => installed,
+        install: async () => {
+            installSpy.push(label);
+        },
+        manualHint: `install ${label}`,
+    };
+}
+
+describe("ensurePackageManagerForTools", () => {
+    it("is a no-op and installs nothing when all tools are present", async () => {
+        const installed: string[] = [];
+        await ensurePackageManagerForTools("pnpm", [fakeTool("Node.js", true, installed)], {});
+        expect(installed).toEqual([]);
+    });
+
+    it("installs missing tools in order when confirm resolves true", async () => {
+        const installed: string[] = [];
+        const tools = [fakeTool("Node.js", false, installed), fakeTool("pnpm", false, installed)];
+        await ensurePackageManagerForTools("pnpm", tools, { confirm: async () => true });
+        expect(installed).toEqual(["Node.js", "pnpm"]);
+    });
+
+    it("auto-proceeds (installs) when no confirm callback is given", async () => {
+        const installed: string[] = [];
+        await ensurePackageManagerForTools("bun", [fakeTool("bun", false, installed)], {});
+        expect(installed).toEqual(["bun"]);
+    });
+
+    it("throws PackageManagerUnavailableError without installing when confirm is declined", async () => {
+        const installed: string[] = [];
+        const tools = [fakeTool("Node.js", false, installed)];
+        await expect(
+            ensurePackageManagerForTools("npm", tools, { confirm: async () => false }),
+        ).rejects.toBeInstanceOf(PackageManagerUnavailableError);
+        expect(installed).toEqual([]);
+    });
+
+    it("passes the plan (pm + only the missing tool labels) to confirm", async () => {
+        const installed: string[] = [];
+        const tools = [fakeTool("Node.js", true, installed), fakeTool("pnpm", false, installed)];
+        let seen: unknown;
+        await ensurePackageManagerForTools("pnpm", tools, {
+            confirm: async (plan) => {
+                seen = plan;
+                return true;
+            },
+        });
+        expect(seen).toEqual({ pm: "pnpm", toolsToInstall: ["pnpm"] });
+    });
+
+    it("propagates an install failure and does not run later tools", async () => {
+        const installed: string[] = [];
+        const node = fakeTool("Node.js", false, installed);
+        node.install = async () => {
+            throw new Error("network down");
+        };
+        const pnpm = fakeTool("pnpm", false, installed);
+        await expect(
+            ensurePackageManagerForTools("pnpm", [node, pnpm], { confirm: async () => true }),
+        ).rejects.toThrow("network down");
+        // pnpm comes after the failed Node install, so it must not have run.
+        expect(installed).toEqual([]);
     });
 });

--- a/src/utils/packageManagers.test.ts
+++ b/src/utils/packageManagers.test.ts
@@ -23,6 +23,7 @@ import {
     bunInstallCommand,
     PM_TOOLS,
     ensurePackageManagerForTools,
+    planPackageManagerForTools,
     PackageManagerUnavailableError,
     type PmTool,
 } from "./packageManagers.js";
@@ -211,5 +212,23 @@ describe("ensurePackageManagerForTools", () => {
         ).rejects.toThrow("network down");
         // pnpm comes after the failed Node install, so it must not have run.
         expect(installed).toEqual([]);
+    });
+});
+
+describe("planPackageManagerForTools", () => {
+    it("reports the pm and only the missing tool labels, installing nothing", async () => {
+        const installed: string[] = [];
+        const tools = [fakeTool("Node.js", true, installed), fakeTool("pnpm", false, installed)];
+        const plan = await planPackageManagerForTools("pnpm", tools);
+        expect(plan).toEqual({ pm: "pnpm", toolsToInstall: ["pnpm"] });
+        expect(installed).toEqual([]);
+    });
+
+    it("reports an empty toolsToInstall when everything is present", async () => {
+        const installed: string[] = [];
+        const plan = await planPackageManagerForTools("npm", [
+            fakeTool("Node.js", true, installed),
+        ]);
+        expect(plan.toolsToInstall).toEqual([]);
     });
 });

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -244,6 +244,24 @@ export async function ensurePackageManagerForTools(
     return pm;
 }
 
+/** Compute the install plan (which tools are missing) without installing. */
+export async function planPackageManagerForTools(
+    pm: PackageManager,
+    tools: PmTool[],
+): Promise<InstallPlan> {
+    const toolsToInstall: string[] = [];
+    for (const tool of tools) {
+        if (!(await tool.check())) toolsToInstall.push(tool.label);
+    }
+    return { pm, toolsToInstall };
+}
+
+/** Disk-backed variant: detect the PM and report its install plan. */
+export async function planPackageManager(projectDir: string): Promise<InstallPlan> {
+    const pm = detectProjectPackageManager(loadPackageManagerSnapshot(projectDir));
+    return planPackageManagerForTools(pm, PM_TOOLS[pm]);
+}
+
 /** Copy-paste manual instructions when we won't / can't auto-install. */
 export function packageManagerManualHint(pm: PackageManager, tools: PmTool[]): string {
     const hints = tools.map((t) => `${t.label}: ${t.manualHint ?? "(see official docs)"}`);

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -27,7 +27,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, resolve } from "node:path";
-import { detectPackageManager, PM_LOCKFILES, type PackageManager } from "./build/detect.js";
+import { detectPackageManager, PM_LOCKFILES_ALL, type PackageManager } from "./build/detect.js";
 import { detectReferencedPackageManagers } from "./mod/packageManager.js";
 import { runShell } from "./process.js";
 import { sudo } from "./sudo.js";
@@ -98,9 +98,15 @@ export function pnpmInstallCommand(): string {
     return "curl -fsSL https://get.pnpm.io/install.sh | sh -";
 }
 
-/** yarn's official path: corepack ships with Node and activates a yarn shim. */
-export function yarnInstallCommand(): string {
-    return "corepack enable && corepack prepare yarn@stable --activate";
+/**
+ * yarn's official path: corepack (ships with Node) writes a yarn shim. We point
+ * `--install-directory` at a user-owned dir instead of corepack's default (the
+ * Node bin dir), because on a NodeSource Linux install that dir is root-owned
+ * and a plain `corepack enable` hits EACCES. The caller prepends `installDir`
+ * to PATH so the shim resolves. Works on macOS and Linux without sudo.
+ */
+export function yarnInstallCommand(installDir: string): string {
+    return `corepack enable --install-directory "${installDir}" && corepack prepare yarn@stable --activate`;
 }
 
 /**
@@ -157,7 +163,14 @@ const YARN_TOOL: PmTool = {
     name: "yarn",
     label: "yarn",
     check: () => commandExists("yarn"),
-    install: (onData) => runShell(yarnInstallCommand(), onData, { description: "install yarn" }),
+    install: async (onData) => {
+        const binDir = resolve(homedir(), ".corepack/bin");
+        await runShell(yarnInstallCommand(binDir), onData, { description: "install yarn" });
+        // corepack wrote the yarn shim into our user-owned --install-directory
+        // (avoids EACCES on a root-owned NodeSource bin dir); expose it now so the
+        // very next step resolves `yarn`.
+        prependPath(binDir);
+    },
     manualHint: "https://yarnpkg.com/getting-started/install",
 };
 
@@ -167,8 +180,10 @@ const BUN_TOOL: PmTool = {
     check: () => commandExists("bun"),
     install: async (onData) => {
         await runShell(bunInstallCommand(), onData, { description: "install bun" });
-        // bun's installer drops the binary in ~/.bun/bin and edits shell rc files.
-        prependPath(resolve(homedir(), ".bun/bin"));
+        // bun's installer writes the binary to $BUN_INSTALL/bin (default ~/.bun),
+        // and edits shell rc files that don't reach the running process. Honor
+        // BUN_INSTALL (the installer does) and expose the bin dir now.
+        prependPath(resolve(process.env.BUN_INSTALL ?? resolve(homedir(), ".bun"), "bin"));
     },
     manualHint: "https://bun.sh/docs/installation",
 };
@@ -219,6 +234,23 @@ export class PackageManagerUnavailableError extends Error {
     }
 }
 
+// Process-wide single-flight for installs, keyed by tool name. `deploy-all`
+// runs builds for several apps concurrently in ONE process; when they share a
+// missing PM, every worker would otherwise launch the same installer at once
+// (two `get.pnpm.io | sh` runs, or racing `sudo apt`/`dpkg` locks). Collapsing
+// concurrent installs of the same tool onto one promise makes that safe.
+const inFlightInstalls = new Map<string, Promise<void>>();
+
+function installOnce(tool: PmTool, onData?: (line: string) => void): Promise<void> {
+    const existing = inFlightInstalls.get(tool.name);
+    if (existing) return existing;
+    const p = Promise.resolve(tool.install(onData)).finally(() => {
+        inFlightInstalls.delete(tool.name);
+    });
+    inFlightInstalls.set(tool.name, p);
+    return p;
+}
+
 /** Core orchestration, parameterized on the tool list so it is trivially testable. */
 export async function ensurePackageManagerForTools(
     pm: PackageManager,
@@ -239,7 +271,23 @@ export async function ensurePackageManagerForTools(
 
     for (const tool of missing) {
         opts.onData?.(`> installing ${tool.label}`);
-        await tool.install(opts.onData);
+        await installOnce(tool, opts.onData);
+    }
+
+    // Re-verify: an installer can exit 0 yet leave the binary off the running
+    // process's PATH (e.g. a prependPath target that doesn't match where the
+    // installer actually wrote). Surface that here with the manual hint, instead
+    // of letting the next build/setup step die with a confusing "command not
+    // found" — the exact scary-error class this whole flow exists to kill.
+    const stillMissing: PmTool[] = [];
+    for (const tool of missing) {
+        if (!(await tool.check())) stillMissing.push(tool);
+    }
+    if (stillMissing.length > 0) {
+        const names = stillMissing.map((t) => t.label).join(", ");
+        throw new Error(
+            `Installed ${names} but it is still not on PATH. ${packageManagerManualHint(pm, stillMissing)}`,
+        );
     }
     return pm;
 }
@@ -284,7 +332,7 @@ export function loadPackageManagerSnapshot(projectDir: string): PmSnapshot {
         }
     }
     const lockfiles = new Set<string>();
-    for (const name of Object.values(PM_LOCKFILES)) {
+    for (const name of PM_LOCKFILES_ALL) {
         if (existsSync(join(projectDir, name))) lockfiles.add(name);
     }
     const setupPath = join(projectDir, "setup.sh");

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -24,9 +24,10 @@
  * boundaries: `src/utils/deploy/*` and `src/utils/build/*`).
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { resolve } from "node:path";
-import { detectPackageManager, type PackageManager } from "./build/detect.js";
+import { join, resolve } from "node:path";
+import { detectPackageManager, PM_LOCKFILES, type PackageManager } from "./build/detect.js";
 import { detectReferencedPackageManagers } from "./mod/packageManager.js";
 import { runShell } from "./process.js";
 import { sudo } from "./sudo.js";
@@ -183,3 +184,108 @@ export const PM_TOOLS: Record<PackageManager, PmTool[]> = {
     yarn: [NODE_TOOL, YARN_TOOL],
     bun: [BUN_TOOL],
 };
+
+/** What `ensurePackageManager` will install, shown to the user before it does. */
+export interface InstallPlan {
+    pm: PackageManager;
+    /** Labels of the tools that are missing and will be installed. */
+    toolsToInstall: string[];
+}
+
+export interface EnsurePackageManagerOptions {
+    /** Per-line install output sink. */
+    onData?: (line: string) => void;
+    /**
+     * Asked once before installing, with the plan. Return true to proceed.
+     * Omitted → auto-proceed (the non-interactive posture).
+     */
+    confirm?: (plan: InstallPlan) => Promise<boolean>;
+}
+
+/**
+ * Thrown when the user declines the install at the confirmation prompt. Carries
+ * the manual-install hint as its message. This is a SOFT outcome — callers
+ * render it as a gentle "install it yourself" notice, not an error row.
+ *
+ * Install-time failures (a curl/apt step exiting non-zero) and the
+ * unsupported-platform case are NOT this class: a tool's `install()` rejects
+ * with a plain Error carrying the captured log / manual hint, which callers
+ * surface as a hard failure. Keep the two paths distinct.
+ */
+export class PackageManagerUnavailableError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "PackageManagerUnavailableError";
+    }
+}
+
+/** Core orchestration, parameterized on the tool list so it is trivially testable. */
+export async function ensurePackageManagerForTools(
+    pm: PackageManager,
+    tools: PmTool[],
+    opts: EnsurePackageManagerOptions,
+): Promise<PackageManager> {
+    const missing: PmTool[] = [];
+    for (const tool of tools) {
+        if (!(await tool.check())) missing.push(tool);
+    }
+    if (missing.length === 0) return pm;
+
+    const plan: InstallPlan = { pm, toolsToInstall: missing.map((t) => t.label) };
+    const proceed = opts.confirm ? await opts.confirm(plan) : true;
+    if (!proceed) {
+        throw new PackageManagerUnavailableError(packageManagerManualHint(pm, missing));
+    }
+
+    for (const tool of missing) {
+        opts.onData?.(`> installing ${tool.label}`);
+        await tool.install(opts.onData);
+    }
+    return pm;
+}
+
+/** Copy-paste manual instructions when we won't / can't auto-install. */
+export function packageManagerManualHint(pm: PackageManager, tools: PmTool[]): string {
+    const hints = tools.map((t) => `${t.label}: ${t.manualHint ?? "(see official docs)"}`);
+    return `This project uses ${pm}. Install it manually, then re-run:\n${hints.join("\n")}`;
+}
+
+/** Read the PM-detection snapshot from a project directory. */
+export function loadPackageManagerSnapshot(projectDir: string): PmSnapshot {
+    const pkgPath = join(projectDir, "package.json");
+    let packageManagerField: string | null = null;
+    if (existsSync(pkgPath)) {
+        try {
+            const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { packageManager?: string };
+            packageManagerField = pkg.packageManager ?? null;
+        } catch {
+            // Unreadable/malformed package.json — fall through to lockfile/script.
+            // Detection degrades gracefully here on purpose; contrast
+            // build/runner.ts::loadDetectInput, which parses unguarded so a
+            // broken manifest fails the build loudly.
+        }
+    }
+    const lockfiles = new Set<string>();
+    for (const name of Object.values(PM_LOCKFILES)) {
+        if (existsSync(join(projectDir, name))) lockfiles.add(name);
+    }
+    const setupPath = join(projectDir, "setup.sh");
+    const setupScript = existsSync(setupPath) ? readFileSync(setupPath, "utf8") : null;
+    return { packageManagerField, lockfiles, setupScript };
+}
+
+/**
+ * Public entry point: detect the project's PM from disk and ensure it (and Node
+ * when required) is installed. Throws PackageManagerUnavailableError when the
+ * user declines the prompt (a soft outcome); rejects with a plain Error
+ * carrying the captured install log when an install step fails or the platform
+ * is unsupported.
+ */
+export async function ensurePackageManager(
+    projectDir: string,
+    opts: EnsurePackageManagerOptions = {},
+): Promise<PackageManager> {
+    const snapshot = loadPackageManagerSnapshot(projectDir);
+    const pm = detectProjectPackageManager(snapshot);
+    return ensurePackageManagerForTools(pm, PM_TOOLS[pm], opts);
+}

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /**
- * Package-manager detection — React-free on purpose.
+ * Package-manager detection and install orchestration — React-free on purpose.
  *
  * The interactive parts of the auto-install flow (the confirmation prompt and
  * the streaming install log) are driven by the TUI layer through callbacks, so
@@ -24,9 +24,13 @@
  * boundaries: `src/utils/deploy/*` and `src/utils/build/*`).
  */
 
+import { homedir, platform } from "node:os";
+import { resolve } from "node:path";
 import { detectPackageManager, type PackageManager } from "./build/detect.js";
 import { detectReferencedPackageManagers } from "./mod/packageManager.js";
+import { runShell } from "./process.js";
 import { sudo } from "./sudo.js";
+import { commandExists, prependPath, type ToolStep } from "./toolchain.js";
 
 export type { PackageManager };
 
@@ -106,3 +110,76 @@ export function yarnInstallCommand(): string {
 export function bunInstallCommand(): string {
     return "curl -fsSL https://bun.sh/install | bash";
 }
+
+/** A toolchain step plus a short label shown in the confirmation prompt. */
+export interface PmTool extends ToolStep {
+    /** Human label for the confirmation prompt (e.g. "Node.js", "pnpm"). */
+    label: string;
+}
+
+const NODE_TOOL: PmTool = {
+    name: "node",
+    label: "Node.js",
+    check: () => commandExists("node"),
+    install: async (onData) => {
+        const cmd = nodeInstallCommand(platform(), await commandExists("brew"));
+        if (!cmd) {
+            throw new Error(
+                "Cannot install Node.js automatically on this platform — install from https://nodejs.org/en/download",
+            );
+        }
+        await runShell(cmd, onData, { description: "install Node.js" });
+    },
+    manualHint: "https://nodejs.org/en/download",
+};
+
+const PNPM_TOOL: PmTool = {
+    name: "pnpm",
+    label: "pnpm",
+    check: () => commandExists("pnpm"),
+    install: async (onData) => {
+        await runShell(pnpmInstallCommand(), onData, { description: "install pnpm" });
+        // get.pnpm.io writes PNPM_HOME and edits shell rc files, but those edits
+        // don't reach the running process. Expose the bin dir now so the very
+        // next step can resolve `pnpm`. The installer's default PNPM_HOME is
+        // platform-specific: ~/Library/pnpm on macOS, ~/.local/share/pnpm on Linux.
+        const pnpmHome =
+            platform() === "darwin"
+                ? resolve(homedir(), "Library/pnpm")
+                : resolve(homedir(), ".local/share/pnpm");
+        prependPath(process.env.PNPM_HOME ?? pnpmHome);
+    },
+    manualHint: "https://pnpm.io/installation",
+};
+
+const YARN_TOOL: PmTool = {
+    name: "yarn",
+    label: "yarn",
+    check: () => commandExists("yarn"),
+    install: (onData) => runShell(yarnInstallCommand(), onData, { description: "install yarn" }),
+    manualHint: "https://yarnpkg.com/getting-started/install",
+};
+
+const BUN_TOOL: PmTool = {
+    name: "bun",
+    label: "bun",
+    check: () => commandExists("bun"),
+    install: async (onData) => {
+        await runShell(bunInstallCommand(), onData, { description: "install bun" });
+        // bun's installer drops the binary in ~/.bun/bin and edits shell rc files.
+        prependPath(resolve(homedir(), ".bun/bin"));
+    },
+    manualHint: "https://bun.sh/docs/installation",
+};
+
+/**
+ * Ordered list of tools to ensure for each PM. Order matters: Node must be
+ * present before yarn (corepack ships with Node) and before pnpm (build scripts
+ * call `node`). bun is its own runtime and needs nothing else.
+ */
+export const PM_TOOLS: Record<PackageManager, PmTool[]> = {
+    npm: [NODE_TOOL],
+    pnpm: [NODE_TOOL, PNPM_TOOL],
+    yarn: [NODE_TOOL, YARN_TOOL],
+    bun: [BUN_TOOL],
+};

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -1,0 +1,71 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Package-manager detection — React-free on purpose.
+ *
+ * The interactive parts of the auto-install flow (the confirmation prompt and
+ * the streaming install log) are driven by the TUI layer through callbacks, so
+ * none of the decision logic here imports React/Ink. That keeps this module
+ * reusable from the build/deploy SDK surface that RevX consumes from a
+ * WebContainer, which must never pull in React/Ink (see the CLI surface
+ * boundaries: `src/utils/deploy/*` and `src/utils/build/*`).
+ */
+
+import { detectPackageManager, type PackageManager } from "./build/detect.js";
+import { detectReferencedPackageManagers } from "./mod/packageManager.js";
+
+export type { PackageManager };
+
+/** Parse a package.json `packageManager` field ("pnpm@9.1.0") to a known PM. */
+export function parsePackageManagerField(field: string | null): PackageManager | null {
+    if (!field) return null;
+    const name = field.split("@")[0]?.trim();
+    if (name === "pnpm" || name === "yarn" || name === "bun" || name === "npm") return name;
+    return null;
+}
+
+/** Inputs to PM detection — a filesystem-free snapshot so the choice is pure. */
+export interface PmSnapshot {
+    /** Raw `packageManager` field from package.json, or null. */
+    packageManagerField: string | null;
+    /** Lockfile basenames present in the project root. */
+    lockfiles: Set<string>;
+    /** Contents of setup.sh, or null when absent. */
+    setupScript: string | null;
+}
+
+/**
+ * Pick the PM the project uses. Precedence: packageManager field (most
+ * authoritative) > lockfile > setup.sh reference > npm default.
+ *
+ * The setup.sh branch takes the first manager `detectReferencedPackageManagers`
+ * returns — ties resolve to that helper's `MANAGERS` table order (npm, pnpm,
+ * bun, yarn), not the order they appear in the script. We re-validate it through
+ * `parsePackageManagerField` so this stays type-safe even if that helper ever
+ * grows a `bin` outside the `PackageManager` union.
+ */
+export function detectProjectPackageManager(snap: PmSnapshot): PackageManager {
+    const fromField = parsePackageManagerField(snap.packageManagerField);
+    if (fromField) return fromField;
+    if (snap.lockfiles.size > 0) return detectPackageManager(snap.lockfiles);
+    if (snap.setupScript) {
+        const fromScript = parsePackageManagerField(
+            detectReferencedPackageManagers(snap.setupScript)[0] ?? null,
+        );
+        if (fromScript) return fromScript;
+    }
+    return "npm";
+}

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -26,6 +26,7 @@
 
 import { detectPackageManager, type PackageManager } from "./build/detect.js";
 import { detectReferencedPackageManagers } from "./mod/packageManager.js";
+import { sudo } from "./sudo.js";
 
 export type { PackageManager };
 
@@ -68,4 +69,40 @@ export function detectProjectPackageManager(snap: PmSnapshot): PackageManager {
         if (fromScript) return fromScript;
     }
     return "npm";
+}
+
+/**
+ * Shell command to install Node.js, or null when we have no controllable
+ * non-interactive path on this platform. NodeSource (not apt's `nodejs`) on
+ * Linux because Debian/Ubuntu ship a years-old Node that breaks modern builds.
+ */
+export function nodeInstallCommand(plat: NodeJS.Platform, hasBrew: boolean): string | null {
+    if (plat === "darwin" && hasBrew) return "brew install node";
+    if (plat === "linux") {
+        return `curl -fsSL https://deb.nodesource.com/setup_lts.x | ${sudo()}bash - && ${sudo()}apt install -y nodejs`;
+    }
+    return null;
+}
+
+/**
+ * pnpm's official standalone installer (manages its own runtime). Note: pnpm's
+ * script does not support Intel Macs (`darwin-x64`); on that host the install
+ * surfaces pnpm's own error plus the manual hint rather than succeeding.
+ */
+export function pnpmInstallCommand(): string {
+    return "curl -fsSL https://get.pnpm.io/install.sh | sh -";
+}
+
+/** yarn's official path: corepack ships with Node and activates a yarn shim. */
+export function yarnInstallCommand(): string {
+    return "corepack enable && corepack prepare yarn@stable --activate";
+}
+
+/**
+ * bun's official standalone installer (its own runtime, no Node needed). On
+ * Linux it requires `unzip` on PATH; bare containers without it surface bun's
+ * own "unzip is required" error plus the manual hint.
+ */
+export function bunInstallCommand(): string {
+    return "curl -fsSL https://bun.sh/install | bash";
 }

--- a/src/utils/sudo.ts
+++ b/src/utils/sudo.ts
@@ -1,0 +1,25 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Privilege prefix for shell install commands. A pure leaf module on purpose:
+ * shared by `toolchain.ts` (login prereqs) and `packageManagers.ts` (which must
+ * stay importable from the React-free build/deploy SDK surface, so it can't pull
+ * in toolchain.ts's process-spawning machinery).
+ */
+
+/** Returns "sudo " when not already running as root, empty string otherwise. */
+export const sudo = (): string =>
+    typeof process.getuid === "function" && process.getuid() === 0 ? "" : "sudo ";

--- a/src/utils/toolchain.ts
+++ b/src/utils/toolchain.ts
@@ -18,9 +18,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { arch, homedir, platform } from "node:os";
 import { runShell as runPiped } from "./process.js";
-
-/** Returns "sudo " when not already running as root, empty string otherwise. */
-const sudo = () => (typeof process.getuid === "function" && process.getuid() === 0 ? "" : "sudo ");
+import { sudo } from "./sudo.js";
 
 /** Async exec — resolves with stdout, rejects on non-zero exit. */
 function run(cmd: string, opts?: { shell?: string }): Promise<string> {


### PR DESCRIPTION
## Summary

When `playground mod` (and `playground deploy`/`build`) needs a JavaScript package manager the user doesn't have, the CLI now detects which one the project uses (pnpm/yarn/bun/npm) and installs it — plus Node.js when needed — for macOS/Linux, instead of failing with a confusing "command not found".

- **`playground mod`**: after downloading an app's source, detects the project's package manager and, when it (or Node.js) is missing, asks once before installing, then runs `setup.sh`. Declining is a soft outcome with a manual-install hint.
- **`playground deploy` / `build`**: a missing manager is installed automatically as part of the build step (output streamed). Non-interactive runs install without prompting.

### How it works
- Detection precedence: `packageManager` field → lockfile → `setup.sh` reference → npm default (`src/utils/packageManagers.ts`).
- Official per-PM installers: Node via brew (macOS) / NodeSource (Linux); pnpm via `get.pnpm.io`; yarn via corepack (into a user-owned `--install-directory` to avoid EACCES on a root-owned Node bin dir); bun via `bun.sh/install`.
- React-free module so it's reusable from the build/deploy SDK surface; the confirmation prompt and streaming log are driven by the TUI layer via callbacks.
- Installs are single-flighted by tool name so concurrent `deploy-all` builds don't race the same installer, and each tool is re-checked after install so a PATH mismatch fails with an actionable hint rather than later.

### Notes / scope
- macOS + Linux only (matches the existing toolchain); Windows / unsupported platforms get a manual-install message.
- `deploy`/`build` auto-install without an interactive prompt; only `mod` prompts. Non-TTY `sudo apt`/NodeSource on Linux requires root or passwordless sudo (same as the existing login toolchain installs).

## Test Plan
- [x] `pnpm typecheck`, `pnpm format:check`, `pnpm lint:license` clean
- [x] `pnpm test` — 973 passing (unit coverage for detection precedence, platform-aware install command builders, the orchestrator's confirm/auto-proceed/decline/failure-propagation/single-flight/post-install-recheck paths, the bun.lock detection, and the `runCommand` live-PATH behavior)
- [ ] Manual: `playground mod` on a pnpm project without pnpm installed (TTY) prompts once, installs Node + pnpm, then runs setup.sh
- [ ] Manual: same with no TTY auto-installs; declining shows the manual-install hint and exits 0