### PR TITLE
chore: release changeset for ipfs kubo install hang fix

### DIFF
--- a/.changeset/fix-ipfs-kubo-install-hang.md
+++ b/.changeset/fix-ipfs-kubo-install-hang.md
@@ -1,0 +1,5 @@
+---
+"playground-cli": patch
+---
+
+Fix `playground login` hanging during the IPFS (Kubo) install step. The installer now runs `install.sh` without sudo first (falling through to `~/.local/bin`) and uses `sudo -n` as a fallback so it no longer blocks on a sudo password prompt.


### PR DESCRIPTION
PR #423 ("Fix hanging when ipfs kubo") merged to `main` without a changeset, so the Release workflow ran as a no-op and the fix is unreleased (still on v0.44.1).

This adds the missing patch changeset. Merging it triggers the Release workflow to bump to v0.44.2 and publish the binaries.

Covers the change in `src/utils/toolchain.ts` (commit 75030ff): the Kubo install now runs without sudo first and uses `sudo -n` as a fallback so `playground login` no longer hangs on a sudo password prompt.