### PR TITLE
chore(funder): source dedicated funder seed from env secret

### DIFF
--- a/.changeset/funder-seed-env.md
+++ b/.changeset/funder-seed-env.md
@@ -1,0 +1,9 @@
+---
+"playground-cli": patch
+---
+
+The dedicated testnet funder seed is no longer hardcoded in the binary. It is
+read from the `MASTER_FUNDER_SEED` environment variable (CI injects it from a
+repository secret); when unset, funding falls back to Alice alone. This affects
+only the E2E suite and operator tooling — no end-user command funds from this
+chain.

--- a/.changeset/funder-seed-env.md
+++ b/.changeset/funder-seed-env.md
@@ -4,6 +4,7 @@
 
 The dedicated testnet funder seed is no longer hardcoded in the binary. It is
 read from the `MASTER_FUNDER_SEED` environment variable (CI injects it from a
-repository secret); when unset, funding falls back to Alice alone. This affects
-only the E2E suite and operator tooling — no end-user command funds from this
-chain.
+repository secret); when unset, funding falls back to Alice alone. The dedicated
+funder is now the primary account (drawn down ahead of public Alice) and is
+derived at the bare root (empty derivation path). This affects only the E2E
+suite and operator tooling — no end-user command funds from this chain.

--- a/.github/workflows/e2e-post-release.yml
+++ b/.github/workflows/e2e-post-release.yml
@@ -90,6 +90,9 @@ jobs:
               env:
                   DOT_TAG: e2e-ci-post-release
                   DOT_TELEMETRY: "1"
+                  # Dedicated-funder seed for globalSetup's SIGNER top-up
+                  # fallback. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Upload forensic artefacts
               if: always()

--- a/.github/workflows/e2e-post-release.yml
+++ b/.github/workflows/e2e-post-release.yml
@@ -90,8 +90,9 @@ jobs:
               env:
                   DOT_TAG: e2e-ci-post-release
                   DOT_TELEMETRY: "1"
-                  # Dedicated-funder seed for globalSetup's SIGNER top-up
-                  # fallback. Absent → Alice only.
+                  # Dedicated-funder seed — the primary account globalSetup
+                  # tops up SIGNER from, ahead of the Alice fallback. Absent →
+                  # Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Upload forensic artefacts

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -79,6 +79,9 @@ jobs:
                   DOT_E2E_BINARY: ${{ github.workspace }}/bin/dot-linux-x64
                   DOT_TAG: e2e-ci-release
                   DOT_TELEMETRY: "1"
+                  # Dedicated-funder seed for globalSetup's SIGNER top-up
+                  # fallback. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Upload forensic artefacts
               if: always()

--- a/.github/workflows/e2e-release.yml
+++ b/.github/workflows/e2e-release.yml
@@ -79,8 +79,9 @@ jobs:
                   DOT_E2E_BINARY: ${{ github.workspace }}/bin/dot-linux-x64
                   DOT_TAG: e2e-ci-release
                   DOT_TELEMETRY: "1"
-                  # Dedicated-funder seed for globalSetup's SIGNER top-up
-                  # fallback. Absent → Alice only.
+                  # Dedicated-funder seed — the primary account globalSetup
+                  # tops up SIGNER from, ahead of the Alice fallback. Absent →
+                  # Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Upload forensic artefacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,8 +70,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
-                  # Seed for the dedicated funder, the fallback globalSetup uses
-                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  # Seed for the dedicated funder, the primary account
+                  # globalSetup tops up SIGNER from (drawn down before public
+                  # Alice, the fallback). Absent → Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail
@@ -168,8 +169,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
-                  # Seed for the dedicated funder, the fallback globalSetup uses
-                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  # Seed for the dedicated funder, the primary account
+                  # globalSetup tops up SIGNER from (drawn down before public
+                  # Alice, the fallback). Absent → Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail
@@ -231,8 +233,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
-                  # Seed for the dedicated funder, the fallback globalSetup uses
-                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  # Seed for the dedicated funder, the primary account
+                  # globalSetup tops up SIGNER from (drawn down before public
+                  # Alice, the fallback). Absent → Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
                   # nightly-deploy-moddable creates a fresh public repo in
                   # paritytech/ each run + pushes the fixture into it. Other
@@ -315,8 +318,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
-                  # Seed for the dedicated funder, the fallback globalSetup uses
-                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  # Seed for the dedicated funder, the primary account
+                  # globalSetup tops up SIGNER from (drawn down before public
+                  # Alice, the fallback). Absent → Alice only.
                   MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,6 +70,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+                  # Seed for the dedicated funder, the fallback globalSetup uses
+                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail
               if: failure()
@@ -165,6 +168,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+                  # Seed for the dedicated funder, the fallback globalSetup uses
+                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail
               if: failure()
@@ -225,6 +231,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+                  # Seed for the dedicated funder, the fallback globalSetup uses
+                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
                   # nightly-deploy-moddable creates a fresh public repo in
                   # paritytech/ each run + pushes the fixture into it. Other
                   # cells in this matrix don't consume GH_TOKEN so setting it
@@ -306,6 +315,9 @@ jobs:
                   DOT_DEPLOY_VERBOSE: "1"
                   DOT_TAG: ${{ steps.setup.outputs.tag }}
                   DOT_TELEMETRY: "1"
+                  # Seed for the dedicated funder, the fallback globalSetup uses
+                  # to top up SIGNER once Alice drains. Absent → Alice only.
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
 
             - name: Surface failure detail
               if: failure()

--- a/.github/workflows/funder-balance-check.yml
+++ b/.github/workflows/funder-balance-check.yml
@@ -38,6 +38,10 @@ jobs:
               # `continue-on-error` so the follow-up step can react to low /
               # error exits instead of the job being marked failed and skipping.
               continue-on-error: true
+              env:
+                  # Seed for the dedicated funder. Without it the probe can't
+                  # derive the address and exits 2 (treated as "low").
+                  MASTER_FUNDER_SEED: ${{ secrets.MASTER_FUNDER_SEED }}
               run: |
                   bun run scripts/check-funder-balance.ts | tee balance.txt
                   echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"

--- a/docs/e2e-bootstrap.md
+++ b/docs/e2e-bootstrap.md
@@ -57,8 +57,15 @@ After a registry-contract redeploy, the next CI run restores them automatically.
 
 | Secret | Required for | Status |
 |---|---|---|
-| `MASTER_FUNDER_SEED` | SIGNER top-up in globalSetup | Required — must be set |
+| `MASTER_FUNDER_SEED` | Dedicated-funder seed — SIGNER top-up in globalSetup + the Funder Balance Check job | Required — must be set |
 | `SENTRY_AUTH_TOKEN` | Telemetry verification (not yet implemented) | Optional |
+
+`MASTER_FUNDER_SEED` is a BIP-39 mnemonic read at runtime by
+`src/utils/account/funder.ts` (env var, never hardcoded). It derives the
+dedicated funder at `//0`, which is the **primary** funder — the chain draws it
+down first and falls back to public Alice only when it's empty. When unset the
+chain is just Alice — fine for offline/local runs, but CI must set it. Provide
+it to local runs with `export MASTER_FUNDER_SEED=…`.
 
 `GITHUB_TOKEN` (auto-provided) is used by the report job and cleanup cron.
 
@@ -103,11 +110,14 @@ bun tools/register-e2e-fixtures.ts --suri "//MyStagingSigner"
 
 Nothing to do manually. `globalSetup` (`e2e/cli/setup/fund.ts`) and
 `tools/register-e2e-fixtures.ts` both auto-top-up when free balance is below
-500 PAS. The top-up source is `MASTER_FUNDER_SEED` (GitHub secret) or the
-CLI's built-in funder derivation locally.
+500 PAS — first from the dedicated funder derived from `MASTER_FUNDER_SEED`
+(GitHub secret in CI; `export MASTER_FUNDER_SEED=…` locally), then from public
+Alice as the fallback.
 
-If `MASTER_FUNDER_SEED` itself is empty, re-fund the parent funder account on
-Paseo and update the secret.
+If both the dedicated funder and Alice are empty, re-fund the dedicated funder
+account (the `//0`-derived address — run `bun run scripts/check-funder-balance.ts`
+with the seed exported to print it) on Paseo, and update the secret if the seed
+itself changed.
 
 ### Registry contract redeployed (all domains wiped)
 

--- a/docs/e2e-bootstrap.md
+++ b/docs/e2e-bootstrap.md
@@ -62,10 +62,11 @@ After a registry-contract redeploy, the next CI run restores them automatically.
 
 `MASTER_FUNDER_SEED` is a BIP-39 mnemonic read at runtime by
 `src/utils/account/funder.ts` (env var, never hardcoded). It derives the
-dedicated funder at `//0`, which is the **primary** funder — the chain draws it
-down first and falls back to public Alice only when it's empty. When unset the
-chain is just Alice — fine for offline/local runs, but CI must set it. Provide
-it to local runs with `export MASTER_FUNDER_SEED=…`.
+dedicated funder at the bare root (empty derivation path), which is the
+**primary** funder — the chain draws it down first and falls back to public
+Alice only when it's empty. When unset the chain is just Alice — fine for
+offline/local runs, but CI must set it. Provide it to local runs with
+`export MASTER_FUNDER_SEED=…`.
 
 `GITHUB_TOKEN` (auto-provided) is used by the report job and cleanup cron.
 
@@ -115,7 +116,7 @@ Nothing to do manually. `globalSetup` (`e2e/cli/setup/fund.ts`) and
 Alice as the fallback.
 
 If both the dedicated funder and Alice are empty, re-fund the dedicated funder
-account (the `//0`-derived address — run `bun run scripts/check-funder-balance.ts`
+account (the bare-root address — run `bun run scripts/check-funder-balance.ts`
 with the seed exported to print it) on Paseo, and update the secret if the seed
 itself changed.
 

--- a/scripts/check-funder-balance.ts
+++ b/scripts/check-funder-balance.ts
@@ -41,14 +41,21 @@ function formatPas(planck: bigint): string {
 }
 
 async function main(): Promise<number> {
+    const address = DEDICATED_FUNDER_ADDRESS;
+    if (!address) {
+        console.error(
+            "MASTER_FUNDER_SEED is not set — cannot derive the dedicated funder address. " +
+                "Export the funder seed (the MASTER_FUNDER_SEED repository secret) and re-run.",
+        );
+        return 2;
+    }
     const client = await getConnection();
     try {
-        const account = await client.assetHub.query.System.Account.getValue(
-            DEDICATED_FUNDER_ADDRESS,
-            { at: "best" },
-        );
+        const account = await client.assetHub.query.System.Account.getValue(address, {
+            at: "best",
+        });
         const free = account.data.free;
-        console.log(`address=${DEDICATED_FUNDER_ADDRESS}`);
+        console.log(`address=${address}`);
         console.log(`balance=${formatPas(free)}`);
         console.log(`balance_planck=${free}`);
         console.log(`threshold=${formatPas(THRESHOLD_PLANCK)}`);

--- a/src/utils/account/funder.test.ts
+++ b/src/utils/account/funder.test.ts
@@ -1,0 +1,74 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Pins the `MASTER_FUNDER_SEED` gating of the dedicated funder. The seed is
+ * read at module load, so each case sets/clears the env var, resets the module
+ * registry, and re-imports `./funder.js` to re-derive the chain.
+ *
+ * Any valid BIP-39 phrase works; we reuse the well-known substrate dev phrase
+ * (also used in other test files) purely because it is a guaranteed-valid
+ * mnemonic — it is NOT the real funder seed, which only ever comes from the
+ * secret.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const VALID_MNEMONIC = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+afterEach(() => {
+    delete process.env.MASTER_FUNDER_SEED;
+    vi.resetModules();
+});
+
+describe("FUNDER_CHAIN dedicated-funder gating", () => {
+    it("omits the dedicated funder when MASTER_FUNDER_SEED is unset", async () => {
+        delete process.env.MASTER_FUNDER_SEED;
+        vi.resetModules();
+        const { FUNDER_CHAIN, DEDICATED_FUNDER_ADDRESS } = await import("./funder.js");
+
+        expect(FUNDER_CHAIN.map((f) => f.name)).toEqual(["Alice"]);
+        expect(DEDICATED_FUNDER_ADDRESS).toBeNull();
+    });
+
+    it("prepends the dedicated funder (primary) ahead of Alice when MASTER_FUNDER_SEED is set", async () => {
+        process.env.MASTER_FUNDER_SEED = VALID_MNEMONIC;
+        vi.resetModules();
+        const { FUNDER_CHAIN, DEDICATED_FUNDER_ADDRESS } = await import("./funder.js");
+
+        // Dedicated funder is tried first; Alice is the fallback.
+        expect(FUNDER_CHAIN.map((f) => f.name)).toEqual(["dedicated", "Alice"]);
+        // Address is derived from the seed and matches the leading chain entry.
+        expect(DEDICATED_FUNDER_ADDRESS).toMatch(/^5/);
+        expect(FUNDER_CHAIN[0]?.address).toBe(DEDICATED_FUNDER_ADDRESS);
+    });
+
+    it("trims surrounding whitespace before deriving", async () => {
+        process.env.MASTER_FUNDER_SEED = `  ${VALID_MNEMONIC}  `;
+        vi.resetModules();
+        const { DEDICATED_FUNDER_ADDRESS } = await import("./funder.js");
+
+        expect(DEDICATED_FUNDER_ADDRESS).not.toBeNull();
+    });
+
+    it("treats a blank MASTER_FUNDER_SEED as unset", async () => {
+        process.env.MASTER_FUNDER_SEED = "   ";
+        vi.resetModules();
+        const { FUNDER_CHAIN, DEDICATED_FUNDER_ADDRESS } = await import("./funder.js");
+
+        expect(FUNDER_CHAIN.map((f) => f.name)).toEqual(["Alice"]);
+        expect(DEDICATED_FUNDER_ADDRESS).toBeNull();
+    });
+});

--- a/src/utils/account/funder.test.ts
+++ b/src/utils/account/funder.test.ts
@@ -28,6 +28,13 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 
 const VALID_MNEMONIC = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
 
+// Frozen bare-root (empty derivation path) address of VALID_MNEMONIC. Pins the
+// derivation path so a regression back to `//0` (or any other junction) fails
+// loudly: the funder is funded at the bare root, and a path drift would silently
+// move the signer to an unfunded account. `//0` of this mnemonic is a DIFFERENT
+// address (5D34dL5…), so this vector genuinely guards the path.
+const VALID_MNEMONIC_BARE_ROOT = "5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV";
+
 afterEach(() => {
     delete process.env.MASTER_FUNDER_SEED;
     vi.resetModules();
@@ -50,8 +57,9 @@ describe("FUNDER_CHAIN dedicated-funder gating", () => {
 
         // Dedicated funder is tried first; Alice is the fallback.
         expect(FUNDER_CHAIN.map((f) => f.name)).toEqual(["dedicated", "Alice"]);
-        // Address is derived from the seed and matches the leading chain entry.
-        expect(DEDICATED_FUNDER_ADDRESS).toMatch(/^5/);
+        // Derived at the bare root (empty path) and matches the leading entry.
+        // The frozen vector pins the derivation path against `//0` regressions.
+        expect(DEDICATED_FUNDER_ADDRESS).toBe(VALID_MNEMONIC_BARE_ROOT);
         expect(FUNDER_CHAIN[0]?.address).toBe(DEDICATED_FUNDER_ADDRESS);
     });
 

--- a/src/utils/account/funder.ts
+++ b/src/utils/account/funder.ts
@@ -15,12 +15,23 @@
 
 /**
  * Testnet funder accounts used to top up users and session keys on Paseo
- * Asset Hub. We try Alice first (public dev account — free tokens while she
- * lasts) and fall back to a dedicated account whose seed is embedded here
- * (obscure, not one of the well-known dev dropdowns in polkadot.js Apps, so
- * random drainers don't target it the way they target Alice).
+ * Asset Hub. We try the dedicated account first — our own controlled funder
+ * whose seed is supplied at runtime via the `MASTER_FUNDER_SEED` environment
+ * variable (NOT one of the well-known dev dropdowns in polkadot.js Apps, so
+ * random drainers don't target it the way they target Alice) — and fall back
+ * to the public Alice dev account (free tokens while she lasts).
  *
- * Goes away on mainnet: users fund themselves and this module is retired.
+ * The seed is deliberately NOT hardcoded so it can never be extracted from the
+ * published binary. CI injects it from the `MASTER_FUNDER_SEED` repository
+ * secret; locally an operator exports it before running the E2E suite or the
+ * funder tooling. The funder chain is exercised ONLY by the E2E suite and
+ * operator tooling — no end-user command funds from it — so when the env var
+ * is absent the dedicated funder is simply dropped from the chain and
+ * everything still works off Alice.
+ *
+ * Even when set this is not a hard security boundary: anyone holding the seed
+ * can spend it. Acceptable on testnet; the whole module is retired on mainnet
+ * where users fund themselves.
  */
 
 import type { PolkadotSigner } from "polkadot-api";
@@ -30,14 +41,14 @@ import { ss58Encode } from "@parity/product-sdk-address";
 import { type Env, getChainConfig } from "../../config.js";
 
 /**
- * Dedicated testnet funder mnemonic. Obscure-by-convention (not in any
- * public dropdown), not a security boundary — anyone with this CLI binary
- * can extract it. Acceptable on testnet; replace for mainnet.
+ * Dedicated testnet funder, derived at `//0` from the `MASTER_FUNDER_SEED`
+ * env var (a BIP-39 mnemonic). `null` when the var is unset/blank — callers
+ * then fall back to Alice alone. Derived once at module load so we don't
+ * re-run BIP-39 + sr25519 on every access.
  */
-const DEDICATED_FUNDER_MNEMONIC =
-    "bargain obey warm sing goose glimpse kind repeat grape orchard reason rely";
-
-const dedicated = seedToAccount(DEDICATED_FUNDER_MNEMONIC, "//0");
+const dedicatedSeed = process.env.MASTER_FUNDER_SEED?.trim();
+const dedicated = dedicatedSeed ? seedToAccount(dedicatedSeed, "//0") : null;
+const dedicatedAddress = dedicated ? ss58Encode(dedicated.publicKey) : null;
 
 export interface Funder {
     /** Log-friendly name — included in `AllFundersExhaustedError.tried`. */
@@ -50,24 +61,35 @@ export interface Funder {
 
 /**
  * Ordered chain of funders. Callers walk this list and pick the first funder
- * whose free balance ≥ required amount. Public Alice comes first so the
- * dedicated account only gets drawn down once she's drained.
+ * whose free balance ≥ required amount. The dedicated funder (our own
+ * controlled account) comes first so we draw it down before touching public
+ * Alice — she's a shared dev account others drain unpredictably, so she's the
+ * fallback, not the primary. The dedicated funder is present only when
+ * `MASTER_FUNDER_SEED` is configured; without it the chain is Alice-only.
  */
 export const FUNDER_CHAIN: readonly Funder[] = [
+    ...(dedicated
+        ? [
+              {
+                  name: "dedicated",
+                  address: dedicatedAddress as string,
+                  signer: dedicated.signer,
+              },
+          ]
+        : []),
     {
         name: "Alice",
         address: ss58Encode(getDevPublicKey("Alice")),
         signer: createDevSigner("Alice"),
     },
-    {
-        name: "dedicated",
-        address: ss58Encode(dedicated.publicKey),
-        signer: dedicated.signer,
-    },
 ];
 
-/** Convenience: public address of the dedicated funder. Used by the balance-check CI job. */
-export const DEDICATED_FUNDER_ADDRESS = FUNDER_CHAIN[1].address;
+/**
+ * Public address of the dedicated funder, or `null` when `MASTER_FUNDER_SEED`
+ * is unset. Used by the balance-check CI job, which always runs with the
+ * secret configured.
+ */
+export const DEDICATED_FUNDER_ADDRESS: string | null = dedicatedAddress;
 
 /**
  * Faucet URL for the env, pre-filled with the user's address — one click to

--- a/src/utils/account/funder.ts
+++ b/src/utils/account/funder.ts
@@ -41,13 +41,13 @@ import { ss58Encode } from "@parity/product-sdk-address";
 import { type Env, getChainConfig } from "../../config.js";
 
 /**
- * Dedicated testnet funder, derived at `//0` from the `MASTER_FUNDER_SEED`
- * env var (a BIP-39 mnemonic). `null` when the var is unset/blank — callers
- * then fall back to Alice alone. Derived once at module load so we don't
- * re-run BIP-39 + sr25519 on every access.
+ * Dedicated testnet funder, derived at the bare root (empty derivation path)
+ * from the `MASTER_FUNDER_SEED` env var (a BIP-39 mnemonic). `null` when the
+ * var is unset/blank — callers then fall back to Alice alone. Derived once at
+ * module load so we don't re-run BIP-39 + sr25519 on every access.
  */
 const dedicatedSeed = process.env.MASTER_FUNDER_SEED?.trim();
-const dedicated = dedicatedSeed ? seedToAccount(dedicatedSeed, "//0") : null;
+const dedicated = dedicatedSeed ? seedToAccount(dedicatedSeed, "") : null;
 const dedicatedAddress = dedicated ? ss58Encode(dedicated.publicKey) : null;
 
 export interface Funder {
@@ -68,11 +68,11 @@ export interface Funder {
  * `MASTER_FUNDER_SEED` is configured; without it the chain is Alice-only.
  */
 export const FUNDER_CHAIN: readonly Funder[] = [
-    ...(dedicated
+    ...(dedicated && dedicatedAddress
         ? [
               {
                   name: "dedicated",
-                  address: dedicatedAddress as string,
+                  address: dedicatedAddress,
                   signer: dedicated.signer,
               },
           ]

--- a/src/utils/account/funding.test.ts
+++ b/src/utils/account/funding.test.ts
@@ -44,9 +44,10 @@ const ALICE_ADDRESS = "5Alice";
 const DEDICATED_ADDRESS = "5Dedicated";
 
 vi.mock("./funder.js", () => ({
+    // Production order: dedicated funder first (primary), Alice as fallback.
     FUNDER_CHAIN: [
-        { name: "Alice", address: ALICE_ADDRESS, signer: ALICE_SIGNER },
         { name: "dedicated", address: DEDICATED_ADDRESS, signer: DEDICATED_SIGNER },
+        { name: "Alice", address: ALICE_ADDRESS, signer: ALICE_SIGNER },
     ],
     DEDICATED_FUNDER_ADDRESS: DEDICATED_ADDRESS,
     faucetUrlFor: (addr: string) => `https://faucet.polkadot.io/?network=pah&address=${addr}`,
@@ -134,22 +135,22 @@ describe("checkBalance", () => {
 describe("pickFunder", () => {
     const required = FUND_AMOUNT + FUNDER_FEE_BUFFER;
 
-    it("returns Alice when she has enough (and never queries the dedicated account)", async () => {
-        const { client, getValue } = makeClient({ [ALICE_ADDRESS]: required + 1n });
-        const funder = await pickFunder(client, required);
-        expect(funder?.name).toBe("Alice");
-        // Short-circuits: only Alice's balance was queried.
-        const addresses = getValue.mock.calls.map((c) => c[0]);
-        expect(addresses).toEqual([ALICE_ADDRESS]);
-    });
-
-    it("falls through to dedicated when Alice is low", async () => {
-        const { client } = makeClient({
-            [ALICE_ADDRESS]: 0n,
-            [DEDICATED_ADDRESS]: required + 1n,
-        });
+    it("returns the dedicated funder when it has enough (and never queries Alice)", async () => {
+        const { client, getValue } = makeClient({ [DEDICATED_ADDRESS]: required + 1n });
         const funder = await pickFunder(client, required);
         expect(funder?.name).toBe("dedicated");
+        // Short-circuits: only the dedicated funder's balance was queried.
+        const addresses = getValue.mock.calls.map((c) => c[0]);
+        expect(addresses).toEqual([DEDICATED_ADDRESS]);
+    });
+
+    it("falls through to Alice when the dedicated funder is low", async () => {
+        const { client } = makeClient({
+            [DEDICATED_ADDRESS]: 0n,
+            [ALICE_ADDRESS]: required + 1n,
+        });
+        const funder = await pickFunder(client, required);
+        expect(funder?.name).toBe("Alice");
     });
 
     it("returns null when every funder is below the threshold", async () => {
@@ -168,16 +169,16 @@ describe("ensureFunded", () => {
         expect(mockSubmitAndWatch).not.toHaveBeenCalled();
     });
 
-    it("funds with FUND_AMOUNT via Alice when she has balance", async () => {
+    it("funds with FUND_AMOUNT via the dedicated funder when it has balance", async () => {
         const { client, transferFactory } = makeClient({
             [USER_ADDRESS]: 0n,
-            [ALICE_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
+            [DEDICATED_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
         });
         await ensureFunded(client, USER_ADDRESS);
 
         expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
         const [, signer] = mockSubmitAndWatch.mock.calls[0];
-        expect(signer).toBe(ALICE_SIGNER);
+        expect(signer).toBe(DEDICATED_SIGNER);
 
         expect(transferFactory).toHaveBeenCalledTimes(1);
         const callArgs = transferFactory.mock.calls[0][0] as {
@@ -191,17 +192,17 @@ describe("ensureFunded", () => {
         expect(callArgs.dest).toMatchObject({ type: "Id" });
     });
 
-    it("falls through to the dedicated funder when Alice is low", async () => {
+    it("falls through to Alice when the dedicated funder is low", async () => {
         const { client } = makeClient({
             [USER_ADDRESS]: 0n,
-            [ALICE_ADDRESS]: 0n,
-            [DEDICATED_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
+            [DEDICATED_ADDRESS]: 0n,
+            [ALICE_ADDRESS]: FUND_AMOUNT + FUNDER_FEE_BUFFER + 1n,
         });
         await ensureFunded(client, USER_ADDRESS);
 
         expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);
         const [, signer] = mockSubmitAndWatch.mock.calls[0];
-        expect(signer).toBe(DEDICATED_SIGNER);
+        expect(signer).toBe(ALICE_SIGNER);
     });
 
     it("throws AllFundersExhaustedError carrying the user address + tried list when every funder is low", async () => {
@@ -212,7 +213,7 @@ describe("ensureFunded", () => {
         });
         await expect(ensureFunded(client, USER_ADDRESS)).rejects.toSatisfy((err: unknown) => {
             if (!(err instanceof AllFundersExhaustedError)) return false;
-            return err.userAddress === USER_ADDRESS && err.tried.join(",") === "Alice,dedicated";
+            return err.userAddress === USER_ADDRESS && err.tried.join(",") === "dedicated,Alice";
         });
         expect(mockSubmitAndWatch).not.toHaveBeenCalled();
     });
@@ -220,7 +221,7 @@ describe("ensureFunded", () => {
     it("uses caller-supplied minBalance + fundAmount when passed", async () => {
         const { client, transferFactory } = makeClient({
             [USER_ADDRESS]: 3_000_000_000n,
-            [ALICE_ADDRESS]: 40_000_000_000n, // covers 20 PAS + buffer
+            [DEDICATED_ADDRESS]: 40_000_000_000n, // covers 20 PAS + buffer
         });
         await ensureFunded(client, USER_ADDRESS, 5_000_000_000n, 20_000_000_000n);
         expect(mockSubmitAndWatch).toHaveBeenCalledTimes(1);

--- a/src/utils/account/funding.ts
+++ b/src/utils/account/funding.ts
@@ -17,10 +17,11 @@
  * Account funding — check balance and fund the user from a testnet funder
  * chain on Paseo Asset Hub.
  *
- * The funder chain is walked in order: Alice first (public dev account — free
- * while she lasts), then a dedicated obscure seed. If every funder is below
- * the required threshold, callers receive `AllFundersExhaustedError` carrying
- * the user's address so they can render a faucet link.
+ * The funder chain is walked in order: the dedicated funder first (our own
+ * controlled account, when `MASTER_FUNDER_SEED` is set), then public Alice as
+ * the fallback. If every funder is below the required threshold, callers
+ * receive `AllFundersExhaustedError` carrying the user's address so they can
+ * render a faucet link.
  *
  * Testnet-only: will be replaced for mainnet where users fund themselves.
  */


### PR DESCRIPTION
The dedicated testnet funder seed was hardcoded in funder.ts, shipping in every published binary. Read it from the MASTER_FUNDER_SEED environment variable instead (CI injects it from the repository secret of the same name); when unset, the funder chain degrades to Alice-only. The chain is exercised only by the E2E suite and operator tooling, so no end-user command is affected.

Also reorder the chain so the dedicated funder is primary and public Alice is the fallback — draw down our own controlled account first rather than the shared dev account others drain unpredictably.

- funder.ts: derive dedicated funder from MASTER_FUNDER_SEED?.trim() at //0; drop the literal mnemonic; dedicated entry leads FUNDER_CHAIN
- check-funder-balance.ts: exit 2 with a clear message when the seed is unset
- CI: inject MASTER_FUNDER_SEED from the secret in the e2e + balance-check workflows
- docs/e2e-bootstrap.md: MASTER_FUNDER_SEED is now actually consumed (was documented but unwired)
- add funder.test.ts; update funding.test.ts for the new order