### PR TITLE
chore(cdm): refresh @w3s/playground-registry snapshot to v17

### DIFF
--- a/.changeset/refresh-cdm-registry-v17.md
+++ b/.changeset/refresh-cdm-registry-v17.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Refresh the `@w3s/playground-registry` snapshot in `cdm.json` to v17. The registry contract was redeployed at a new address (`0x4a32e0FB190112F169308Ebc8aC5A4e624263035`), so contract deploys and playground publishes now target the current contract. The v17 ABI drops the unused `rateApp`, `removeRating`, `getContextId`, and `refreshReputationReference` functions.

--- a/cdm.json
+++ b/cdm.json
@@ -5,8 +5,8 @@
   },
   "contracts": {
     "@w3s/playground-registry": {
-      "version": 15,
-      "address": "0xd9894fA7A2D234A9ebF0AbD08b53360e620AEf62",
+      "version": 17,
+      "address": "0x4a32e0FB190112F169308Ebc8aC5A4e624263035",
       "abi": [
         {
           "type": "constructor",
@@ -140,42 +140,6 @@
         },
         {
           "type": "function",
-          "name": "rateApp",
-          "inputs": [
-            {
-              "name": "domain",
-              "type": "string"
-            },
-            {
-              "name": "rating",
-              "type": "uint8"
-            },
-            {
-              "name": "comment_uri",
-              "type": "string"
-            }
-          ],
-          "outputs": [],
-          "stateMutability": "nonpayable"
-        },
-        {
-          "type": "function",
-          "name": "removeRating",
-          "inputs": [
-            {
-              "name": "domain",
-              "type": "string"
-            },
-            {
-              "name": "reviewer",
-              "type": "address"
-            }
-          ],
-          "outputs": [],
-          "stateMutability": "nonpayable"
-        },
-        {
-          "type": "function",
           "name": "star",
           "inputs": [
             {
@@ -185,18 +149,6 @@
           ],
           "outputs": [],
           "stateMutability": "nonpayable"
-        },
-        {
-          "type": "function",
-          "name": "getContextId",
-          "inputs": [],
-          "outputs": [
-            {
-              "name": "",
-              "type": "bytes32"
-            }
-          ],
-          "stateMutability": "view"
         },
         {
           "type": "function",
@@ -1018,13 +970,6 @@
         },
         {
           "type": "function",
-          "name": "refreshReputationReference",
-          "inputs": [],
-          "outputs": [],
-          "stateMutability": "nonpayable"
-        },
-        {
-          "type": "function",
           "name": "importApp",
           "inputs": [
             {
@@ -1297,7 +1242,7 @@
           "stateMutability": "nonpayable"
         }
       ],
-      "metadataCid": "bafk2bzacecmce7tevya3yoh4m2sefbbn4xmqtj4tnttiw7jg5oxrz6dptyoca"
+      "metadataCid": "bafk2bzaceajvnka7nooku6vuuwwizjttilvh7ygsa6knpi5yns52bz7fyjfkg"
     }
   }
 }


### PR DESCRIPTION
## What

Re-resolved the CDM contract snapshot via \`playground contract install\`, which pulls \`@w3s/playground-registry\` from the meta-registry on paseo-next-v2 into \`cdm.json\` and regenerates the (gitignored) codegen.

| | before | after |
|---|---|---|
| version | 15 | **17** |
| address | \`0xd9894fA7A2D234A9ebF0AbD08b53360e620AEf62\` | **\`0x4a32e0FB190112F169308Ebc8aC5A4e624263035\`** |
| metadataCid | \`bafk…dptyoca\` | \`bafk…b7fyjfkg\` |

The registry contract was **redeployed at a new address**, so contract deploys and playground publishes now target the current contract — not just a cosmetic version bump.

The v17 ABI drops four functions: \`rateApp\`, \`removeRating\`, \`getContextId\`, \`refreshReputationReference\`. No CLI source references any of them.

Only \`cdm.json\` is tracked; \`.cdm/\` codegen is gitignored.

## Verification

- \`pnpm format:check\` ✓
- \`pnpm typecheck\` ✓
- \`pnpm lint:license\` ✓
- \`pnpm test\` — 1005 passed (95 files) ✓