### PR TITLE
Fix contract install registry selection

### DIFF
--- a/.changeset/fix-contract-install-registry.md
+++ b/.changeset/fix-contract-install-registry.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Use the active Playground contract registry for contract installs instead of stale `cdm.json` registry snapshots.

--- a/cdm.json
+++ b/cdm.json
@@ -1,12 +1,12 @@
 {
-  "registry": "0xf62c2ece29cd8df2e10040ecfa5a894a5c5d9cb0",
+  "registry": "0xa5747e60ae27f93e92019e4021abfc4957050141",
   "dependencies": {
     "@w3s/playground-registry": "latest"
   },
   "contracts": {
     "@w3s/playground-registry": {
-      "version": 17,
-      "address": "0x4a32e0FB190112F169308Ebc8aC5A4e624263035",
+      "version": 1,
+      "address": "0x49091Eb6dbBf2f95B55243b987ebc15eaaEe711F",
       "abi": [
         {
           "type": "constructor",
@@ -1242,7 +1242,7 @@
           "stateMutability": "nonpayable"
         }
       ],
-      "metadataCid": "bafk2bzaceajvnka7nooku6vuuwwizjttilvh7ygsa6knpi5yns52bz7fyjfkg"
+      "metadataCid": "bafk2bzaceciehmxltebki5zxj4p7i476dnbn4yxeuisja76ko4shbjd6op5g2"
     }
   }
 }

--- a/src/commands/contract.test.ts
+++ b/src/commands/contract.test.ts
@@ -114,7 +114,7 @@ describe("resolveContractInstallTarget", () => {
         });
     });
 
-    it("uses the registry recorded in cdm.json when present", () => {
+    it("prefers the active playground registry over stale cdm.json by default", () => {
         const cfg = getChainConfig();
         const cdmJson: CdmJson = {
             dependencies: {},
@@ -124,7 +124,7 @@ describe("resolveContractInstallTarget", () => {
         expect(resolveContractInstallTarget({}, cdmJson)).toEqual({
             assethubUrl: cfg.assetHubRpc,
             ipfsGatewayUrl: cfg.bulletinGateway,
-            registryAddress: "0x1111111111111111111111111111111111111111",
+            registryAddress: getRegistryAddress(cfg.cdmEnvName),
             chainName: undefined,
         });
     });

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -138,8 +138,8 @@ export interface CdmPackageOwnershipConflict {
     caller: HexString;
 }
 
-function assertHexAddress(value: string, label: string): HexString {
-    if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
+function assertHexAddress(value: string | undefined, label: string): HexString {
+    if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(value)) {
         throw new Error(`${label} must be a 20-byte hex address`);
     }
     return value as HexString;
@@ -227,10 +227,12 @@ export function resolveContractInstallTarget(
         registryAddress ??= preset.registryAddress;
     }
 
-    registryAddress ??= cdmJson?.registry;
     assethubUrl ??= cfg.assetHubRpc;
     ipfsGatewayUrl ??= cfg.bulletinGateway;
-    registryAddress ??= getRegistryAddress(cfg.cdmEnvName);
+    if (registryAddress == null) {
+        const activeRegistryAddress = getRegistryAddress(cfg.cdmEnvName);
+        registryAddress = activeRegistryAddress || cdmJson?.registry;
+    }
 
     return {
         assethubUrl,


### PR DESCRIPTION
## Summary
- prefer the active Playground/CDM environment registry during `playground contract install` instead of stale `cdm.json` registry snapshots
- keep `cdm.json` refreshed from `cdm i -n w3s`, pointing at the w3s meta-registry and live `@w3s/playground-registry`
- add a regression test for stale `cdm.json.registry` during install target resolution

## Verification
- `pnpm test src/commands/contract.test.ts`
- `pnpm format:check`
- `pnpm lint:license`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit 2>&1 | grep -c "error TS" || true` -> `0`
- `pnpm test`
