### PR TITLE
feat: gate mod/deploy/decentralize/deploy-all behind a revealed builder identity

### DIFF
--- a/.changeset/builder-identity-gate.md
+++ b/.changeset/builder-identity-gate.md
@@ -1,0 +1,13 @@
+---
+"playground-cli": minor
+---
+
+Gate `mod`, `init`, `deploy`, `decentralize`, and `deploy-all` behind a revealed
+builder identity. These commands now require you to be signed in (`playground
+login`) and to have joined the competition at playground.dot in your desktop
+app — the CLI reads your product account's on-chain identity binding from the
+playground registry (via the keyless read-only origin, no phone tap) and refuses
+to act for anonymous accounts. When you haven't joined yet, the command prints a
+friendly yellow notice explaining how to become a builder and exits without
+error. The check is signer-mode-agnostic: dev and `--suri` runs are gated too,
+but once you've revealed yourself they work as before.

--- a/src/commands/decentralize/index.ts
+++ b/src/commands/decentralize/index.ts
@@ -48,7 +48,8 @@ import {
     type DecentralizeOutcome,
     type DecentralizeSource,
 } from "../../utils/decentralize/run.js";
-import { destroyConnection } from "../../utils/connection.js";
+import { getConnection, destroyConnection } from "../../utils/connection.js";
+import { enforceIdentityGate } from "../shared/gateOrNotice.js";
 import {
     ensureGitInstalled,
     ModdablePreflightError,
@@ -147,6 +148,18 @@ export const decentralizeCommand = new Command("decentralize")
     .action(async (opts: DecentralizeOpts) =>
         runCliCommand("decentralize", { hardExit: true }, async () => {
             const env: Env = resolveLegacyEnv(opts.env);
+
+            // Builder-identity gate (any signer mode): only revealed builders
+            // who joined the competition may decentralize. Blocked is a soft
+            // outcome (yellow box, exit 0); release the shared connection we
+            // primed for the read before returning.
+            const conn = await getConnection();
+            if (await enforceIdentityGate(conn.raw.assetHub)) {
+                destroyConnection();
+                process.exitCode = 0;
+                return;
+            }
+
             if (opts.site || opts.path) {
                 await runHeadless({ env, opts });
             } else {

--- a/src/commands/deploy-all/index.ts
+++ b/src/commands/deploy-all/index.ts
@@ -31,6 +31,7 @@ import { Command, Option } from "commander";
 import { captureWarning, errorMessage, withSpan } from "../../telemetry.js";
 import { resolveSigner, SignerNotAvailableError, type ResolvedSigner } from "../../utils/signer.js";
 import { getConnection, destroyConnection } from "../../utils/connection.js";
+import { enforceIdentityGate } from "../shared/gateOrNotice.js";
 import { checkMapping } from "../../utils/account/mapping.js";
 import { readLoginStampMs, staleSessionWarning } from "../../utils/loginStamp.js";
 import { onProcessShutdown } from "../../utils/process-guard.js";
@@ -141,6 +142,16 @@ async function runDeployAll(opts: DeployAllOpts): Promise<void> {
     onProcessShutdown(cleanupOnce);
 
     try {
+        // Builder-identity gate (any signer mode): only revealed builders who
+        // joined the competition may deploy. Runs before signer resolution;
+        // reuses the shared connection. Blocked is a soft outcome (exit 0).
+        const conn = await getConnection();
+        if (await enforceIdentityGate(conn.raw.assetHub)) {
+            cleanupOnce();
+            process.exitCode = 0;
+            return;
+        }
+
         userSigner = await preflightSigner({ env, mode, suri: opts.suri, publishToPlayground });
 
         if (mode === "phone" && userSigner?.source !== "session") {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -26,6 +26,7 @@ import { captureWarning, errorMessage, withSpan } from "../../telemetry.js";
 import { readLoginStampMs, staleSessionWarning } from "../../utils/loginStamp.js";
 import { resolveSigner, SignerNotAvailableError, type ResolvedSigner } from "../../utils/signer.js";
 import { getConnection, destroyConnection } from "../../utils/connection.js";
+import { enforceIdentityGate } from "../shared/gateOrNotice.js";
 import { checkMapping } from "../../utils/account/mapping.js";
 import { onProcessShutdown } from "../../utils/process-guard.js";
 import { runCliCommand } from "../../cli-runtime.js";
@@ -156,6 +157,24 @@ export const deployCommand = new Command("deploy")
                 };
             })();
             onProcessShutdown(cleanupOnce);
+
+            // Builder-identity gate (any signer mode): only revealed builders
+            // who joined the competition may deploy. Runs before signer
+            // resolution / phone work; reuses the shared connection preflight
+            // will use. Blocked is a soft outcome (yellow box, exit 0).
+            try {
+                const conn = await getConnection();
+                if (await enforceIdentityGate(conn.raw.assetHub)) {
+                    cleanupOnce();
+                    process.exitCode = 0;
+                    return;
+                }
+            } catch (err) {
+                process.stderr.write(`\n✖ ${errorMessage(err)}\n`);
+                cleanupOnce();
+                process.exitCode = 1;
+                throw err;
+            }
 
             // `--yes` fills the fields the TUI would prompt for (signer ⇒ dev,
             // buildDir ⇒ default) and requires --domain. Resolve it BEFORE

--- a/src/commands/mod/index.ts
+++ b/src/commands/mod/index.ts
@@ -20,6 +20,7 @@ import { existsSync } from "node:fs";
 import { withSpan } from "../../telemetry.js";
 import { getConnection, destroyConnection } from "../../utils/connection.js";
 import { getReadOnlyRegistryContract } from "../../utils/registry.js";
+import { enforceIdentityGate } from "../shared/gateOrNotice.js";
 import { AppBrowser, type AppEntry } from "./AppBrowser.js";
 import { SetupScreen } from "./SetupScreen.js";
 import { QuestPicker } from "./QuestPicker.js";
@@ -58,6 +59,15 @@ export async function runModCommand(rawDomain: string | undefined): Promise<void
         const registry = await withSpan("cli.mod.registry", "load registry contract", () =>
             getReadOnlyRegistryContract(client.raw.assetHub),
         );
+
+        // Builder-identity gate: modding is reserved for revealed builders who
+        // joined the competition. This also gates `playground init`, which
+        // delegates here. Reuse the registry we just resolved so the gate
+        // doesn't re-resolve it. Blocked is a soft outcome (yellow box, exit 0).
+        if (await enforceIdentityGate(client.raw.assetHub, registry)) {
+            process.exitCode = 0;
+            return;
+        }
 
         let domain: string;
         let metadata: AppEntry | null = null;

--- a/src/commands/shared/IdentityGateNotice.tsx
+++ b/src/commands/shared/IdentityGateNotice.tsx
@@ -1,0 +1,65 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useEffect } from "react";
+import { render, Text } from "ink";
+import { Callout } from "../../utils/ui/theme/index.js";
+import type { BlockedIdentityStatus } from "../../utils/identity/identityGate.js";
+import { identityGateCopy } from "./identityGateCopy.js";
+
+/**
+ * One-shot yellow callout shown when the builder-identity gate blocks a
+ * command. No interaction: it paints once, then signals the host to unmount.
+ */
+export function IdentityGateNotice({
+    status,
+    onDone,
+}: {
+    status: BlockedIdentityStatus;
+    onDone: () => void;
+}) {
+    // Defer the unmount one tick so Ink flushes the frame before teardown.
+    useEffect(() => {
+        const t = setTimeout(onDone, 0);
+        return () => clearTimeout(t);
+    }, [onDone]);
+
+    const copy = identityGateCopy(status);
+    return (
+        <Callout tone="warning" title={copy.title}>
+            {copy.lines.map((line, i) => (
+                // Blank entries are intentional spacers; Ink collapses an empty
+                // string, so render a single space (matches the drip screen).
+                <Text key={i}>{line === "" ? " " : line}</Text>
+            ))}
+        </Callout>
+    );
+}
+
+/**
+ * Render the blocked-gate notice once and resolve after it has been shown and
+ * torn down. Mirrors the `status`/`drip` render/`waitUntilExit` shape.
+ */
+export function renderIdentityGateNotice(status: BlockedIdentityStatus): Promise<void> {
+    return new Promise((resolve) => {
+        const app = render(
+            React.createElement(IdentityGateNotice, {
+                status,
+                onDone: () => app.unmount(),
+            }),
+        );
+        void app.waitUntilExit().then(() => resolve());
+    });
+}

--- a/src/commands/shared/gateOrNotice.test.ts
+++ b/src/commands/shared/gateOrNotice.test.ts
@@ -1,0 +1,81 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the gate decision + the Ink render so the test exercises only the
+// mapping contract enforceIdentityGate owns. withSpan is collapsed to a
+// pass-through so the span wrapper doesn't pull in Sentry.
+const { checkIdentityGateMock, renderNoticeMock } = vi.hoisted(() => ({
+    checkIdentityGateMock: vi.fn(),
+    renderNoticeMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/identity/identityGate.js", () => ({
+    checkIdentityGate: checkIdentityGateMock,
+}));
+
+vi.mock("./IdentityGateNotice.js", () => ({
+    renderIdentityGateNotice: renderNoticeMock,
+}));
+
+vi.mock("../../telemetry.js", () => ({
+    withSpan: (_op: string, _name: string, fn: () => unknown) => fn(),
+}));
+
+import { enforceIdentityGate } from "./gateOrNotice.js";
+
+const RAW = {} as any;
+const H160 = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" as `0x${string}`;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    renderNoticeMock.mockResolvedValue(undefined);
+});
+
+describe("enforceIdentityGate", () => {
+    it("does not block a revealed builder and prints nothing", async () => {
+        checkIdentityGateMock.mockResolvedValue({ status: "revealed", productH160: H160 });
+
+        const blocked = await enforceIdentityGate(RAW);
+
+        expect(blocked).toBe(false);
+        expect(renderNoticeMock).not.toHaveBeenCalled();
+    });
+
+    it.each(["not-logged-in", "anonymous", "unverifiable"] as const)(
+        "blocks and renders the %s notice",
+        async (status) => {
+            checkIdentityGateMock.mockResolvedValue(
+                status === "unverifiable" ? { status, detail: "x" } : { status, productH160: H160 },
+            );
+
+            const blocked = await enforceIdentityGate(RAW);
+
+            expect(blocked).toBe(true);
+            expect(renderNoticeMock).toHaveBeenCalledTimes(1);
+            expect(renderNoticeMock).toHaveBeenCalledWith(status);
+        },
+    );
+
+    it("forwards a pre-resolved registry to the gate (so mod doesn't re-resolve)", async () => {
+        checkIdentityGateMock.mockResolvedValue({ status: "revealed", productH160: H160 });
+        const registry = { getRootAccount: { query: vi.fn() } };
+
+        await enforceIdentityGate(RAW, registry as any);
+
+        expect(checkIdentityGateMock).toHaveBeenCalledWith(RAW, { registry });
+    });
+});

--- a/src/commands/shared/gateOrNotice.ts
+++ b/src/commands/shared/gateOrNotice.ts
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { PolkadotClient } from "polkadot-api";
+import { withSpan } from "../../telemetry.js";
+import { checkIdentityGate, type IdentityRegistry } from "../../utils/identity/identityGate.js";
+import { renderIdentityGateNotice } from "./IdentityGateNotice.js";
+
+/**
+ * Enforce the builder-identity gate for the signed-in session.
+ *
+ * Returns `true` when the user is BLOCKED — the caller should set
+ * `process.exitCode = 0` (a soft, actionable outcome) and return after running
+ * its own cleanup. Returns `false` when the user is a revealed builder and the
+ * command may proceed; nothing is printed on that path (no flash on success).
+ */
+export async function enforceIdentityGate(
+    rawAssetHubClient: PolkadotClient,
+    registry?: IdentityRegistry,
+): Promise<boolean> {
+    const result = await withSpan("cli.identity-gate", "check builder identity", () =>
+        checkIdentityGate(rawAssetHubClient, { registry }),
+    );
+    if (result.status === "revealed") return false;
+    await renderIdentityGateNotice(result.status);
+    return true;
+}

--- a/src/commands/shared/identityGateCopy.test.ts
+++ b/src/commands/shared/identityGateCopy.test.ts
@@ -1,0 +1,50 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import { identityGateCopy } from "./identityGateCopy.js";
+import type { BlockedIdentityStatus } from "../../utils/identity/identityGate.js";
+
+const STATUSES: BlockedIdentityStatus[] = ["not-logged-in", "anonymous", "unverifiable"];
+
+describe("identityGateCopy", () => {
+    it("returns a non-empty title and body for every blocked status", () => {
+        for (const status of STATUSES) {
+            const copy = identityGateCopy(status);
+            expect(copy.title.length).toBeGreaterThan(0);
+            const body = copy.lines.filter((l) => l.trim().length > 0);
+            expect(body.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("points not-logged-in at `playground login`", () => {
+        const copy = identityGateCopy("not-logged-in");
+        expect(copy.lines.join(" ")).toContain("playground login");
+        expect(copy.lines.join(" ")).toContain("playground.dot");
+    });
+
+    it("tells anonymous builders to join the competition at playground.dot", () => {
+        const copy = identityGateCopy("anonymous");
+        expect(copy.lines.join(" ").toLowerCase()).toContain("become a builder");
+        expect(copy.lines.join(" ")).toContain("playground.dot");
+    });
+
+    it("tells unverifiable users to confirm they joined, then retry", () => {
+        const copy = identityGateCopy("unverifiable");
+        const body = copy.lines.join(" ");
+        expect(body).toContain("playground.dot");
+        expect(body.toLowerCase()).toContain("try again");
+    });
+});

--- a/src/commands/shared/identityGateCopy.ts
+++ b/src/commands/shared/identityGateCopy.ts
@@ -1,0 +1,59 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Yellow-callout copy for a blocked builder-identity gate. Lifted out of the
+ * Ink component so it can be unit-tested without React. An empty string is a
+ * blank-line spacer (the renderer maps it to a `<Text> </Text>`).
+ */
+
+import type { BlockedIdentityStatus } from "../../utils/identity/identityGate.js";
+
+export interface GateNoticeCopy {
+    title: string;
+    lines: string[];
+}
+
+export function identityGateCopy(status: BlockedIdentityStatus): GateNoticeCopy {
+    switch (status) {
+        case "not-logged-in":
+            return {
+                title: "Join the competition first",
+                lines: [
+                    "Playground commands are for builders who've joined the competition, so you need to be signed in first.",
+                    "",
+                    "Run `playground login` and scan the QR code with your Polkadot mobile app, then become a builder and join the competition at playground.dot in your desktop app.",
+                ],
+            };
+        case "anonymous":
+            return {
+                title: "Join the competition first",
+                lines: [
+                    "You're signed in, but you haven't revealed yourself yet — and there are no points for anonymous builders.",
+                    "",
+                    "To deploy, mod, or decentralize an app you need to first become a builder and join the competition at playground.dot in your desktop app, then try again.",
+                ],
+            };
+        case "unverifiable":
+            return {
+                title: "Couldn't verify your builder status",
+                lines: [
+                    "We couldn't check whether you've joined the competition right now.",
+                    "",
+                    "Make sure you joined the competition on playground.dot in your desktop app, then try again.",
+                ],
+            };
+    }
+}

--- a/src/utils/identity/identityGate.test.ts
+++ b/src/utils/identity/identityGate.test.ts
@@ -1,0 +1,190 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Boundary mocks: the gate composes session lookup (auth.ts) + a read-only
+// registry dry-run (registry.ts). We never want a real adapter / network here.
+const { findSessionMock, deriveSessionAddressesMock, getReadOnlyRegistryContractMock } = vi.hoisted(
+    () => ({
+        findSessionMock: vi.fn(),
+        deriveSessionAddressesMock: vi.fn(),
+        getReadOnlyRegistryContractMock: vi.fn(),
+    }),
+);
+
+vi.mock("../auth.js", () => ({
+    findSession: findSessionMock,
+    deriveSessionAddresses: deriveSessionAddressesMock,
+}));
+
+vi.mock("../registry.js", () => ({
+    getReadOnlyRegistryContract: getReadOnlyRegistryContractMock,
+}));
+
+import { checkIdentityGate, isAnonymousRoot } from "./identityGate.js";
+
+const ZERO = ("0x" + "00".repeat(32)) as `0x${string}`;
+const REVEALED = ("0x" + "11".repeat(32)) as `0x${string}`;
+const H160 = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" as `0x${string}`;
+
+function fakeHandle() {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    return { adapter: { destroy }, address: "5x", session: { rootAccountId: new Uint8Array(32) } };
+}
+
+function fakeRegistry(
+    query: (addr: `0x${string}`) => Promise<{ success: boolean; value?: unknown }>,
+) {
+    return { getRootAccount: { query: vi.fn(query) } };
+}
+
+const FAST = { attempts: 2, delayMs: 0 };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    deriveSessionAddressesMock.mockReturnValue({
+        rootAddress: "5Root",
+        productAddress: "5Prod",
+        productH160: H160,
+    });
+});
+
+describe("isAnonymousRoot", () => {
+    it("treats the 32-zero-byte hex sentinel as anonymous", () => {
+        expect(isAnonymousRoot(ZERO)).toBe(true);
+        expect(isAnonymousRoot("0X" + "00".repeat(32))).toBe(true);
+        expect(isAnonymousRoot("00".repeat(32))).toBe(true); // no 0x prefix
+        expect(isAnonymousRoot("0x")).toBe(true); // empty body
+    });
+
+    it("treats a non-zero root as revealed", () => {
+        expect(isAnonymousRoot(REVEALED)).toBe(false);
+        expect(isAnonymousRoot("0x" + "00".repeat(31) + "01")).toBe(false);
+        expect(
+            isAnonymousRoot("0xAbC0000000000000000000000000000000000000000000000000000000000000"),
+        ).toBe(false);
+    });
+
+    it("handles byte-array representations", () => {
+        expect(isAnonymousRoot(new Uint8Array(32))).toBe(true);
+        const nonZero = new Uint8Array(32);
+        nonZero[31] = 1;
+        expect(isAnonymousRoot(nonZero)).toBe(false);
+        expect(isAnonymousRoot([0, 0, 0])).toBe(true);
+        expect(isAnonymousRoot([0, 1, 0])).toBe(false);
+    });
+
+    it("treats null/undefined as anonymous", () => {
+        expect(isAnonymousRoot(null)).toBe(true);
+        expect(isAnonymousRoot(undefined)).toBe(true);
+    });
+
+    it("throws on an unrecognized representation (forces unverifiable upstream)", () => {
+        expect(() => isAnonymousRoot(5 as unknown)).toThrow();
+        expect(() => isAnonymousRoot({} as unknown)).toThrow();
+    });
+});
+
+describe("checkIdentityGate", () => {
+    it("returns not-logged-in and never reads the registry when no session exists", async () => {
+        findSessionMock.mockResolvedValue(null);
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result).toEqual({ status: "not-logged-in" });
+        expect(getReadOnlyRegistryContractMock).not.toHaveBeenCalled();
+    });
+
+    it("returns revealed for a non-zero root and releases the session adapter", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        getReadOnlyRegistryContractMock.mockResolvedValue(
+            fakeRegistry(async () => ({ success: true, value: REVEALED })),
+        );
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result).toEqual({ status: "revealed", productH160: H160 });
+        expect(handle.adapter.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns anonymous for the zero-root sentinel and releases the adapter", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        getReadOnlyRegistryContractMock.mockResolvedValue(
+            fakeRegistry(async () => ({ success: true, value: ZERO })),
+        );
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result).toEqual({ status: "anonymous", productH160: H160 });
+        expect(handle.adapter.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns unverifiable when the dry-run fails on every attempt", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        const registry = fakeRegistry(async () => ({ success: false }));
+        getReadOnlyRegistryContractMock.mockResolvedValue(registry);
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result.status).toBe("unverifiable");
+        expect(registry.getRootAccount.query).toHaveBeenCalledTimes(2); // retried
+        expect(handle.adapter.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns unverifiable when the query throws", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        getReadOnlyRegistryContractMock.mockResolvedValue(
+            fakeRegistry(async () => {
+                throw new Error("RPC down");
+            }),
+        );
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result.status).toBe("unverifiable");
+        expect(handle.adapter.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses an injected registry without re-resolving its own", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        const registry = fakeRegistry(async () => ({ success: true, value: REVEALED }));
+
+        const result = await checkIdentityGate({} as any, { ...FAST, registry });
+
+        expect(result).toEqual({ status: "revealed", productH160: H160 });
+        expect(registry.getRootAccount.query).toHaveBeenCalledTimes(1);
+        expect(getReadOnlyRegistryContractMock).not.toHaveBeenCalled();
+    });
+
+    it("returns unverifiable (and releases the adapter) when the session can't be derived", async () => {
+        const handle = fakeHandle();
+        findSessionMock.mockResolvedValue(handle);
+        deriveSessionAddressesMock.mockImplementation(() => {
+            throw new Error("bad session");
+        });
+
+        const result = await checkIdentityGate({} as any, FAST);
+
+        expect(result.status).toBe("unverifiable");
+        expect(handle.adapter.destroy).toHaveBeenCalledTimes(1);
+        expect(getReadOnlyRegistryContractMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/identity/identityGate.ts
+++ b/src/utils/identity/identityGate.ts
@@ -1,0 +1,164 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Builder-identity gate.
+ *
+ * The value-creating commands (`mod`/`init`, `deploy`, `decentralize`,
+ * `deploy-all`) are reserved for users who have "revealed themselves" — bound
+ * a verified identity on-chain via the playground-app's "Become a builder"
+ * flow. Anonymous accounts earn no competition points, so the CLI refuses to
+ * act for them.
+ *
+ * "Revealed" is decided exactly as the playground-app decides it
+ * (`hasRevealedIdentity`): `playground-registry.getRootAccount(productH160)`
+ * returns a NON-zero bytes32. The contract `unwrap_or`s a missing binding to 32
+ * zero bytes and never reverts, so the zero sentinel IS the "anonymous" answer.
+ *
+ * This module is pure logic (no React/Ink). The session's product H160 is
+ * derived signer-free from the persisted login (`findSession` ->
+ * `deriveSessionAddresses`), and the read uses the keyless revive origin
+ * (`getReadOnlyRegistryContract`), so evaluating the gate needs neither a phone
+ * tap nor a mapped/funded account.
+ */
+
+import type { PolkadotClient } from "polkadot-api";
+import { findSession, deriveSessionAddresses } from "../auth.js";
+import { getReadOnlyRegistryContract } from "../registry.js";
+
+export type IdentityGateResult =
+    | { status: "revealed"; productH160: `0x${string}` }
+    | { status: "not-logged-in" }
+    | { status: "anonymous"; productH160: `0x${string}` }
+    | { status: "unverifiable"; detail: string };
+
+/** Blocked outcomes — everything except `revealed`. */
+export type BlockedIdentityStatus = "not-logged-in" | "anonymous" | "unverifiable";
+
+interface RootQueryResult {
+    success: boolean;
+    value?: unknown;
+}
+
+/**
+ * Minimal structural view of the registry handle. `getReadOnlyRegistryContract`
+ * returns a runtime Proxy (via `suppressReviveTraceNoise`) whose full typing we
+ * don't want to depend on here. The generated ABI does expose `getRootAccount`
+ * (`.cdm/contracts.d.ts`, `response: SizedHex<32>` — i.e. a hex string); we
+ * narrow to just the one read method we call.
+ */
+export interface IdentityRegistry {
+    getRootAccount: { query(account: `0x${string}`): Promise<RootQueryResult> };
+}
+
+interface GateOptions {
+    /** Dry-run retry budget. Defaults to 2 (a transient RPC blip shouldn't lock out a builder). */
+    attempts?: number;
+    /** Delay between retries in ms. Defaults to 250. */
+    delayMs?: number;
+    /**
+     * Pre-resolved registry handle. Callers that already built one (e.g. `mod`)
+     * pass it to avoid a second meta-registry resolution + Revive dry-run. When
+     * omitted, the gate resolves its own from `rawAssetHubClient`.
+     */
+    registry?: IdentityRegistry;
+}
+
+function describe(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Whether a `getRootAccount` result represents an anonymous (unbound) account.
+ *
+ * Robust to the representations a bytes32 contract output can arrive as: a
+ * `0x`-prefixed (or bare) hex string, a `Uint8Array`/number array, or
+ * null/undefined (treated as anonymous). Throws on anything unrecognized so the
+ * orchestrator degrades to `unverifiable` rather than guessing.
+ */
+export function isAnonymousRoot(value: unknown): boolean {
+    if (value === null || value === undefined) return true;
+    if (typeof value === "string") {
+        const hex = value.slice(0, 2).toLowerCase() === "0x" ? value.slice(2) : value;
+        return hex.length === 0 || /^0+$/.test(hex);
+    }
+    if (value instanceof Uint8Array) return value.every((b) => b === 0);
+    if (Array.isArray(value)) return value.every((b) => Number(b) === 0);
+    throw new Error(`Unrecognized root account representation: ${typeof value}`);
+}
+
+async function queryRoot(
+    registry: IdentityRegistry,
+    account: `0x${string}`,
+    attempts: number,
+    delayMs: number,
+): Promise<unknown> {
+    let lastError: unknown;
+    for (let i = 0; i < attempts; i++) {
+        try {
+            const res = await registry.getRootAccount.query(account);
+            if (res.success) return res.value;
+            lastError = new Error("registry.getRootAccount dry-run was rejected (success=false)");
+        } catch (err) {
+            lastError = err;
+        }
+        if (i < attempts - 1 && delayMs > 0) await sleep(delayMs);
+    }
+    throw lastError instanceof Error ? lastError : new Error(describe(lastError));
+}
+
+/**
+ * Evaluate the builder-identity gate for the currently signed-in session.
+ *
+ * Never throws: any failure to read the binding collapses to `unverifiable`
+ * (fail-closed — the caller blocks, but softly). Always releases the session
+ * adapter it opens, on every path (we only need the derived address, never the
+ * signer).
+ */
+export async function checkIdentityGate(
+    rawAssetHubClient: PolkadotClient,
+    opts: GateOptions = {},
+): Promise<IdentityGateResult> {
+    const attempts = Math.max(1, opts.attempts ?? 2);
+    const delayMs = opts.delayMs ?? 250;
+
+    const handle = await findSession();
+    if (!handle) return { status: "not-logged-in" };
+
+    let productH160: `0x${string}`;
+    try {
+        productH160 = deriveSessionAddresses(handle.session).productH160;
+    } catch (err) {
+        return { status: "unverifiable", detail: describe(err) };
+    } finally {
+        // The signer is never used here — release the adapter so its WebSocket
+        // doesn't keep the event loop alive (mirrors `drip`/`status`).
+        await handle.adapter.destroy().catch(() => {});
+    }
+
+    try {
+        const registry =
+            opts.registry ??
+            ((await getReadOnlyRegistryContract(rawAssetHubClient)) as unknown as IdentityRegistry);
+        const root = await queryRoot(registry, productH160, attempts, delayMs);
+        return isAnonymousRoot(root)
+            ? { status: "anonymous", productH160 }
+            : { status: "revealed", productH160 };
+    } catch (err) {
+        return { status: "unverifiable", detail: describe(err) };
+    }
+}


### PR DESCRIPTION
## What

Reserves the value-creating commands — `mod`, `init`, `deploy`, `decentralize`, `deploy-all` — for users who have **revealed themselves** (bound a verified identity on-chain via the playground-app's "Become a builder" flow). Anonymous accounts earn no competition points, so the CLI now refuses to act for them.

## How it works

- **Predicate:** "revealed" == `playground-registry.getRootAccount(productH160)` returns a non-zero `bytes32`. Anonymous accounts read back as the 32-zero-byte sentinel (the contract `unwrap_or`s a missing binding to zero and never reverts) — the exact predicate the playground-app uses (`hasRevealedIdentity` vs `ZERO_ROOT`).
- **Signer-free:** the product H160 is derived from the persisted session (`findSession` → `deriveSessionAddresses`) and the read uses the **keyless read-only revive origin** (`getReadOnlyRegistryContract`), so evaluating the gate needs no phone tap, no account mapping, and no funding.
- **Signer-mode-agnostic:** dev mode and `--suri` are gated too — the gate checks the *session's* reveal status, not the signing key. Once revealed, dev mode works exactly as before.
- **Outcomes:** `revealed` proceeds silently (no UI flash on the happy path); `not-logged-in`, `anonymous`, and `unverifiable` (read failure → fail-closed) each render a yellow callout and **exit 0** (soft, actionable — mirrors `drip`/`status`).
- `init` is gated because it delegates to `runModCommand`.

## Structure

- `src/utils/identity/identityGate.ts` — pure logic (no React/Ink): `checkIdentityGate` + `isAnonymousRoot`.
- `src/commands/shared/` — `IdentityGateNotice.tsx` (yellow `Callout`), `identityGateCopy.ts` (testable copy), `gateOrNotice.ts` (`enforceIdentityGate`).
- Gate wired into all four command entry points, before any signer resolution / phone work.

## Tests

21 new unit tests (`identityGate`, `identityGateCopy`, `gateOrNotice`). Full suite **994 pass**; `typecheck`, `format:check`, `lint:license` all clean. Changeset included (`minor`).

## ⚠️ Known follow-up — e2e suite

The e2e tests drive `mod`/`deploy`/`decentralize` with `--suri` and **no logged-in session**, so the gate (correctly) blocks them. This is an intended behavior change, not a logic bug — but the e2e harness needs a revealed-session fixture (and its deployer account revealed on-chain) before the e2e matrix is green again. I deliberately did **not** weaken the gate or add an env bypass. Tracking the e2e session story as a follow-up.