### PR TITLE
Switch default testnet environment to Summit

### DIFF
--- a/.changeset/summit-default-env.md
+++ b/.changeset/summit-default-env.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Switch the default testnet environment from Paseo Next v2 to Summit.

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export const ENV_FLAG_CHOICES: readonly string[] = [...ENV_IDS, ...LEGACY_ENV_AL
  * rest. The `config.test.ts` guard blocks the flip until the target env's
  * endpoints match upstream AND its CDM meta-registry address exists.
  */
-export const ACTIVE_TESTNET_ENV: Env = "paseo-next-v2";
+export const ACTIVE_TESTNET_ENV: Env = "summit";
 export const DEFAULT_ENV: Env = ACTIVE_TESTNET_ENV;
 
 export interface ChainConfig {


### PR DESCRIPTION
## Summary
- switch ACTIVE_TESTNET_ENV from paseo-next-v2 to summit
- add a patch changeset for the default environment change

## Verification
- pnpm format:check
- pnpm lint:license
- pnpm exec tsc --noEmit 2>&1 | grep -c "error TS" (printed 0)
- pnpm test