### PR TITLE
fix: reword identity gate notice to 'joined the competition'

### DIFF
--- a/.changeset/identity-gate-joined-competition.md
+++ b/.changeset/identity-gate-joined-competition.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Reword the builder-identity gate notice for signed-in-but-not-joined users to "You're signed in, but you haven't joined the competition yet." for consistent "join the competition" wording across all gate messages.

--- a/src/commands/shared/identityGateCopy.ts
+++ b/src/commands/shared/identityGateCopy.ts
@@ -41,7 +41,7 @@ export function identityGateCopy(status: BlockedIdentityStatus): GateNoticeCopy 
             return {
                 title: "Join the competition first",
                 lines: [
-                    "You're signed in, but you haven't revealed yourself yet — and there are no points for anonymous builders.",
+                    "You're signed in, but you haven't joined the competition yet.",
                     "",
                     "To deploy, mod, or decentralize an app you need to first become a builder and join the competition at playground.dot in your desktop app, then try again.",
                 ],


### PR DESCRIPTION
## What

The builder-identity gate notice shown to signed-in-but-not-joined users said "you haven't revealed yourself yet — and there are no points for anonymous builders." This rewords it to:

> You're signed in, but you haven't joined the competition yet.

(The second line is unchanged.) This makes all three gate notices (`not-logged-in`, `anonymous`, `unverifiable`) use consistent "join the competition" wording instead of the "reveal yourself" phrasing.

## Scope

Only the user-facing `anonymous` gate copy changed. Internal `"revealed"` status enum literals, code comments, tests, and local-only docs were intentionally left as-is — they're not shown to users and renaming the enum would be a behavior-neutral refactor with regression risk.

## Verification

- `pnpm format:check` ✅
- `pnpm lint:license` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (994 passing)

Includes a `patch` changeset.