### PR TITLE
fix(contract): clarify command help text

### DIFF
--- a/.changeset/contract-help-text.md
+++ b/.changeset/contract-help-text.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Clarify the `contract` command help: replace the opaque "Run CDM contract workflows" description with "Install and deploy smart contract libraries for your app" and add a `<command> [options]` usage hint so its subcommands are discoverable from `playground --help`.

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -742,6 +742,7 @@ function makeInstallCommand(): Command {
 }
 
 export const contractCommand = new Command("contract")
-    .description("Run CDM contract workflows")
+    .description("Install and deploy smart contract libraries for your app")
+    .usage("<command> [options]")
     .addCommand(makeDeployCommand())
     .addCommand(makeInstallCommand());


### PR DESCRIPTION
## Summary

Fixes #270 — the `contract` command's `--help` listing was opaque:

```
contract                Run CDM contract workflows
```

Two problems the DevEx audit flagged:
1. "CDM" means nothing to a new user — replaced with plain English.
2. No `<command>` hint, so it wasn't obvious `contract` takes subcommands (`deploy`, `install`).

## Change

In `src/commands/contract.ts`:

```ts
.description("Install and deploy smart contract libraries for your app")
.usage("<command> [options]")
```

Rendered help now reads:

```
Usage: contract <command> [options]

Install and deploy smart contract libraries for your app
```

## Verification

- `pnpm format:check`, `pnpm lint:license`, `pnpm typecheck` — clean
- `pnpm test` — 973 passed (90 files)
- Help output verified by rendering `contractCommand`
- Changeset included (patch)